### PR TITLE
Manage global Claude Code config (CLAUDE.md + personal skills) in dotfiles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+## Process
+
+- **No breadcrumbs**. If you delete or move code, do not leave a comment in the old place. No "// moved to X". Just remove it.
+- Fix things from first principles. Find the source, fix it there. No bandaids.
+- **Search before pivoting**. If stuck, web search for official docs first. Do not change direction unless asked.
+- Clean up dead code ruthlessly. Dead helpers, unused parameters, stale imports: delete them.
+- If code is confusing, simplify it. Add an ASCII art diagram in a comment if it would help.
+- **Don't inherit rot**. Match the surrounding code's style, but if a neighboring pattern is actually wrong, fix it or flag it. Agents copy whatever is already there, including the outdated stuff, so bad patterns propagate silently.
+
+## Design & Data Modeling
+
+- **Don't ship the 2nd-best solution**. The first design that passes tests is usually the 2nd or 3rd best way to do it. Before committing to a shape, ask if there's a cleaner one and say why you picked this. "It works" is the floor, not the bar. If you settled to save time, say so instead of hiding it.
+- **Definition of done**. Not done if the implementation is ugly. Not done if it's undocumented. Not done if a user can't discover it. Passing tests is where "done" starts, not where it ends.
+- **The data model is the highest-leverage decision**. Avoid ambiguous unions like `string | string[]` that force every consumer to branch on the type. Pick one shape (normalize, or a discriminated union with a tag) so consumers don't each re-derive what they're holding. Make illegal states unrepresentable.
+- **One-way doors vs two-way doors**. For things that are hard to change later (data models, public API and wire formats, DB schema), stop and think before writing code and surface the tradeoff first. "The LLM can fix it later" is not a reason to get it wrong now, the cost lands on every downstream consumer.
+- **Precision over slop**. Don't accept a 20% margin of error because "AI can just figure it out". Get the details right, sloppiness compounds.
+
+## Version Control
+
+- If a `.jj/` directory exists, this is a **Jujutsu (jj)** repo. Load the `jj-vcs` skill before any VCS operation. Do not use raw git commands in jj repos, they desync state.
+- jj workflow: `jj describe -m "intent"` to unlock edits, work, then session idle auto-commits via `jj new`. Every commit has a declared purpose.
+- jj uses **bookmarks**, not branches. Move bookmark to tip and push once. Don't push commits sequentially or squash after pushing.
+- Only the primary agent manages jj workflow (describe/new/push). Subagents that hit the edit gate should return to parent.
+- In non-jj repos, do not run `git` commands that write. Read-only only (`git show`, `git status`, `git diff`).
+- Never revert or assume missing changes were yours.
+
+## Tooling
+
+- If a `justfile` exists, use `just` for build, test, and lint. Don't add one unless asked. Fall back to `Makefile` if present.
+- TypeScript: use `just` targets; if none exist, confirm with the user before running `npm` or `pnpm` scripts.
+- Python: use `just` targets; if absent, run `uv run` commands from `pyproject.toml`.
+- Read `.github/workflows` to understand how CI runs tests. It should behave the same locally.
+- For any file search or grep in the current git-indexed directory, use `fff` tools.
+- If a command hangs past 5 minutes, stop it and check with the user.
+
+## Picking the right models for workflows and subagents
+
+Rankings, higher = better. Cost reflects value-per-limits on my plan, not list price. Intelligence is how hard a problem you can hand the model unsupervised. Taste covers UI/UX, code quality, API design, and copy.
+
+| model    | cost | intelligence | taste |
+|----------|------|--------------|-------|
+| sonnet-5 | 5    | 5            | 7     |
+| opus-4.8 | 4    | 7            | 8     |
+| fable-5  | 2    | 9            | 9     |
+
+How to apply:
+- **These are defaults, not limits.** You have standing permission to override them: if a cheaper model's output doesn't meet the bar, rerun or redo the work with a smarter model without asking. Judge the output, not the price tag. Escalating costs less than shipping mediocre work.
+- **Cost is a tie-breaker only.** When axes conflict for anything that ships, intelligence > taste > cost.
+- **Bulk/mechanical work** (clear-spec implementation, data analysis, migrations): sonnet-5. A tight spec doesn't need Fable's intelligence, and Sonnet is the cheapest per unit of work.
+- **Anything user-facing** (UI, copy, API design) needs taste ≥ 7: opus-4.8 or fable-5.
+- **Hardest unsupervised problems** (ambiguous specs, gnarly debugging, architecture): fable-5.
+- **Reviews of plans/implementations**: fable-5 or opus-4.8. For high-stakes work run both as independent perspectives; two lenses catch more than one.
+- **Never use Haiku** for anything that ships.
+- **Fable is token-hungry, so meter it.** Run Fable on `high` effort by default. Reserve `xhigh` for genuinely hard problems; skip `max`/`extra` (a furnace, and worse outputs than lower effort in practice).
+- **Don't burn Fable context on grunt work.** Token-heavy chores (computer use, broad codebase analysis, log trawling) go to a cheaper model or a subagent that reports results back, not to Fable directly.
+- **Mechanics**: Claude models run via the Agent/Workflow `model` parameter (`fable`, `opus`, `sonnet`, `haiku`), with `effort` set per the rules above.
+
+## Testing
+
+- No mocks. Unit tests or e2e tests, nothing in between.
+- Test everything. Tests must be rigorous enough that a new contributor cannot silently break things.
+- Run only the tests you added or modified unless asked otherwise.
+
+## Language Guidance
+
+### TypeScript
+
+- Never use `any`.
+- Never use `as`. Model the real shapes with proper types.
+- Model states so the compiler rejects the illegal ones: discriminated unions with a tag, not booleans-and-optionals soup. Lean on the type system as a correctness tool, not just style. Run the typechecker after edits and treat its errors as the feedback loop.
+- Assume modern browsers unless told otherwise, skip polyfills.
+
+### Python
+
+- We use `uv` and `pyproject.toml`. No `pip` venvs, Poetry, or `requirements.txt` unless asked.
+- Type hints everywhere. Explicit models, not loose dicts or strings.
+
+### KCL
+
+- Assume you have access to the Zoo MCP server. If you don't, tell the user.
+- Use the multi-view snapshot tool to verify the model looks right.
+- Do not use the text-to-cad tool. Write code yourself.
+- Write math into the model, don't use external tools to compute and inject raw values.
+- Write parametric models that won't break when a parameter changes.
+- Don't trust other KCL files on the host system. Look up KCL docs via web search instead.
+- Build models incrementally: base shape, snapshot, verify, add feature, snapshot, verify. Step by step.
+
+## Dependencies
+
+- Before adding a dependency, web search for the most maintained, widely-used option. Confirm with the user before adding.
+
+## Communication
+
+- Dry, concise humor. If uncertain a joke will land, don't attempt it. No forced memes, no flattery.
+- Skip em dashes. Use commas, parentheses, or periods.
+- Cursing in code comments is allowed. Jokes in comments are fine if used sparingly.
+- If I sound angry, it's at the code, not at you.

--- a/.claude/skills/android-cli/SKILL.md
+++ b/.claude/skills/android-cli/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: android-cli
+description: Orchestrates Android development tasks including project creation, deployment, SDK management, and environment diagnostics using the `android` command-line tool.
+---
+# Android CLI Specialist
+
+This skill provides instructions for using the `android` CLI tool. The tool includes various commands for creating projects, running applications, interacting with devices, and managing the CLI environment.
+
+## Installation
+
+If the android tool is not in the path, install it. To install run the following command:
+Linux: curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash
+Mac Arm: curl -fsSL https://dl.google.com/android/cli/latest/darwin_arm64/install.sh | bash
+Mac Intel: curl -fsSL https://dl.google.com/android/cli/latest/darwin_x86_64/install.sh | bash
+Windows: curl -fsSL https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd -o "%TEMP%\i.cmd" && "%TEMP%\i.cmd"
+
+## SDK management
+To manage the installation of Android SDKs and tools, use the `sdk` command. For example:
+
+- `android sdk install <package>[@<version>]...`: Install specific packages. Multiple packages can be specified, separated by spaces. `<version>` defaults to latest. For example: `android sdk install platforms/android-30@2 platforms/android-34`
+- `android sdk update [<pkg-name>]`: Update a specific package or all packages to the latest version.
+- `android sdk remove <pkg-name>`: Remove a package from the local SDK.
+- `android sdk list --all`: List installed and available SDK packages.
+
+## Project creation
+Create projects from templates using the `create` command.
+
+For example: `android create empty-activity --name="My App" --output=./my-app`
+
+## Interacting with devices
+For more information on interacting with running devices, see [here](references/interact.md)
+
+## Running journey tests
+For more information on running journeys, see [here](references/journeys.md)
+
+## Doc searching
+The `docs` command searches authoritative, high-quality Android developer documentation in the Android Knowledge Base.
+By providing a few keywords, this tool will return high quality articles that contain examples or guidance on how to use Android APIs or libraries.
+Use this tool to obtain additional information on how to achieve Android-specific tasks or to know more about Android APIs, surfaces, libraries, or devices.
+
+Always use this tool to get the most up-to-date information about Android concepts. Typical good use cases are:
+  - Finding migration guides for APIs.
+  - Finding examples for APIs.
+  - Finding up-to-date information about Android APIs.
+  - Finding best practices for Android concepts.
+
+## Running APKs
+Use the `run` command to run Android apps.
+
+## Managing emulators
+
+Manage Android Virtual Devices (AVDs) using the `android emulator` command
+
+## Capturing screenshots
+
+Capture an image of the current screen of a connected Android device and output it to a file using the `android screenshot` command.
+
+## Managing skills
+
+Manage antigravity agent skills for Android using the `android skills` command.
+
+## Inspecting UI Layouts
+
+Use the `android layout` command to inspect the UI layout of an Android application. It returns the layout tree of an Android application in JSON format. When debugging UI errors, this is often a much faster approach than taking a screenshot.
+
+## Updating the CLI
+
+Update the Android CLI using the `android update` command.
+
+# `android help` output
+
+Usage: android [-hV] [--sdk=PARAM] [COMMAND]
+  -h, --help        Show this help message and exit.
+      --sdk=PARAM   Path to the Android SDK
+  -V, --version     Print version information and exit.
+Commands:
+  create    Create a new Android project
+  describe  Analyzes an Android project to generate descriptive metadata.
+  docs      Android documentation commands
+  emulator  Emulator commands
+  help      Shows the help of all commands
+  info      Print environment information (SDK Location, etc.)
+  init      Initializes the environment (eg. skills) for Android CLI.
+  layout    Returns the layout tree of an application
+  run       Deploy an Android Application
+  screen    Commands to view the device
+  sdk       Download and list SDK packages
+  skills    Manage skills
+  studio    Android Studio commands
+  update    Update the Android CLI
+
+create
+          Usage: android create [-h] [--verbose] [--list] [--minSdk=api]
+                                --name=applicationName [-o=dest-path] [template-name]
+          Create a new Android project
+                [template-name]      The template name
+            -h, --help               Show this help message and exit.
+                --minSdk=api         The 'minSdk' supported by the application (default
+                                       is defined in the template)
+                --name=applicationName
+                                     The name of the application (e.g. 'My Application')
+            -o, --output=dest-path   The destination project directory path (default is
+                                       '.')
+                --verbose            Enables verbose output
+                --list               List all available templates
+
+describe
+          Usage: android describe [-hV] [--project_dir=PARAM]
+          Analyzes an Android project to generate descriptive metadata.
+          This command identifies and outputs the paths to JSON files that detail the
+          project's structure, including build targets and their corresponding output
+          artifact locations (e.g., APKs). This information enables other tools and
+          commands to locate build artifacts efficiently.
+            -h, --help                Show this help message and exit.
+                --project_dir=PARAM   The project directory to describe
+            -V, --version             Print version information and exit.
+
+docs
+          Usage: android docs [-h] [COMMAND]
+          Android documentation commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            search  Search Android documentation
+            fetch   Fetch Android documentation
+
+emulator
+          Usage: android emulator [-h] [COMMAND]
+          Emulator commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            create  Creates a virtual device
+            start   Launches the specified virtual device. This command will return when
+                      the emulator is fully started and ready to use.
+            stop    Stops the specified virtual device
+            list    Lists available virtual devices
+            remove  Delete a virtual device
+
+help
+          Usage: android help [COMMAND]
+          Shows the help of all commands
+                [COMMAND]   The command to show help for
+
+info
+          Usage: android info <field>
+          Print environment information (SDK Location, etc.)
+                <field>   The specific field to print the value of. If omitted print all.
+
+init
+          Usage: android init
+          Initializes the environment (eg. skills) for Android CLI.
+
+layout
+          Usage: android layout [-dhp] [--device=PARAM] [-o=PARAM]
+          Returns the layout tree of an application
+            -d, --diff           Returns a flat list of the layout elements that have
+                                   changed since the last invocation of ui-dump
+                --device=PARAM   The device serial number
+            -h, --help           Show this help message and exit.
+            -o, --output=PARAM   Writes the layout tree to the specified file or
+                                   directory. If omitted, prints the tree to standard
+                                   output
+            -p, --pretty         Pretty-prints the returned JSON
+
+run
+          Usage: android run [-h] [--debug] [--activity=PARAM] [--device=PARAM]
+                             [--type=PARAM] [--apks=PARAM[,PARAM...]]...
+          Deploy an Android Application
+                --activity=PARAM   The activity name
+                --apks=PARAM[,PARAM...]
+                                   The paths to the APKs
+                --debug            Run in debug mode
+                --device=PARAM     The device serial number
+            -h, --help             Show this help message and exit.
+                --type=PARAM       The component type (ACTIVITY, SERVICE, etc.)
+
+screen
+          Usage: android screen [-h] [COMMAND]
+          Commands to view the device
+            -h, --help   Show this help message and exit.
+          Commands:
+            capture  Outputs the device screen to a PNG
+            resolve  Target UI elements visually
+
+sdk
+          Usage: android sdk [COMMAND]
+          Download and list SDK packages
+          Commands:
+            install  Install SDK packages
+            update   Update one or all packages to the latest version
+            remove   Remove a package from the SDK
+            list     List installed and available SDK packages
+
+skills
+          Usage: android skills [COMMAND]
+          Manage skills
+          Commands:
+            add     Install a skill
+            remove  Remove a skill
+            list    List available skills
+            find    Find skills by keyword
+
+studio
+          Usage: android studio [-h] [COMMAND]
+          Android Studio commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            find-declaration        Find declaration of a symbol
+            find-usages             Find usages of a symbol
+            open-file               Open a file in Android Studio
+            check                   Check the status of running Studio instances
+            analyze-file            Analyze a file in Android Studio
+            render-compose-preview  Render a Compose preview in Android Studio
+            version-lookup          Looks up the latest available versions on the
+                                      internet of maven artifacts, Android versions, and
+                                      more.
+
+update
+          Usage: android update [--url=PARAM]
+          Update the Android CLI
+                --url=PARAM   The URL to download the update from
+

--- a/.claude/skills/android-cli/references/interact.md
+++ b/.claude/skills/android-cli/references/interact.md
@@ -1,0 +1,83 @@
+# Tools
+Run `android layout --help` and `android screen --help`.
+
+## UI Dump
+`android layout`  returns a flat JSON list of the UI elements on screen.
+`android layout --diff` returns a flat JSON list of the UI elements that have changed since the last call to `layout` or `layout --diff`
+
+Each JSON object represents a UI element in the Android app. The following properties may be present:
+- `text` - any literal text the element contains
+- `resourceId` - the Android resource id used to refer to the element
+- `contentDesc` - a description of a UI element for use by accessibility tools
+- `interactions` - the set of user interactions the element supports. May contain one or more of: `checkable`, `clickable`, `focusable`, `scrollable`, `long-clickable`, `password`
+- `state` - the set of states the element is in. May contain one or more of `checked`, `focused`, `selected`
+- `bounds` - the screen coordinates of the bounding rectangle of the element, in the format `[min X,min Y][max X, max Y]`
+- `center` - the screen coordinates of the center of the element, in the format `[x,y]`
+- `off-screen` - if true, the element is in the UI hierarchy but not visible; it may require scrolling to view.
+
+Use `layout` as a primary means of examining an Android app. Use `layout --diff` to focus on changes and to keep your context small.
+Example: When entering digits into a calculator, use `layout --diff` to output only the digit readout element.
+
+`layout` may fail due to the app displaying a WebView or animation; in these cases, use `android screen --annotate` to inspect the app.
+This failure will likely resolve after navigating away from the current screen.
+
+## Screenshot
+`android screen capture -o <file path>` saves a PNG of the current device screen to `<file path>`
+
+Use `screen capture` as a secondary means of examining an Android app
+Examples:
+- Understanding the content of an on-screen image
+- Looking at a `WebView` (web content does not always appear in the ui dump)
+- Trying to find a UI element by its visual appearance
+
+**IMPORTANT**: Always *VISUALLY* examine the PNG image returned from `android screen` BEFORE doing anything else.
+
+## Annotated Screenshot
+`android screen capture --annotate -o <file path>`
+`android screen resolve --screen <path> --string <string>`
+
+The `--annotate` command adds numerical labels and bounding boxes around UI elements. Use this command to locate UI elements that cannot
+be located in the `layout` output.
+
+**IMPORTANT**: When using `android screen --annotate`, always *VISUALLY* examine the resulting PNG file.
+
+To refer to these labels in input commands, use `screen resolve` to convert labels into coordinates:
+
+`android screen resolve --screen <file path> --string "#3"` returns `<x coord of region 3> <y coord of region 3>`
+
+To save turns, you can combine shell commands:
+
+`adb shell input $(android screen resolve --screen screen.png --string "tap #34")`
+
+This command taps on region #34 from `screen.png`
+
+## Input
+Use `adb shell input` for interacting with Android devices.
+Refer to the `"interactions"` property of an element for what interactions can be performed on a particular element.
+
+Interact with UI elements with their `center` coordinate or their `bounds` coordinates:
+```json
+{
+  "key": -248568265,
+  "class": "android.widget.Button",
+  "bounds": "[138,9][167,38]",
+  "center": "[152,23]"
+}
+```
+To tap on this button, you would execute `adb shell input tap 152 23`. This taps the center.
+
+```json
+{
+  "key": 12487234,
+  "class": "com.example.ui.ScrollableList",
+  "bounds": "[100,200][400,600]",
+  "center": "[250,400]"
+}
+```
+To scroll down on this list, you would execute `adb shell input swipe 250 400 600 500`. This swipes from the center to the bottom over 500ms.
+
+# Android Interaction Rules
+1. Always ensure text input fields have `"focused"` in their `"state"` list before entering text
+2. If an element has `"scrollable"` in its `"interactions"` list, try scrolling it when looking for missing UI elements
+2. Always scroll slowly when executing scroll inputs. The 5th argument to `adb shell input swipe` controls scroll duration.
+3. Content may take time to load; if a `layout` is missing information after you take an action, wait a few seconds, then perform `layout --diff` to see if anything changes.

--- a/.claude/skills/android-cli/references/journeys.md
+++ b/.claude/skills/android-cli/references/journeys.md
@@ -1,0 +1,97 @@
+A journey is an XML-specified test of an Android app's behavior. It consists of a list of `<action>` elements. For example:
+```xml
+<journey name="My Journey">
+   <description>
+      A sample journey to illustrate the format
+   </description>
+   <actions>
+     <action>
+       Tap the "Home" icon
+     </action>
+     <action>
+       Verify that the app is on its Home screen
+     </action>
+   </actions>
+</journey>
+```
+
+Evaluate a journey by proceeding through the `<actions>` list in sequential order. Evaluate each `<action>` block individually.
+A journey succeeds if all elements in the `<actions>` list succeed.
+
+A journey is a test case for an app. The journey XML is the source of truth; if the app disagrees with the journey, the app has failed.
+Additionally, if the app exits, crashes, or freezes, journey evaluation stops and the journey fails.
+
+**IMPORTANT** - Execute each step EXACTLY as written, and independently of other steps! If an action says to `"tap the first search result"`,
+you MUST find the search results and tap the first one. Do this even if you believe you know the intent behind the action.
+
+## Taking Actions
+Some `<action>` elements specify UI interactions to perform on the running Android app. Perform the interaction and verify that the app does 
+not crash or behave in an unexpected manner. This is the *only* verification you should perform for an `<action>`.
+
+If the interaction cannot be performed as specified, the journey fails. 
+Example: 
+```<action>Click the red button</action>```
+If you determine a red button is not present in the UI, the journey fails. 
+
+If the text of an `<action>` specifies a list of actions, break it into sub-actions and evaluate them individually: 
+Example:
+```<action>Search for soda and add the first result to the cart</action>```
+This should be evaluated as:
+```
+<action>Search for soda</action>
+<action>Add the first result to the cart</action>
+```
+
+If an `<action>` contains something that is not a specification for a UI interaction, alert the user that the journey is malformed and exit
+early, specifying the error in question.
+
+## Verifying Expectations
+`<action>` elements that begin with "check" or "verify" specify expectations for the current state of the Android app. Determine the current
+state of the app and check if the expectations are met.
+
+Determine the current state of the app by inspecting the current screen of the device without interacting with it.
+Example:
+```<action>Check if "Switch 2" is visible on the screen</action>```
+This requires only inspecting the current screen, not scrolling or interacting. If "Switch 2" is not currently visible, the action fails.
+
+If the expectations are not met, mark the `<action>` as a failure and the journey evaluation ends. A single `<action>` may contain
+multiple expectations.
+Example:
+```<action>Verify that the app is on the Home screen, the Home icon is blue, and the temperature is displayed</action>```
+This `<action>` fails if ANY of the following are false:
+- The app is on the Home screen
+- There is a Home icon, and it is blue
+- A temperature is displayed
+
+## Handling failure 
+When running a journey, evaluate it as a test. Failure is acceptable, and often expected. Proper reporting of failures is the priority.
+
+Keep debugging and troubleshooting to a minimum; assume that tools are showing you the correct output every time. The goal is to determine 
+if the *current* Android app can correctly handle the *current* steps outlined in the journey. Suggestions for bug fixes, clarification, or 
+other improvements should be kept to journey evaluation summary at the end.
+
+## Summarizing
+For each `<action>` you evaluated, output JSON describing the results.
+
+```
+{
+  "journey:", The name of the journey
+  "results:" [
+    {
+      // A string containing the full text of the <action> 
+      "action": "Click the blue button,
+      // "PASSED" if the instruction was evaluated, "FAILED" if the instruction could not be evaluated, or "SKIPPED" if journey evaluation ended early because an instruction failed 
+      "status": "PASSED", 
+      // A list of the ADB commands executed while evaluating the instruction,
+      "commands": [ "adb input swipe 490 200 500 500 500", "adb input tap 45 920" ],  
+      // Failure reasons, feedback, or other useful information 
+      "comment": "The journey step doesn't specify that the button requires scrolling to see", 
+    },
+    {
+      "action": "The home screen is shown", 
+      "status": "FAILED", 
+      "comment": "The settings page was shown",   
+    },
+  ]
+}
+```

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: design
+description: Design and build new UI with the complete ui.sh design guideline system.
+---
+
+# Design
+
+Use this when the user wants to create new UI that follows the full ui.sh design guideline system.
+
+## Activation
+
+### Use For
+
+- designing new UI, layouts, sections, components, or pages from scratch
+- implementing visually polished Tailwind CSS UI
+- adding a new section or page to an existing UI
+- applying reusable design, markup, and Tailwind authoring rules while building UI
+
+### Do Not Use For
+
+- UI picker scaffolding only
+- semantic unstyled markup from screenshots, Figma exports, mockups, wireframes, or UI images
+- component extraction or code organization only
+- Tailwind class cleanup only
+- adding dark mode to an existing UI only
+- making an existing desktop-oriented UI responsive only
+
+## Load First
+
+- Read [UI Design Guidelines](./design-guidelines.md) before writing UI code.
+- Scan the rule-file index and load every guideline file that could apply.
+- Load reference modules only when the request needs that reference material.
+
+## Progress Updates
+
+Keep the user informed so longer runs do not look stuck.
+
+- One-line status update before each major phase.
+- Concrete and lightweight: what you are doing now, not verbose logs.
+
+## Workflow
+
+1. Inspect the user's request, target files, existing design conventions, and available components.
+2. Load [UI Design Guidelines](./design-guidelines.md) plus every applicable rule file.
+3. Implement the UI using the project's existing framework, component patterns, assets, and Tailwind conventions.
+4. Check the result across responsive breakpoints and interaction states.
+
+## Rules
+
+- Treat the guideline files in this skill as the source of truth for new UI design work.
+- Err on the side of loading too many applicable guideline files rather than too few.
+- Preserve user constraints unless a guideline explicitly requires asking about a design conflict.
+
+## Verify
+
+- Check desktop and mobile layouts.
+- Confirm every applicable guideline file was loaded and followed.
+- Run relevant formatting, lint, typecheck, or tests when available.

--- a/.claude/skills/design/design-guidelines.md
+++ b/.claude/skills/design/design-guidelines.md
@@ -1,0 +1,74 @@
+# UI Design Guidelines
+
+Use this when designing or building new UI with the top-level `design` skill, or when a workflow tells you to load design guidance before editing UI code.
+
+## Load Contract
+
+- Before writing UI code, scan the rule-file index below and load every rule file that could apply.
+- Err on the side of loading too many rule files rather than too few.
+- Treat rules as applicable even when they are indirect: heading group rules apply to hero sections; landing page rules apply to individual page sections; surface rules apply to dashboard cards and list items.
+- Load reference modules only when the user's request needs that reference material.
+
+## General Design Principles
+
+- Every layout must adapt from mobile to desktop — use responsive breakpoint classes to adjust the design at different screen sizes; see [Responsive Design](./guidelines/responsive-design.md) for detailed rules
+
+## Rule Files
+
+Follow these rules when designing or building UI. Each rule file covers a specific topic:
+
+- [Avatars](./guidelines/avatars.md) — profile photos, user thumbnails, and people images used in testimonials, team sections, comments, and anywhere a person's face appears
+- [Badges](./guidelines/badges.md) — badges, tags, pills, status indicators, labels, and chips with or without icons
+- [Border Radius](./guidelines/border-radius.md) — rounding corners on cards, containers, buttons, images, screenshots, and nested elements with concentric radii
+- [Buttons](./guidelines/buttons.md) — primary and secondary buttons, CTAs, icon buttons, destructive/danger actions, and touch targets
+- [Colors](./guidelines/colors.md) — brand colors, accent colors, color palette selection, and default color choices
+- [Copywriting](./guidelines/copywriting.md) — punctuation, periods, headings, taglines, subtitles, descriptions, and list items
+- [Custom Fonts](./guidelines/custom-fonts.md) — loading custom fonts via `<link>` tags or `@import url()`, registering fonts in `@theme` with `--font-*`, font-feature-settings, and font-variation-settings
+- [Dark Mode](./guidelines/dark-mode.md) — dark theme styling, contrast ratios, colored panels, card backgrounds, shadow removal, decorative elements, heading colors, dark-mode image handoff, and inline/external SVG dark-mode handling
+- [Description Lists](./guidelines/description-lists.md) — `<dl>`, `<dt>`, and `<dd>` styling, term/detail contrast and font weight hierarchy
+- [Dashboards](./guidelines/dashboards.md) — dashboard layouts, stat grids, KPI cards, metric cards, admin panels, analytics views, and any section displaying key statistics, charts, or summary data
+- [Feature Lists](./guidelines/feature-lists.md) — feature grids, feature sections, benefit lists, and any section that lists multiple features with titles and descriptions
+- [Flexbox Layout](./guidelines/flexbox-layout.md) — flex containers, flex children, `min-w-0` shrinking behavior, `shrink-0` on icons/images/SVGs, fluid vs fixed layouts, sidebar + content patterns, and any layout using `flex-1` or flexible sizing
+- [Footers](./guidelines/footers.md) — page footers, footer logos, footer links, social media icons, and site-wide bottom navigation
+- [Form Controls](./guidelines/form-controls.md) — inputs, selects, checkboxes, radio buttons, login forms, sign-up forms, checkout forms, search bars, newsletter sign-up fields, and input + button combos
+- [General](./guidelines/general.md) — general markup rules (class placement on block vs inline elements, redundant display classes, `role="list"`) and Tailwind CSS authoring rules (utility preferences, spacing conventions, arbitrary value syntax, variant patterns, deprecated utilities) that apply across all components
+- [Headers](./guidelines/headers.md) — site headers, navigation bars, navbars, top bars, logos, mobile menus, and hamburger menus
+- [Heading Groups](./guidelines/heading-groups.md) — the headline, subheadline, and optional eyebrow at the top of marketing and landing page sections (hero, features, team, pricing, CTA, etc.); does not apply to blog posts, articles, or editorial content
+- [Icons](./guidelines/icons.md) — SVG icons, icon sizing, icon alignment with text, Heroicons, filled vs stroked icons, and inline list icons like checkmarks
+- [Images](./guidelines/images.md) — photos, thumbnails, screenshots, app UI mockups, and image borders/outlines
+- [Interactivity](./guidelines/interactivity.md) — hover states, transitions, animations, and interactive behavior on clickable vs non-clickable elements
+- [Landing Pages](./guidelines/landing-pages.md) — full page consistency rules for buttons, fonts, containers, border radius, column gaps, layout alignment, and responsive constraints across all sections on a page
+- [Login Pages](./guidelines/login-pages.md) — login, sign-in, sign-up, and authentication page backgrounds and layout rules
+- [Logo Clouds](./guidelines/logo-clouds.md) — logo grids, client logo rows, partner logos, trust bars, and any section displaying a collection of brand logos
+- [Navigation](./guidelines/navigation.md) — sidebar nav, header nav, mobile nav menus, tabs, tab bars, vertical menus, active/selected states, and current page indicators in any navigation pattern
+- [Pagination](./guidelines/pagination.md) — page number links, previous/next buttons, and paged navigation controls
+- [Placeholder Content](./guidelines/placeholder-content.md) — dummy logos, placeholder avatars, app screenshots, wallpapers, and the assets API for generating realistic placeholder content
+- [Prose Content](./guidelines/prose-content.md) — styling raw HTML from markdown, CMS, or database content where Tailwind classes can't be applied to individual elements; replaces the `@tailwindcss/typography` plugin with a custom `.prose` class
+- [Pricing Cards](./guidelines/pricing-cards.md) — pricing tiers, pricing tables, plan cards, emphasized/popular plan styling, and button alignment across pricing columns
+- [Responsive Design](./guidelines/responsive-design.md) — responsive breakpoints, container queries, `@container` placement, and mobile-to-desktop layout adaptation
+- [SVG](./guidelines/svg.md) — inline SVG elements, `xmlns` attributes, SVG color styling (`fill`, `stroke`, `currentColor`), and SVG markup conventions used anywhere in HTML/JSX
+- [Section Layout](./guidelines/section-layout.md) — left-aligned vs centered section layouts, content width constraints, and aligning containers across stacked page sections
+- [Shadows](./guidelines/shadows.md) — box shadows on cards, modals, popovers, dropdowns, and elevated elements, including border pairing rules
+- [Surfaces](./guidelines/surfaces.md) — cards, wells, borders, dividers, and white space as surface treatments; when to use cards vs subtle dividers vs recessed backgrounds vs no separation at all; applies to stat grids, dashboard metrics, list items, sidebars, and any content grouping decision
+- [Tables](./guidelines/tables.md) — data tables, comparison tables, table headings, row dividers, and table containers
+- [Team Sections](./guidelines/team-sections.md) — team grids, team member cards, staff listings, about-us sections, and people galleries with photos and bios
+- [Testimonials](./guidelines/testimonials.md) — customer quotes, reviews, social proof sections, testimonial cards, hanging punctuation, and attribution layout
+- [Typography](./guidelines/typography.md) — font weights, line heights, text sizes, heading styles, max-width constraints, text-pretty/text-balance, tracking, and eyebrow text
+
+## Reference Modules
+
+Load these only when the request needs the reference:
+
+- [Assets API](./guidelines/assets-api.md) — placeholder asset URLs, query parameters, and examples for marks, avatars, logos, screenshots, and wallpapers
+- [Font Recommendations](./guidelines/font-recommendations.md) — optional font suggestions for when the user asks for help choosing a font or wants to try different fonts across design variations; includes sourcing notes, feature settings, and tips for each font
+
+## Design Conflicts
+
+When a rule says **⚠️ ask-user**, the user's input conflicts with a design guideline. Do not silently override the user or silently follow their request. Instead:
+
+1. Use the `AskUserQuestion` tool to flag the conflict
+2. Explain what the guideline recommends and why the input doesn't fit
+3. Offer a concrete alternative (e.g. a rewritten version of their copy, a different layout)
+4. Wait for the user to choose before proceeding
+
+Never skip this — even if it feels minor. The user should always be aware when their input bumps up against a design rule.

--- a/.claude/skills/design/guidelines/assets-api.md
+++ b/.claude/skills/design/guidelines/assets-api.md
@@ -1,0 +1,196 @@
+# Assets API
+
+Covers: placeholder marks, avatars, logos, screenshots, wallpapers, and concrete asset URL parameters.
+
+Base URL: `https://assets.ui.sh`
+
+Prefer file extensions in asset URLs whenever the route supports them. Use `/marks/{id}.svg`, `/avatars/{id}.webp`, `/logos/{id}.svg`, `/screenshots/{id}.webp`, and `/wallpapers/{type}.webp?variant={name}`.
+
+## Marks
+
+`GET /marks/{id}`
+
+Preferred URL: `/marks/{id}.svg`
+
+Returns an SVG mark, optionally with text.
+
+IDs: `1`
+
+| Param           | Type   | Default | Notes                                                                    |
+| --------------- | ------ | ------: | ------------------------------------------------------------------------ |
+| `text`          | string |       — | Optional label text                                                      |
+| `font`          | string | `inter` | `inter`, `dm-sans`, `sora`, `outfit`, `instrument-sans`, `space-grotesk` |
+| `weight`        | number |   `600` | Font weight                                                              |
+| `color`         | string | `black` | Mark color                                                               |
+| `textColor`     | string | `color` | Text color                                                               |
+| `letterSpacing` | number |    `-1` | Spacing between letters in pixels                                        |
+
+## Avatars
+
+`GET /avatars/{id}`
+
+Preferred URL: `/avatars/{id}.webp`
+
+Other image extensions such as `.jpg`, `.jpeg`, and `.png` are also accepted. Prefer `.webp` in docs and examples.
+
+Returns an avatar image.
+
+IDs: `1`-`16`
+
+| Param       | Type   | Default | Notes           |
+| ----------- | ------ | ------: | --------------- |
+| `size`      | number |       — | Square resize   |
+| `w`         | number |       — | Width           |
+| `h`         | number |       — | Height          |
+| `grayscale` | flag   |     off | Apply grayscale |
+
+## Logos
+
+`GET /logos/{id}`
+
+Preferred URL: `/logos/{id}.svg`
+
+Returns an SVG logo. IDs are matched fuzzily: case-insensitive, ignoring non-alphanumeric characters.
+
+IDs: `align`, `artifact`, `axiom`, `concise`, `looply`, `orbital`, `pinelabs`, `quirk`, `relay`
+
+| Param          | Type   | Default | Notes          |
+| -------------- | ------ | ------: | -------------- |
+| `color`        | string |       — | Primary fill   |
+| `accent-color` | string | `color` | Secondary fill |
+| `height`       | string |       — | SVG height     |
+| `width`        | string |       — | SVG width      |
+
+## Screenshots
+
+`GET /screenshots/{id}`
+
+Preferred URL: `/screenshots/{id}.webp`
+
+Other image extensions such as `.jpg`, `.jpeg`, and `.png` are also accepted. Prefer `.webp` in docs and examples.
+
+Returns a screenshot image.
+
+IDs: `1`
+
+- `1` colors: `mauve`, `mist`, `olive`, `stone`, `taupe`
+
+| Param    | Type   | Default | Notes            |
+| -------- | ------ | ------: | ---------------- |
+| `color`  | string |       — | Variant name     |
+| `top`    | number |       — | Crop from top    |
+| `bottom` | number |       — | Crop from bottom |
+| `left`   | number |       — | Crop from left   |
+| `right`  | number |       — | Crop from right  |
+
+Crop:
+
+- `top` + `bottom`: height `top + bottom` from `y=0`
+- `top` only: top crop with height `top`
+- `bottom` only: bottom crop with height `bottom`
+- `left` + `right`: width `left + right` from `x=0`
+- `left` only: left crop with width `left`
+- `right` only: right crop with width `right`
+- All values must be positive integers
+
+## Wallpapers
+
+`GET /wallpapers/{type}`
+
+Preferred URL: `/wallpapers/{type}.webp?variant={name}`
+
+Other image extensions such as `.jpg`, `.jpeg`, and `.png` are also accepted. Prefer `.webp` in docs and examples.
+
+Returns a wallpaper image.
+
+| Param     | Type   |       Default | Notes        |
+| --------- | ------ | ------------: | ------------ |
+| `variant` | string | type-specific | Variant name |
+
+Aliases:
+
+- `landscape` -> `landscapes`
+
+### `blend`
+
+Default: `arctic-glimmer`
+
+Variants:
+
+- `arctic-glimmer`: cool arctic slate and frosted mint in the upper left flowing through a serene cerulean blue then merging into a deep navy and obsidian shadow toward the lower right
+- `emerald-mist`: deep forest green and dark moss in the upper left flowing through a vibrant sage and misty lime transition then settling into a soft eucalyptus and pale silver-grey at the lower right
+- `golden-hour-mist`: soft champagne and pale cream in the upper left shifting into a warm apricot glow then deepening into a rich honey and toasted sienna at the lower right
+- `midnight-nebula`: deep indigo and charcoal in the upper left transitioning into a vibrant violet haze followed by electric magenta and finishing in a soft turquoise glow at the bottom right
+- `nebula-glow`: —
+
+### `haze`
+
+Default: `default`
+
+Variants:
+
+- `dark`: dark charcoal and deep grey monochrome
+- `default`: warm off-white and cream monochrome
+- `mauve-dark`: dark muted purple-grey monochrome
+- `mauve`: muted purple-grey and soft lavender monochrome
+- `mist-dark`: dark cool blue-grey monochrome
+- `mist`: cool blue-grey monochrome
+- `sage`: muted sage green and soft olive-grey monochrome
+- `taupe-dark`: dark warm taupe monochrome
+- `taupe`: warm taupe and neutral grey monochrome
+
+### `horizon`
+
+Default: `arctic-rim`
+
+Variants:
+
+- `arctic-rim`: Deep navy and cold-charcoal backgrounds with highlights of desaturated cyan and pale frosted silver.
+- `calcite-dusk`: Deep charcoal and slate backgrounds with highlights of desaturated pearl and soft bone-white.
+- `celestial-lead`: Cold lead-gray and charcoal backgrounds with highlights of desaturated lilac and frosted zinc.
+- `jade-corner`: Deep oceanic-gray and muted charcoal backgrounds with highlights of desaturated jade and pale misty teal.
+- `obsidian-ember`: Deep mahogany and dark umber backgrounds with highlights of desaturated bronze and weathered ash-gray.
+- `oxide-center`: Deep graphite and charred-umber backgrounds with highlights of matte rust and weathered bronze.
+- `sepia-rim`: Deep umber and warm-charcoal backgrounds with highlights of matte gold and weathered bronze.
+
+### `landscapes`
+
+Default: `valley`
+
+Variants:
+
+- `arctic-fjord`: deep-seated glacial fjord flanked by sheer granite cliffs and distant ice-capped peaks — icy cerulean, muted indigo, frosted slate, pale bone white
+- `basalt-plateau`: vast basalt plateau with distant volcanic ridges — ash grey, muted obsidian, dark pewter, faint earthy umber
+- `coast`: coastal beach with gentle waves — slate blues, soft teal, pale grey sky, cool sandy beige
+- `dunes`: desert dunes at sunset — dusty rose, terracotta, warm mauve, soft peach sky
+- `forest`: misty pine forest valley — sage greens, cool grays, muted blue-green
+- `fossil-cliffs`: towering chalk cliffs overlooking a still, pale sea — creamy bone white, soft oyster grey, muted sea-foam green, pale flint blue
+- `highland-moors`: rolling highland moorland with patches of wild heather and moss — muted heather purple, deep moss green, weathered peat brown, soft charcoal grey
+- `hills`: rolling pastoral hills with scattered autumn trees — olive green, faded ochre, burnt umber, warm taupe
+- `lake`: still lake at twilight with forested shoreline — deep slate blue, muted teal, soft peach undertones
+- `limestone-karst`: submerged limestone pillars rising from a calm and misty bay — faded lichen green, weathered grey stone, soft misty blue water
+- `meadow`: alpine meadow with distant mountains — soft sage green, pale grey-blue mountains, warm hay tones
+- `misty-marshland`: low-lying wetlands with scattered pools and tall reeds — mossy green, muted bronze, dark water grey, pale foggy lavender
+- `pampas-grassland`: expansive plains of tall pampas grass under a wide, open sky — pale straw, muted silver, dusty lilac, soft grey-blue
+- `salt-crust-expanse`: expansive dry salt flats with distant mountain silhouettes — pearl white, ivory, faint lilac shadows, muted silver-grey
+- `snow`: minimalist snowfield with soft rolling dunes — off-white snow, cool blue-grey shadows, pale sky
+- `valley`: misty mountain valley with scattered trees — sage greens, soft grays, warm taupe undertones
+- `weathered-badlands`: deeply eroded sedimentary hills and canyons with horizontal strata lines — muted terracotta, dusty clay, pale sandstone, soft ochre, warm charcoal
+
+### `silk`
+
+Default: `crimson-surge`
+
+Variants:
+
+- `crimson-surge`: Deep scarlet and polished ruby textures
+- `cyan-glacier`: Vivid turquoise and liquid crystalline textures
+- `emerald-glint`: Deep hunter green and iridescent teal accents
+- `midnight-violet`: Deep obsidian and translucent violet hues
+- `molten-amber`: Deep burnt orange and polished bronze textures
+- `platinum-flow`: Liquid mercury and polished titanium textures
+- `sapphire-flux`: Deep royal blue and luminous sapphire-blue textures
+
+## Color Resolution
+
+Color params accept Tailwind names like `red-500` and `blue-600`, resolved to `oklch()`. Other CSS colors pass through unchanged.

--- a/.claude/skills/design/guidelines/avatars.md
+++ b/.claude/skills/design/guidelines/avatars.md
@@ -1,0 +1,8 @@
+# Avatars
+
+Covers: profile photos, user thumbnails, testimonial people, comments, team members, and overlapping avatar groups.
+
+- See [Assets API](./assets-api.md) for avatar URLs and query parameters
+- Prefer extension-suffixed avatar URLs such as `/avatars/1.webp`
+- Use `outline-1 -outline-offset-1 outline-black/5` or `outline-black/10` on light surfaces; use `outline-white/10` on dark surfaces
+- Give stacked/overlapping avatar groups a 2px `ring` that matches the background color (e.g. `ring-2 ring-white`)

--- a/.claude/skills/design/guidelines/badges.md
+++ b/.claude/skills/design/guidelines/badges.md
@@ -1,0 +1,5 @@
+# Badges
+
+Covers: badges, tags, pills, labels, chips, status indicators, and compact metadata with icons.
+
+- Badges with a leading or trailing icon — never use symmetric `px-*`; use `pl-*`/`pr-*` and set the icon side's padding equal to the vertical padding: `py-1 pr-2 pl-1` (left icon), `py-1 pr-1 pl-2` (right icon)

--- a/.claude/skills/design/guidelines/border-radius.md
+++ b/.claude/skills/design/guidelines/border-radius.md
@@ -1,0 +1,6 @@
+# Border Radius
+
+Covers: rounded cards, panels, buttons, images, screenshots, nested surfaces, and any UI element where radius consistency matters.
+
+- Use concentric border radii on closely nested rounded elements — define the relationship explicitly with CSS variables and `calc()` so the math is enforced, e.g. `rounded-(--radius) p-(--padding)` on the outer element, `rounded-[calc(var(--radius)-var(--padding))]` on the inner
+- Use `min()` with viewport units for image/screenshot border radii instead of fixed `rounded-*` values — e.g. `rounded-[min(1vw,12px)]`; the radius should match the intended value at full desktop width and scale proportionally as the screen shrinks

--- a/.claude/skills/design/guidelines/buttons.md
+++ b/.claude/skills/design/guidelines/buttons.md
@@ -1,0 +1,27 @@
+# Buttons
+
+Covers: primary buttons, secondary buttons, CTAs, icon buttons, destructive actions, form actions, and touch targets.
+
+## Design Rules
+
+- When adding shadows to buttons, follow the shadow rules in `shadows.md` — never pair `shadow-*` with solid gray borders; use `ring-1 ring-black/5` or `ring-1 ring-black/10` instead
+- Primary buttons with a ring — never use reduced opacity on the ring; use a solid color that matches the button background (e.g. `ring-indigo-600` on an `bg-indigo-600` button, not `ring-black/10`)
+- Dangerous actions like "Delete" use a secondary/muted button style by default — only use a primary button style when the dangerous action is the primary action on the page or dialog (e.g. a confirm-delete dialog)
+- Only one primary button per page — scan the entire page and ensure only one button uses a filled/solid primary style; every other button must use a secondary style — soft/muted (solid with opacity), outline, or ghost (text-only); treat dialogs/modals as their own page
+- Never make a secondary button higher contrast than the primary button — the primary button must always be the most visually prominent
+- Any button that is not the page's primary submit/save action is an inline form action — change avatar, change photo, upload file, generate password, verify email, add item, resend code, etc.; always use the smaller of the two button sizes and a secondary style; these must never be the same height as the form's primary/submit button
+
+### Sizing
+
+- Use less horizontal padding — `px-3 py-2` not `px-4 py-2`, `px-4 py-3` not `px-5 py-3`
+- Application UIs (dashboards, settings, admin) — `text-sm` with compact padding, never `text-base`; total rendered button height (including outer wrapper/ring) must stay within 28–38px; account for the `p-px` border wrapper when calculating — the wrapper adds 2px total
+- Maximum 2 button sizes per application UI — pick two distinct heights and use only those; the difference between them must be at least 6px
+- Buttons with a leading or trailing icon — never use symmetric `px-*`; use `pl-*`/`pr-*` and set the icon side's padding equal to the vertical padding: `py-2 pr-3 pl-2` (left icon), `py-2 pr-2 pl-3` (right icon), `py-1.5 pr-2.5 pl-1.5` (left icon, compact)
+
+### Focus Styles
+
+- Solid buttons need a custom focus ring — use `focus-visible:outline-*` with `focus-visible:outline-offset-2`; default to `focus-visible:outline-blue-500` if the project has no established focus color
+
+## Coding Rules
+
+- Small/icon buttons must meet the 48×48px minimum touch target — make the button `relative` and add `<span class="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden" aria-hidden="true" />` as a direct child

--- a/.claude/skills/design/guidelines/colors.md
+++ b/.claude/skills/design/guidelines/colors.md
@@ -1,0 +1,6 @@
+# Colors
+
+Covers: brand colors, accent colors, neutral palettes, text colors, and default color families.
+
+- Never default to indigo as the brand/accent color — only use indigo if the project already uses it or the user explicitly requests it
+- Never default to `gray-*` or `slate-*` for neutral/text colors — only use them if the project already uses them or the user explicitly requests them; prefer `zinc-*` or `neutral-*` instead

--- a/.claude/skills/design/guidelines/copywriting.md
+++ b/.claude/skills/design/guidelines/copywriting.md
@@ -1,0 +1,9 @@
+# Copywriting
+
+Covers: headings, taglines, subtitles, descriptions, labels, list items, button text, and other UI copy.
+
+- Headings — periods or no periods are both fine, but be consistent within a page
+- Always use proper punctuation (ending period) on full sentences and paragraphs
+- Use a period on any descriptive text that stands alone — taglines, subtitles, tier descriptions like "For professionals and growing teams.", single-line descriptions like "For organizations that need more power and control."
+- Only omit periods on items in a list — e.g. feature bullet points in pricing cards
+- Never use emojis anywhere — not in headings, descriptions, buttons, labels, or any other text

--- a/.claude/skills/design/guidelines/custom-fonts.md
+++ b/.claude/skills/design/guidelines/custom-fonts.md
@@ -1,0 +1,7 @@
+# Custom Fonts
+
+Covers: loading custom fonts, registering font theme variables, and applying display/body font utilities.
+
+- Always load custom fonts before using them — add `<link>` tags in the HTML `<head>` (preferred); if no `<head>` is available, use `@import url('…');` at the top of the CSS file instead
+- Register frequently used custom fonts in the CSS `@theme` block — e.g. `--font-display: "Oswald", sans-serif;`; optionally set `--font-display--font-feature-settings` and `--font-display--font-variation-settings` for fine-tuning
+- Register headline/display fonts as `--font-display` (creates a `font-display` utility) — use `--font-sans` for body/UI fonts and `--font-display` for fonts that are only used on headings and display text; apply `font-display` on headings alongside `font-sans` on the body

--- a/.claude/skills/design/guidelines/dark-mode.md
+++ b/.claude/skills/design/guidelines/dark-mode.md
@@ -1,0 +1,29 @@
+# Dark Mode
+
+Covers: dark-mode styling, light-to-dark conversion, dark-mode contrast audits, dark-mode images, and dark-mode SVGs.
+
+## Design Rules
+
+- Dark mode is about maintaining the same contrast ratios as light mode, not simply inverting colors
+- Dark mode doesn't need to preserve every detail of the light mode design — it just needs to look good
+- Default dark mode to follow the operating system's `prefers-color-scheme` setting (Tailwind's built-in `dark:` behavior); only add a manual toggle when the user explicitly asks for one
+- Remove all shadows in dark mode — use `dark:shadow-none`
+- On dark-mode-only sites, add the `scheme-only-dark` class to `<html>` or the top-level element — ensures native elements like scrollbars, form controls, and `color-scheme` render in dark mode
+
+## Component Rules
+
+- Never keep large branded/colored panels in dark mode; instead use the same background color and add a light divider between sections
+- Style cards only slightly lighter than the page background (e.g. `dark:bg-gray-900` on a `dark:bg-gray-950` page); add a `dark:inset-ring dark:inset-ring-white/5` for definition
+- Make decorative quote marks in testimonials very faint (e.g. `dark:text-white/5`)
+- Never use multiple heading text colors in dark mode (e.g. dark gray + brand color); use a single light color like `white` or `gray-100` for all heading text
+
+## Raster Image Rules
+
+- When adding or improving dark mode, audit the page for rasterized images that need dark-mode versions: photos, screenshots, product mockups, decorative backgrounds, textures, and rasterized illustrations
+- Never use CSS filters (`invert`, `brightness`, `contrast`, `opacity`) as the final dark-mode treatment for raster images; always create real dark-mode image files
+- Generate dark-mode raster image variants with the `dark-mode-image` skill, which MUST load and use the `imagegen` skill before creating or editing any raster image assets
+
+## SVG Rules
+
+- For inline `<svg>` elements, style dark mode with Tailwind `dark:*` classes (e.g. `dark:fill-*`, `dark:stroke-*`, `dark:text-*`)
+- For external SVG files referenced via `<img>`, always create a dark-mode version alongside the original (e.g. `logo.svg` and `logo-dark.svg`); never substitute CSS filters (`invert`, `brightness`) or opacity adjustments for a true dark variant

--- a/.claude/skills/design/guidelines/dashboards.md
+++ b/.claude/skills/design/guidelines/dashboards.md
@@ -1,0 +1,12 @@
+# Dashboards
+
+Covers: dashboard layouts, stat grids, KPI cards, metric cards, admin panels, analytics views, and summary data.
+
+## Design Rules
+
+- Never allow stat or metric card titles to wrap; use `truncate` to keep them on a single line
+- Never put icons in stat/metric cards — use plain text labels and values only
+
+## Coding Rules
+
+- Always use container queries for responsive dashboard widgets, not media queries

--- a/.claude/skills/design/guidelines/description-lists.md
+++ b/.claude/skills/design/guidelines/description-lists.md
@@ -1,0 +1,5 @@
+# Description Lists
+
+Covers: `<dl>`, `<dt>`, and `<dd>` content, term/detail pairs, metadata groups, and definition-style lists.
+
+- Style `<dt>` elements with higher contrast text color and a slightly heavier font weight (e.g. `font-medium`); style `<dd>` elements with regular font weight and a lower contrast color — this lets links inside `<dd>` elements use the higher contrast color to stand out

--- a/.claude/skills/design/guidelines/feature-lists.md
+++ b/.claude/skills/design/guidelines/feature-lists.md
@@ -1,0 +1,5 @@
+# Feature Lists
+
+Covers: feature grids, benefit lists, product feature sections, and any section listing multiple features with titles and descriptions.
+
+- Use `<dl>`, `<dt>`, and `<dd>` elements for feature sections that list multiple features — not `<ul>`/`<li>` or plain `<div>` groups

--- a/.claude/skills/design/guidelines/flexbox-layout.md
+++ b/.claude/skills/design/guidelines/flexbox-layout.md
@@ -1,0 +1,6 @@
+# Flexbox Layout
+
+Covers: flex containers, flexible children, fixed-size icons/images, truncation, sidebars, and layouts using `flex-1`, `min-w-0`, or `shrink-0`.
+
+- Always add `min-w-0` (or `min-width: 0`) to flex children that need to shrink below their content size — flex items default to `min-width: auto` and won't shrink past their content without it; applies at every scale, from page-level layouts (e.g. a fluid content area next to a fixed-width sidebar using `flex-1`) down to small UI pieces (e.g. a truncated text label in a row, a flexible input next to a fixed button)
+- Always add `shrink-0` to flex children that should never shrink — icons, SVGs, images, logos, avatars, and any element that would become visually distorted if compressed

--- a/.claude/skills/design/guidelines/font-recommendations.md
+++ b/.claude/skills/design/guidelines/font-recommendations.md
@@ -1,0 +1,175 @@
+# Font Recommendations
+
+Covers: optional font suggestions, type direction exploration, and font ideas for design variations.
+
+These are optional recommendations for when the user asks for help choosing a font or wants to try different fonts across design variations. Never force these — only reference them when font selection is part of the task.
+
+## General Guidelines
+
+- Default to Inter for body/UI text unless the user is specifically exploring other options
+- Always recommend sans-serif fonts unless the user explicitly asks for serif/non-sans-serif, uses words like "sophisticated" or "editorial", or the project clearly calls for it (e.g. luxury brand, literary magazine, fashion editorial)
+
+## By Purpose
+
+### Body & UI
+
+Fonts that work well for body copy, application interfaces, and general-purpose use. Most of these also work for headings.
+
+**Sans-serif:**
+
+- **[DM Sans](#dm-sans)** — low-contrast geometric, large x-height, excellent small-text readability
+- **[Figtree](#figtree)** — friendly geometric with curved letterforms, warm and approachable
+- **[General Sans](#general-sans)** — compact rationalist, space-efficient, good for dense UI
+- **[Geist](#geist)** — Swiss-inspired, minimal and precise, built for UI
+- **[Host Grotesk](#host-grotesk)** — uniwidth (weight changes don't shift layout), good for nav/tabs/buttons
+- **[Inter](#inter)** — clean and highly legible, the default recommendation for screens
+- **[Instrument Sans](#instrument-sans)** — geometric neo-grotesque, clean and technical
+- **[Mona Sans](#mona-sans)** — GitHub's neo-grotesque, strong industrial feel
+- **[Satoshi](#satoshi)** — modernist with personality, double-storey `a` and `g`
+
+**Serif:**
+
+- **[Lora](#lora)** — well-balanced contemporary serif, good readability at body sizes, subtle brush-stroke contrast
+
+### Headlines & Display
+
+Fonts best suited for headings and large display text. Many Body & UI fonts above also work well for headings — the fonts listed here are particularly strong choices for display use or are display-only.
+
+**Sans-serif:**
+
+- **[DM Sans](#dm-sans)** — low-contrast geometric that scales up cleanly for headlines while staying readable at body sizes
+- **[Fixel Display](#fixel-display)** — geometric-humanist hybrid, display sizes only
+- **[Geist](#geist)** — Swiss-inspired precision that looks sharp and authoritative at headline sizes
+- **[Inter](#inter)** — clean and versatile with a Display optical size variant that activates automatically at larger sizes
+- **[Mona Sans (wide)](#mona-sans)** — Mona Sans with `"wdth"` axis cranked up, strictly for headlines
+- **[Satoshi](#satoshi)** — double-storey `a` and `g` give headlines personality without losing modernist discipline
+
+**Serif:**
+
+- **[Instrument Serif](#instrument-serif)** — high-contrast editorial serif, pairs with a sans-serif body for a premium feel
+
+### Monospace
+
+For code snippets, inline code, or a technical/developer aesthetic.
+
+- **[Geist Mono](#geist-mono)** — Vercel's monospace, pairs naturally with Geist
+- **[IBM Plex Mono](#ibm-plex-mono)** — IBM's monospace, versatile and highly legible
+
+---
+
+## Font Details
+
+### DM Sans
+
+A low-contrast geometric with open apertures and a large x-height. Single-storey `a` and `g`, straight-legged `R`. Excellent small-text readability — works especially well as a body font paired with other headline fonts. Also works for headlines.
+
+- **Source:** load from Google Fonts (`family=DM+Sans:opsz,wght@9..40,100..1000`)
+- **Registration:** register in `@theme` as `--font-sans: "DM Sans", sans-serif;`
+- **Pairs with:** Inter, Geist
+
+### Figtree
+
+A friendly geometric with distinctive curved `t`, `f`, and `y` letterforms that give it warmth without being playful. Monolinear stroke. Good for friendly, approachable designs. Works for both headlines and body.
+
+- **Source:** load from Google Fonts (`family=Figtree:wght@300..900`)
+- **Registration:** register in `@theme` as `--font-sans: "Figtree", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Fixel Display
+
+A geometric-humanist hybrid with open letterforms and wide proportions. Display variant optimized for larger sizes — use for headlines and display text only, never for body copy.
+
+- **Source:** must be self-hosted — download from `https://fixel.macpaw.com`
+- **Registration:** register in `@theme` as `--font-display: "Fixel Display", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Geist
+
+A Swiss-inspired sans-serif by Vercel — minimal, precise, built for UI. Works for body copy, application UI, and headings.
+
+- **Source:** load from Google Fonts (`family=Geist:wght@100..900`)
+- **Registration:** register in `@theme` as `--font-sans: "Geist", sans-serif;`
+- **Pairs with:** Inter, DM Sans
+
+### Geist Mono
+
+A monospace font by Vercel. Good for technical/developer-oriented sites or for code snippets and inline code styling.
+
+- **Source:** load from Google Fonts
+- **Registration:** register in `@theme` as `--font-mono: "Geist Mono", monospace;`
+
+### IBM Plex Mono
+
+IBM's monospace typeface. Versatile and highly legible — works for code snippets, technical content, and developer-oriented sites.
+
+- **Source:** load from Google Fonts (`family=IBM+Plex+Mono:wght@400;500;600;700`)
+- **Registration:** register in `@theme` as `--font-mono: "IBM Plex Mono", monospace;`
+
+### General Sans
+
+A compact rationalist sans-serif with small apertures and a disciplined, closed feel. Space-efficient — good for dense UI and tight layouts. Works for both headlines and body.
+
+- **Source:** load from Fontshare (`https://api.fontshare.com/v2/css?f[]=general-sans@200,300,400,500,600,700&display=swap`)
+- **Registration:** register in `@theme` as `--font-sans: "General Sans", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Host Grotesk
+
+A uniwidth sans-serif — letter widths stay consistent across all weights, so changing weight never shifts layout. Good for tabs, buttons, navigation, and anywhere weight changes must not cause reflow. Works for both headlines and body.
+
+- **Source:** load from Google Fonts (`family=Host+Grotesk:wght@300..800`)
+- **Registration:** register in `@theme` as `--font-sans: "Host Grotesk", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Instrument Sans
+
+A geometric neo-grotesque built from straight lines and simple circles. Uniform strokes, straight terminals. Has 12 stylistic sets for alternate glyphs. Best suited for clean, technical interfaces. Works for both headlines and body.
+
+- **Weight restriction:** only supports `font-normal` (400) — never use `font-medium`, `font-semibold`, or `font-bold`
+- **Source:** load from Google Fonts (`family=Instrument+Sans:wght@400..700`)
+- **Registration:** register in `@theme` as `--font-sans: "Instrument Sans", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Instrument Serif
+
+A high-contrast editorial serif for headlines and display text. Gives pages a premium, editorial feel when paired with a clean sans-serif body font — works especially well for marketing sites, landing pages, and brand-forward designs.
+
+- **Sizing:** Instrument Serif is optically small — never use `text-4xl` or smaller for headings; use `text-5xl` and up where other fonts would use `text-4xl`
+- **Source:** load from Google Fonts
+- **Registration:** register in `@theme` as `--font-display: "Instrument Serif", serif;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Inter
+
+A clean, highly legible sans-serif designed for screens. Works well for body copy, application UI, and headings.
+
+- **Source:** always load from `https://rsms.me/inter/inter.css` or self-host — never use the Google Fonts version, which lacks the Display optical size variant and `font-feature-settings` support
+- **Optical sizing:** Inter includes a Display variant that automatically activates at larger sizes via `font-optical-sizing: auto`; the Google Fonts build strips this out
+- **Feature settings:** turn on optional OpenType features to give Inter a more custom feel — `cv02` (double-story `a`→single-story), `cv03` (open `6`/`9`), `cv04` (open `4`), `cv11` (single-story `l`), `ss01` (open digits), `ss03` (round quotes)
+- **Registration:** register in `@theme` as `--font-sans: "InterVariable", sans-serif;` with `--font-sans--font-feature-settings: "cv02", "cv03", "cv04", "cv11";` to enable features globally
+- **Pairs with:** Geist, DM Sans
+
+### Lora
+
+A well-balanced contemporary serif with roots in calligraphy. Moderate contrast with subtle brush-stroke terminals — readable at body sizes while still feeling refined. Works for editorial content, blogs, and long-form reading. Also works for headlines.
+
+- **Source:** load from Google Fonts (`family=Lora:wght@400..700`)
+- **Registration:** register in `@theme` as `--font-serif: "Lora", serif;`
+- **Pairs with:** Inter, Geist, DM Sans, Satoshi
+
+### Mona Sans
+
+GitHub's neo-grotesque with an optical size axis that adjusts letterforms automatically at different sizes. Strong, industrial feel. Works for both headlines and body.
+
+- **Source:** load from Google Fonts (`family=Mona+Sans:wght@200..900`)
+- **Width axis:** has a `wdth` variable axis — use a wider value (e.g. `"wdth" 112.5`) for headlines to give them a bolder, more expanded feel; the wide variant is strictly for headlines, never for body copy
+- **Registration:** register in `@theme` as `--font-sans: "Mona Sans", sans-serif;`; when using the wide variant for headlines, also register `--font-display: "Mona Sans", sans-serif;` with `--font-display--font-variation-settings: "wdth" 112.5;`
+- **Pairs with:** Inter, Geist, DM Sans
+
+### Satoshi
+
+A modernist sans-serif blending rounded shapes with sharp angular details. Double-storey `a` and `g` give it more personality than typical geometrics — lean into that for brand-forward designs. Works for both headlines and body.
+
+- **Source:** load from Fontshare (`https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap`)
+- **Registration:** register in `@theme` as `--font-sans: "Satoshi", sans-serif;`
+- **Pairs with:** Inter, Geist, DM Sans

--- a/.claude/skills/design/guidelines/footers.md
+++ b/.claude/skills/design/guidelines/footers.md
@@ -1,0 +1,13 @@
+# Footers
+
+Covers: page footers, footer logos, footer navigation, footer links, and social media icons.
+
+## Design Rules
+
+- Logo height between `h-5` and `h-7`
+- Use `font-normal` for footer links
+- Social media icons must be at least `text-gray-600` — never use `text-gray-400` or lighter
+
+## Coding Rules
+
+- Always use the [placeholder content](./placeholder-content.md) logo endpoint when no logo file is provided — never create logos from scratch with HTML or icons

--- a/.claude/skills/design/guidelines/form-controls.md
+++ b/.claude/skills/design/guidelines/form-controls.md
@@ -1,0 +1,139 @@
+# Form Controls
+
+Covers: inputs, selects, textareas, checkboxes, radio buttons, toggles, search bars, checkout forms, auth forms, and input/button combos.
+
+## Design Rules
+
+- Never pair `shadow-*` with solid gray borders on any form control:
+
+  Don't:
+
+  ```html
+  <... class="border border-gray-300 shadow-* ..." />
+  ```
+
+  ```html
+  <... class="border border-gray-950/10 shadow-* ..." />
+  ```
+
+  Do:
+
+  ```html
+  <... class="ring-1 ring-black/10 shadow-* ..." />
+  ```
+
+- Use `max-w-xs` for compact, single-purpose forms like login, sign-up, or single-field inputs — `max-w-sm` and wider is too spacious for focused UI
+- If a text input's font size is smaller than `16px`, add `max-sm:text-base/{lh}` to bump it to `16px` on mobile
+- Never use `outline-offset-*` on custom focus rings for `<input>` and `<textarea>` elements; use `outline-offset-0` or omit the offset entirely
+- When using a 2px focus outline on `<input>` or `<textarea>`, inset it with `-outline-offset-1` so it doesn't extend outside the element
+- Never use the conjoined input + button pattern where they share a border — use a gap between them or nest the button visually inside the input
+
+## Coding Rules
+
+- Always include a `name` attribute on `<input>`, `<select>`, and `<textarea>` elements
+- Every `<input>`, `<select>`, and `<textarea>` must have either a corresponding `<label>` associated via `id`/`for`, or an `aria-label` attribute
+- Always set an explicit `type` attribute on `<button>` elements — `type="submit"` inside forms, `type="button"` otherwise
+- Use `placeholder` with `aria-label` instead of visible `<label>` elements for ecommerce/checkout forms where the field purpose is obvious from context — still use section headings (e.g. "Shipping address", "Payment") to group related fields
+
+## Selects
+
+- Use a custom chevron for consistent cross-browser styling — wrap only the `<select>` and chevron in `inline-grid grid-cols-[1fr_--spacing(8)]` (never the label); add `col-span-full row-start-1 appearance-none pr-8` to the `<select>`; place an SVG chevron with `pointer-events-none col-start-2 row-start-1 place-self-center`
+
+```html
+<svg
+  viewBox="0 0 8 5"
+  width="8"
+  height="5"
+  fill="none"
+  class="pointer-events-none col-start-2 row-start-1 place-self-center"
+>
+  <path d="M.5.5 4 4 7.5.5" stroke="currentcolor" />
+</svg>
+```
+
+## Checkboxes
+
+- Use a native `<input type="checkbox">`
+- The styles are all applied in CSS based on the input state
+- **Never use JavaScript to toggle classes based on input state** — use CSS states and variants exclusively
+- Replace `{brand}` with the appropriate brand color
+- Every class is required, do not omit any
+- When a label is present, associate it with the input using `id` and `for`; otherwise give it an `aria-label`
+- To vertically center a checkbox with adjacent text, wrap it in an element with `h-lh items-center` and the matching `text-{size}` — never put `h-lh` on the `inline-grid` wrapper itself; never use top margins or manual alignment
+- Checkboxes should be larger on mobile — e.g. `size-5 sm:size-4`
+
+```html
+<span class="group inline-grid size-4 grid-cols-1">
+  <input
+    type="checkbox"
+    class="checked:border-{brand} checked:bg-{brand} indeterminate:border-{brand} indeterminate:bg-{brand} focus-visible:outline-{brand} dark:checked:border-{brand} dark:checked:bg-{brand} dark:indeterminate:border-{brand} dark:indeterminate:bg-{brand} dark:focus-visible:outline-{brand} col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white focus-visible:outline-2 focus-visible:outline-offset-2 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
+  />
+  <svg
+    viewBox="0 0 14 14"
+    fill="none"
+    class="pointer-events-none col-start-1 row-start-1 size-7/8 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25 dark:group-has-disabled:stroke-white/25"
+  >
+    <path
+      d="M3 8L6 11L11 3.5"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="group-not-has-checked:opacity-0"
+    />
+    <path
+      d="M3 7H11"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="group-not-has-indeterminate:opacity-0"
+    />
+  </svg>
+</span>
+```
+
+## Radio Buttons
+
+- Use a native `<input type="radio">`
+- The styles are all applied in CSS based on the input state
+- **Never use JavaScript to toggle classes based on input state** — use CSS states and variants exclusively
+- Replace `{brand}` with the appropriate brand color
+- Every class is required, do not omit any
+- When a label is present, associate it with the input using `id` and `for`; otherwise give it an `aria-label`
+- To vertically center a radio button with adjacent text, wrap it in an element with `h-lh items-center` and the matching `text-{size}` — never put `h-lh` on the `inline-grid` wrapper itself; never use top margins or manual alignment
+- Radio buttons should be larger on mobile — e.g. `size-5 sm:size-4`
+
+```html
+<span class="group inline-grid size-4 grid-cols-1">
+  <input
+    type="radio"
+    class="checked:border-{brand} checked:bg-{brand} focus-visible:outline-{brand} dark:checked:border-{brand} dark:checked:bg-{brand} dark:focus-visible:outline-{brand} col-start-1 row-start-1 appearance-none rounded-full border border-gray-300 bg-white focus-visible:outline-2 focus-visible:outline-offset-2 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
+  />
+  <span
+    class="pointer-events-none col-start-1 row-start-1 size-[round(down,40%,1px)] self-center justify-self-center rounded-full bg-white group-not-has-checked:opacity-0 group-has-disabled:bg-gray-400 dark:group-has-disabled:bg-white/25"
+  ></span>
+</span>
+```
+
+## Toggles
+
+- Use a native `<input type="checkbox">`
+- The styles are all applied in CSS based on the input state
+- **Never use JavaScript to toggle classes based on input state** — use CSS states and variants exclusively
+- Replace `{brand}` with the appropriate brand color
+- Replace `{gray}` with the appropriate gray color
+- Every class is required, do not omit any
+- Use `w-9` as the default size; only adjust the width to make it larger or smaller
+- Toggles should be larger on mobile — e.g. `w-11 sm:w-9`
+- When a label is present, associate it with the input using `id` and `for`; otherwise give it an `aria-label`
+- Remove all `dark:` classes if the site doesn't support dark mode; for always-dark sites, use only the `dark:` variant values as the base classes and remove the `dark:` prefixed versions
+
+```html
+<div
+  class="group outline-{brand}-600 has-checked:bg-{brand}-600 dark:outline-{brand}-500 dark:has-checked:bg-{brand}-500 bg-{gray}-200 inset-ring-{gray}-900/5 relative inline-flex w-9 shrink-0 rounded-full p-0.5 inset-ring outline-offset-2 transition-colors duration-200 ease-in-out has-focus-visible:outline-2 dark:bg-white/5 dark:inset-ring-white/10"
+>
+  <span
+    class="ring-{gray}-900/5 aspect-square w-1/2 rounded-full bg-white ring-1 shadow-xs transition-transform duration-200 ease-in-out group-has-checked:translate-x-full"
+  ></span>
+  <input type="checkbox" class="absolute inset-0 size-full appearance-none focus:outline-hidden" />
+</div>
+```

--- a/.claude/skills/design/guidelines/general.md
+++ b/.claude/skills/design/guidelines/general.md
@@ -1,0 +1,47 @@
+# General
+
+Covers: general markup rules and Tailwind CSS authoring rules that are not specific to one component.
+
+## Coding Rules
+
+### Markup
+
+- Never apply `text-*` (font size) or `leading-*` (line height) classes to inline elements like `<span>`, `<a>`, `<strong>`, `<em>`, or `<code>` — always apply them to containing block-level elements like `<div>`, `<p>`, `<h1>`–`<h6>`, `<li>`, or `<td>`
+- Never add redundant display classes that match an element's default display — e.g. no `block` on `<div>`, `<p>`, `<h1>`–`<h6>`; no `inline` on `<span>`, `<a>`; no `inline-block` on `<input>`, `<button>`, `<select>`; no `table` on `<table>`. This only applies to classes that don't change child layout — `flex`, `grid`, `inline-flex`, `inline-grid` are never redundant
+- Never apply conflicting classes for the same property on the same element without a distinguishing variant — e.g. no `outline-1 outline-2`, no `outline-black/5 outline-white`; keep only the intended value
+- Always add `role="list"` to `<ul>` and `<ol>` elements unless a `list-style-*` class (e.g. `list-disc`, `list-decimal`) is applied
+
+### Tailwind CSS
+
+- Always apply `antialiased` to the root element
+- Always apply `isolate` to the main app container (the element that gets `inert` when dialogs open) — prevents z-index conflicts with portalled elements
+- Place `@import` statements with remote URLs (`http`/`https`) or `url()` at the very top of the CSS file, before `@import "tailwindcss"` — but after `@charset` if present
+- Add `tabular-nums` to elements that display numbers, especially values that change over time (e.g. counters, timers, prices, stats) — prevents layout shift as digits update
+- Never use `mt-*`/`mb-*`/`ml-*`/`mr-*`/`mx-*`/`my-*` between flex/grid children — use `gap-*` on the parent instead
+- Prefer `size-{n}` over `h-{n} w-{n}` when both values are the same
+- Prefer shorthand classes over split axis classes — `p-8` not `px-8 py-8`, `inset-0` not `inset-x-0 inset-y-0`; keep them split when a variant overrides one axis, e.g. `p-8 md:px-10`
+- Use `--spacing(…)` for arbitrary spacing values — `--padding: --spacing(2)` not `--padding: 8px`
+- Never use `calc(var(--spacing)*…)` — use `--spacing(…)` instead
+- Never use `theme(spacing.…)` — use `--spacing(…)` instead
+- Never use `theme()` for colors or other tokens in arbitrary values — use CSS variables instead; `[stop-color:var(--color-emerald-500)]` not `[stop-color:theme(colors.emerald.500)]`
+- Use `rem` for arbitrary font sizes — `text-[0.8125rem]` not `text-[13px]`
+- Pixels are fine for properties that use pixels natively in Tailwind — e.g. `border-*`, `outline-*`
+- Use theme variable references for arbitrary radii — `--radius: var(--radius-xl)` not `--radius: 16px`
+- Never use named line-height values like `tight`, `snug`, `relaxed` — not in `leading-tight`, not in `text-6xl/tight`; only use spacing scale values (e.g. `leading-6`, `text-sm/5`), and only when a custom line height is specifically required
+- Never use inline `style` attributes for static CSS properties that lack a utility class — use arbitrary property syntax instead; `class="[animation-delay:300ms]"` not `style="animation-delay: 300ms"`
+- Set CSS variables using arbitrary property syntax, not inline styles — `class="[--padding:--spacing(3)]"` not `style="--padding: --spacing(3)"` (unless the value is dynamic)
+- For dynamic values, prefer CSS variables over setting CSS properties directly in `style` attributes — `class="w-(--progress)" style="--progress: 72%"` not `style="width: 72%"`; name the variable descriptively relative to the context
+- Prefer bare values over arbitrary values for integers and multiples of `0.25` — `z-999` not `z-[999]`
+- Prefer bare opacity modifiers on color utilities — `bg-neutral-950/2` not `bg-neutral-950/[0.02]`; use `[…]` only for non-`0.25`-increment values
+- Negate `hidden` with a single conditional variant instead of setting `hidden` and conditionally re-applying the display class — `flex items-center gap-x-6 max-lg:hidden` not `hidden lg:flex lg:items-center lg:gap-x-6`; `not-dark:hidden` not `hidden dark:block`
+- Prefer `not-*` variants over setting a base value and conditionally overriding it — `group-not-has-checked:opacity-0` not `group-has-checked:opacity-100 opacity-0`; place `not-` directly before the state being negated — not `not-group-has-checked:…` (would trigger without a `group` parent) or `group-has-not-checked:…` (would match any unchecked element)
+- Use bare values in variants over arbitrary values in variants — `data-closed:…` not `data-[closed]:…`, `group-data-open:…` not `group-data-[open]:…`
+- Always use classes like `min-h-dvh/svh/lvh`, never `min-h-screen` (`screen` is deprecated)
+- Always use `bg-linear-*` for gradients, never `bg-gradient-*` (deprecated)
+- Use `shrink-*` not `flex-shrink-*`, `grow-*` not `flex-grow-*` (deprecated)
+- Prefer whole-number ratios in arbitrary grid/flex values — `grid-cols-[21fr_19fr]` not `grid-cols-[1.05fr_0.95fr]`; multiply all values by the same factor to eliminate decimals
+- Prefer `@utility my-utility { … }` over plain class selectors (`.my-utility { … }`) for reusable styles — utilities work with all Tailwind variants (`hover:my-utility`, `lg:my-utility`)
+- Use `@utility my-utility-* { … }` with `--value()` and `--modifier()` for parameterized utilities that accept arguments
+- Use `@variant the-variant { … }` inside `@utility` definitions to apply an existing variant — don't manually write the media query or selector
+- Use `@custom-variant` to define new custom variants when the built-in set doesn't cover the case
+- Never nest `@utility` inside another at-rule like `@media` or `@supports` — move the at-rule inside the `@utility` block instead

--- a/.claude/skills/design/guidelines/headers.md
+++ b/.claude/skills/design/guidelines/headers.md
@@ -1,0 +1,8 @@
+# Headers
+
+Covers: site headers, navigation bars, top bars, logos, mobile menus, hamburger menus, and header CTAs.
+
+## Design Rules
+
+- Always wrap the main logo in an `<a href="/">` with `aria-label="Homepage"`
+- Navbar button actions must always feel secondary to the hero's primary CTA — use ghost, outline, subtle, or a smaller solid button; matching the hero's color is fine if the navbar button is noticeably smaller

--- a/.claude/skills/design/guidelines/heading-groups.md
+++ b/.claude/skills/design/guidelines/heading-groups.md
@@ -1,0 +1,19 @@
+# Heading Groups
+
+Covers: headline, subheadline, and optional eyebrow groups at the top of marketing or landing page sections.
+
+A heading group is a headline and subheadline (and optional eyebrow) at the top of a marketing or landing page section — e.g. the title and description above a feature grid, team grid, pricing table, testimonial section, CTA, or hero. These rules apply to promotional/marketing page sections only, not to blog posts, articles, documentation, or editorial content.
+
+- Never constrain the width of a heading group wrapper — no `max-w-*`, no `max-lg:max-w-*`, no width constraints of any kind on the wrapper `<div>`. Always constrain each text element (headline, subheadline) individually with `max-w-[*ch]` directly on the element — `text-base` → `max-w-[56ch]`, `text-lg` → `max-w-[48ch]`, `text-xl` → `max-w-[40ch]`, `text-2xl`–`text-3xl` → `max-w-[40ch]`, `text-4xl` → `max-w-[35ch]`, `text-5xl` → `max-w-[30ch]`, `text-6xl` → `max-w-[24ch]`, `text-7xl` → `max-w-[20ch]`.
+
+  Example:
+
+  ```html
+  <div class="/* never add a max width here */">
+    <h2 class="mx-auto max-w-[35ch] text-4xl font-semibold tracking-tight text-balance">…</h2>
+    <p class="mx-auto mt-6 max-w-[48ch] text-lg text-pretty text-gray-600">…</p>
+  </div>
+  ```
+
+- Always use a left-aligned layout for heading groups when the subheadline exceeds ~120 characters (~3 lines when centered)
+  - **⚠️ ask-user** if a centered layout is requested but the subheadline exceeds ~120 characters — offer a rewritten version that fits; only center if the user accepts the shorter copy

--- a/.claude/skills/design/guidelines/icons.md
+++ b/.claude/skills/design/guidelines/icons.md
@@ -1,0 +1,18 @@
+# Icons
+
+Covers: SVG icons, Heroicons, inline checkmarks, icon buttons, icon sizing, and icon alignment with text.
+
+## Design Rules
+
+- Never generate raw SVG icons — import from the project's existing icon library, or use Heroicons if no library is established
+- Never wrap icons in decorative containers (colored squares, circles with backgrounds) — use the icon directly
+- Never scale icons — `viewBox="0 0 24 24"` always uses `size-6`, `viewBox="0 0 20 20"` uses `size-5`, `viewBox="0 0 16 16"` uses `size-4`; if the icon looks too small, use a different icon set, don't increase the size class
+- Always use 16px/micro icons (`size-4`) when inline with `text-sm` text — checklists, feature items, comparison tables, inline labels; only use 20px/mini icons (`size-5`) for navigation list icons
+- Icons next to a text group (label + supporting text) — align the icon with the first line/label using `items-start` or `items-baseline`, never `items-center` on the group
+- Application UIs (dashboards, settings, admin, sidebar nav, forms) — only use Heroicons Micro (16px, `size-4`); never use 20px/mini or 24px/outline icons in application UIs
+
+## Coding Rules
+
+- Use `size-{n} h-lh` on SVG icons to vertically center them with adjacent text; set the `font-size` on a wrapper element instead of using top margins or manual alignment
+- Use `fill-{color}` for filled icons and `stroke-{color}` for stroked icons — never use `text-{color}` with `currentColor` (legacy v2 hack)
+- Always add `shrink-0` to icons inside flex containers

--- a/.claude/skills/design/guidelines/images.md
+++ b/.claude/skills/design/guidelines/images.md
@@ -1,0 +1,12 @@
+# Images
+
+Covers: photos, thumbnails, screenshots, app mockups, product images, media frames, and image borders/outlines.
+
+## Design Rules
+
+- Never use borders on photos or thumbnails — use `outline-1 -outline-offset-1 outline-black/5` or `outline-black/10` if the image needs a visible edge
+- Use `outline-1 -outline-offset-1 outline-black/5` or `outline-black/10` on light surfaces; use `outline-white/10` on dark surfaces for screenshots and app UI mockups
+
+## Coding Rules
+
+- Use `alt=""` on images when the subject is identified by adjacent visible text

--- a/.claude/skills/design/guidelines/interactivity.md
+++ b/.claude/skills/design/guidelines/interactivity.md
@@ -1,0 +1,6 @@
+# Interactivity
+
+Covers: hover states, transitions, animations, active states, and behavior on clickable and non-clickable elements.
+
+- Never add `hover:*` states to non-interactive elements — reserve for buttons, links, and other clickable elements
+- Never add `transition-*` for hover color/background changes — reserve transitions for elements that move or transform

--- a/.claude/skills/design/guidelines/landing-pages.md
+++ b/.claude/skills/design/guidelines/landing-pages.md
@@ -1,0 +1,11 @@
+# Landing Pages
+
+Covers: landing pages, marketing pages, stacked page sections, heroes, CTAs, pricing sections, feature sections, and full-page consistency.
+
+- Reuse the same primary/secondary button styling across the entire page — if the hero uses a link-style secondary, every other section with a secondary action (CTA, pricing, etc.) must also use a link-style secondary
+- Reuse the same font treatment (size, weight, color) when the same or similar idea appears multiple times on a page — match the existing instance exactly
+- Use the same container style across the entire page — once a container style is established (outline, tinted, etc.), all subsequent containers should match
+- Use the same border radius for all containers at the same level — panels, cards, and other sibling containers on a page should share a consistent radius
+- Use the same column `gap-*` value across all multi-column page sections — card grids, split layouts, and any other two-column or multi-column section must share the same gap; check existing sections before adding a new one and match the value already in use
+- Never place a centered/center-constrained layout directly below a left-aligned layout — use left-aligned instead, unless: the section above ends with full-width containers that create a natural divide, a background color change separates them, or a visible divider sits between
+- Never have more centered heading groups than left-aligned ones on a landing page — centered headings work best for hero sections, CTAs, and sections with symmetrical content beneath (e.g. centered pricing cards, logo clouds); default to left-aligned for feature grids, split layouts, and content-heavy sections

--- a/.claude/skills/design/guidelines/login-pages.md
+++ b/.claude/skills/design/guidelines/login-pages.md
@@ -1,0 +1,5 @@
+# Login Pages
+
+Covers: login, sign-in, sign-up, authentication, password reset, and account access pages.
+
+- Never use light gray or other light-tinted backgrounds (e.g. `bg-gray-50`, `bg-gray-100`, `bg-slate-50`) on login/sign-in pages — use solid white (`bg-white`) or dark (`bg-gray-900`, `bg-gray-950`, `bg-black`), unless the form content is wrapped in a distinct panel or card

--- a/.claude/skills/design/guidelines/logo-clouds.md
+++ b/.claude/skills/design/guidelines/logo-clouds.md
@@ -1,0 +1,6 @@
+# Logo Clouds
+
+Covers: logo grids, customer logos, partner logos, trust bars, client rows, and collections of brand marks.
+
+- Always distribute logos evenly across rows when wrapping — never allow an unbalanced last row (e.g. 5 on one row and 1 on the next); use a grid or layout that splits logos as evenly as possible across all rows (e.g. 3+3 instead of 5+1 for 6 logos)
+- Logo clouds directly beneath a hero are an extension of the hero — match the hero's alignment; left-aligned hero → left-aligned logo cloud label and logos

--- a/.claude/skills/design/guidelines/navigation.md
+++ b/.claude/skills/design/guidelines/navigation.md
@@ -1,0 +1,10 @@
+# Navigation
+
+Covers: sidebar nav, header nav, mobile menus, tabs, tab bars, vertical menus, active states, and current-page indicators.
+
+- Every app must have a mobile navigation menu on small screens, regardless of whether the desktop nav is in a header or sidebar — use a dialog or disclosure panel with a hamburger toggle; hide the desktop nav with `hidden lg:flex` (header) or `hidden lg:block` (sidebar) and show the mobile menu below `lg:`
+- Never use a high-contrast or primary-color background for active nav items — use darker text color, a soft/muted background, or both
+- Never change `font-weight` between nav item states (default, hover, active) — use color and background changes only
+- Horizontal menus (tabs, tab bars, pill navs) must never overflow the parent container — use horizontal scrolling when items don't fit
+- Never use icons in top header horizontal navigation links — use text-only links
+- When centering nav links on the page (not just between side items), use a three-section flex layout: `<div class="flex flex-1 items-center">` for the left section (logo), the nav links in their natural width (no `flex-1`), and `<div class="flex flex-1 items-center justify-end">` for the right section (actions). The matching `flex-1` gutters force the centered group to the true page center. Apply the same pattern when centering a logo: keep the logo in its natural width and use `flex-1` on the side sections to center it on the page rather than between the surrounding items.

--- a/.claude/skills/design/guidelines/pagination.md
+++ b/.claude/skills/design/guidelines/pagination.md
@@ -1,0 +1,5 @@
+# Pagination
+
+Covers: pagination, page number links, previous/next buttons, and paged navigation controls.
+
+- Hide page numbers on mobile when pagination includes both page numbers and previous/next buttons

--- a/.claude/skills/design/guidelines/placeholder-content.md
+++ b/.claude/skills/design/guidelines/placeholder-content.md
@@ -1,0 +1,23 @@
+# Placeholder Content
+
+Covers: placeholder logos, avatars, screenshots, app images, wallpapers, people, and fallback assets when real content is not provided.
+
+See [Assets API](./assets-api.md) for all available endpoints, parameters, and asset IDs.
+
+- When no logo file is provided, use the marks endpoint with the app name provided by the user; pick a font that matches the design
+  - Use `color` for the mark and `textColor` for the text; make mark white, black, dark gray, or an accent color; keep text white, black, or dark gray
+  - Prefer extension-suffixed asset URLs when supported
+  - Omit `text` (and `textColor`/`font`) to get just the mark icon — e.g. `/marks/1.svg?color=blue-500`
+  - Never create logos from scratch with HTML or icons — always use the marks or logos endpoint
+  - Use the same endpoint for all other logos — company logos in testimonials, client logo grids, etc.
+- Always use `https://assets.ui.sh/screenshots/1.webp` for app screenshots, dashboard images, or any UI that should look like a real product — never use Unsplash or stock photos for these; content doesn't need to match, just needs to look like a realistic app UI at a glance
+  - For full-width or near-full-width hero images, use the full uncropped screenshot — never use crop parameters at large sizes
+  - For feature section screenshots, use only these exact cropped variants — never invent new crop parameters:
+    - `?top=900&left=1200&position=bottom-right` — Sidebar + inbox list (1200×900)
+    - `?top=900&right=1200&position=bottom-left` — AI agent panel with customer insights (1200×900)
+    - `?top=600&right=800&position=bottom-left` — AI agent header, tight focus (800×600)
+    - `?top=1200&left=1600&position=bottom-right` — Full interface overview (1600×1200)
+    - `?top=1500&left=2000&position=bottom-right` — Wide overview with sidebar, inbox, and conversation (2000×1500)
+    - `?top=1400&right=1867&position=bottom-left` — Email conversation + AI assistant (1867×1400)
+- Use the avatars endpoint for placeholder avatars, preferring extension-suffixed URLs such as `/avatars/1.webp`
+- Use unisex names for placeholder people — avatars are random so names must work for any photo

--- a/.claude/skills/design/guidelines/pricing-cards.md
+++ b/.claude/skills/design/guidelines/pricing-cards.md
@@ -1,0 +1,42 @@
+# Pricing Cards
+
+Covers: pricing tiers, pricing cards, pricing tables, plan comparisons, emphasized plans, and popular/recommended plans.
+
+## Design Rules
+
+- Emphasize cards through button styling and optional "Popular" or "Recommended" text — never use a different background color for the entire card
+- For feature list checkmarks, follow [Icons](./icons.md) rules — use `size-4 h-lh` to vertically center with text
+
+## Coding Rules
+
+- Never isolate the emphasized card from the rest — it's a grid sibling, not a standalone section
+- Always align buttons across pricing cards — `flex flex-col justify-between` on each card; wrap all content above the button in a single `<div>` so the button pushes to the bottom
+
+```html
+<div class="flex flex-col justify-between …">
+  <div>
+    <!-- name, price, description, features -->
+  </div>
+  <div>
+    <button>Get started</button>
+  </div>
+</div>
+```
+
+- If the emphasized card is taller than the siblings, use CSS grid with explicit rows — never use negative margins or relative positioning; the gap rows define how much the card pokes out, unemphasized cards sit in the middle row, the emphasized card spans all rows
+
+```html
+<!-- Pokes out top and bottom -->
+<div class="{breakpoint}:grid-cols-3 {breakpoint}:grid-rows-[--spacing(6)_1fr_--spacing(6)] grid">
+  <div class="{breakpoint}:row-start-2"><!-- normal card --></div>
+  <div class="{breakpoint}:row-span-full"><!-- emphasized card --></div>
+  <div class="{breakpoint}:row-start-2"><!-- normal card --></div>
+</div>
+
+<!-- Pokes out top only -->
+<div class="{breakpoint}:grid-cols-3 {breakpoint}:grid-rows-[--spacing(6)_1fr] grid">
+  <div class="{breakpoint}:row-start-2"><!-- normal card --></div>
+  <div class="{breakpoint}:row-span-full"><!-- emphasized card --></div>
+  <div class="{breakpoint}:row-start-2"><!-- normal card --></div>
+</div>
+```

--- a/.claude/skills/design/guidelines/prose-content.md
+++ b/.claude/skills/design/guidelines/prose-content.md
@@ -1,0 +1,11 @@
+# Prose Content
+
+Covers: raw HTML from markdown, CMS content, database content, blog posts, articles, documentation, and rendered markup where classes cannot be applied to individual elements.
+
+- Never use the `@tailwindcss/typography` plugin — instead, create a `.prose` class that styles raw HTML elements (headings, links, lists, code blocks, images, etc.) using plain CSS with Tailwind's CSS theme variables (`var(--color-*)`, `var(--text-*)`, `var(--font-weight-*)`, `var(--radius-*)`, `--spacing(*)`, `--alpha()`); use `@variant dark { … }` and `@variant hover { … }` for dark mode and hover states; use `* + *` for vertical spacing between elements; style every element that could appear in the rendered markup — `h1`–`h6`, `p`, `a`, `ul`, `ol`, `li`, `pre`, `code`, `img`, `strong`, `blockquote`
+- Apply the `.prose` wrapper class to the container element that holds the rendered HTML — `<div class="prose">` around blog post content, markdown output, CMS-generated markup, or any HTML where you can't add Tailwind classes to individual elements
+- Default to `var(--text-base)` (`16px`) for prose body text; only use `var(--text-lg)` (`18px`) or larger if specifically requested or the project already uses that size for body text elsewhere
+- Never set `max-width` inside the `.prose` CSS — constrain width with a `max-w-[*ch]` class alongside `prose` in the markup (e.g. `<div class="prose max-w-[65ch]">`); use `60ch`–`90ch`, matched to the site's existing content widths
+- Set prose body `line-height` to at least `1.75` times the font size — e.g. `--spacing(7)` for `var(--text-base)`
+- Use `text-pretty` on blog post and article titles, not `text-balance`
+- When the article title/`h1` uses a sans-serif font, use the same sans-serif for all subheadings (`h2`–`h6`) within the article — never mix a sans-serif title with serif subheadings

--- a/.claude/skills/design/guidelines/responsive-design.md
+++ b/.claude/skills/design/guidelines/responsive-design.md
@@ -1,0 +1,15 @@
+# Responsive Design
+
+Covers: mobile, tablet, desktop, breakpoints, container queries, overflow, wrapping, clipping, and cramped narrow viewports.
+
+## Design Rules
+
+- Every layout must adapt from mobile to desktop — use responsive breakpoint classes (`sm:`, `md:`, `lg:`, etc.) to adjust grid columns, spacing, font sizes, and visibility at different screen sizes
+- Multi-column desktop layouts (sidebars, secondary navigation, filter panels) must collapse to a single-column layout on small screens — use a mobile menu, disclosure, or other compact pattern instead of shrinking columns
+- Body text, subheadings, form controls, and icons should be **larger on mobile** and scale down at `sm:` — write the mobile (larger) size as the default and the desktop (smaller) size with `sm:` (e.g. `text-2xl/8 sm:text-xl/8`, `text-base/7 sm:text-sm/6`, `text-lg/6 sm:text-sm/6`, `size-5 sm:size-4`, `py-2.5 sm:py-1.5`); this applies to body text, subheadings, stat values, form input labels, badges, buttons, select/input padding, and icons — **not** h1s (page titles stay the same size or get smaller on mobile, not bigger)
+- Body text must be at least `text-base` (16px) on mobile — `text-sm` is only acceptable at `sm:` or larger breakpoints (e.g. `text-base/7 sm:text-sm/6`, never `text-sm/6` without a breakpoint prefix for body copy)
+
+## Coding Rules
+
+- Use container queries (`@container`) for component-level responsiveness — anything whose layout depends on available space rather than the viewport (e.g. dashboard widgets, feature cards, pricing tiers, testimonial grids)
+- When using container queries, place the `@container` element as close to the responsive content as possible — ideally a direct wrapper around the items, never on a page-level container

--- a/.claude/skills/design/guidelines/section-layout.md
+++ b/.claude/skills/design/guidelines/section-layout.md
@@ -1,0 +1,23 @@
+# Section Layout
+
+Covers: page sections, constrained containers, centered vs left-aligned layouts, section padding, grids, and stacked content alignment.
+
+## Design Rules
+
+- Left-aligned sections align to page container edge — never narrow `max-w-*` + `mx-auto`; use page-level `max-w-*`, constrain inner content separately
+- Align containers and boundings that occupy the same proportion across stacked sections — e.g. a 1/2-width card grid and a 1/2-width split with bounding below it should share the same column edges; use consistent grid definitions and gap values so edges line up when scrolling
+- Avoid nested max-width constraints on grids/lists that fill their container — if a feature grid or icon list spans the full constrained width, don't add a narrower `max-w-*` on it; the content should align with the page container edges, not float in the middle. Nested `max-w-*` is fine for self-contained units that are meant to feel bounded (pricing cards, forms, comparison tables, centered media).
+
+## Coding Rules
+
+- Use a two-element pattern for constrained page sections — outer element handles background and vertical padding, inner element handles max-width, centering, and horizontal padding:
+
+  ```html
+  <... class="{vertical-padding}">
+    <... class="{max-width} mx-auto {horizontal-padding}">
+      ...
+    </...>
+  </...>
+  ```
+
+  Apply this consistently across all sections on a landing page so content edges align when scrolling.

--- a/.claude/skills/design/guidelines/shadows.md
+++ b/.claude/skills/design/guidelines/shadows.md
@@ -1,0 +1,6 @@
+# Shadows
+
+Covers: shadows on cards, modals, popovers, dropdowns, buttons, elevated surfaces, and shadow/border pairings.
+
+- Never pair shadows with solid gray borders — use `ring-1 ring-black/5` or `ring-1 ring-black/10` (or `950` of your neutral)
+- Never make elevated elements (cards, modals, popovers with `shadow-*`) darker than their canvas — use `white` or the lightest neutral, not `gray-100`/`gray-50`; darker fills are fine for inset panels/wells without outer shadows

--- a/.claude/skills/design/guidelines/surfaces.md
+++ b/.claude/skills/design/guidelines/surfaces.md
@@ -1,0 +1,13 @@
+# Surfaces
+
+Covers: cards, wells, borders, dividers, white space, recessed backgrounds, and other content grouping treatments.
+
+- Don't default to white cards on gray backgrounds — prefer content directly on a white background, or white cards with just a `border` on a white background
+- Choose surface treatments based on information hierarchy: white space alone for tightly related items; subtle borders/dividers for sibling content that needs separation; wells (recessed backgrounds like `bg-gray-50`) for secondary or nested content; cards with borders or shadows for standalone, interactive, or highly distinct items
+- Use the lightest separation that still works — whitespace first, then subtle borders/dividers, then cards; never jump straight to cards
+- Reserve cards for content that is independently interactive (clickable to navigate) or contains fundamentally different content types
+- Use subtle top borders or vertical dividers for sibling items in a shared context — stat grids, metric rows, dashboard KPIs
+- Divider-separated items — middle items get equal padding on both sides of the divider (`px-*`); first item in a row gets only `pr-*` (no `pl-*`), last item gets only `pl-*` (no `pr-*`); for horizontal dividers: first item only `pb-*` (no `pt-*`), last item only `pt-*` (no `pb-*`); when grid columns change at a breakpoint, reset padding per the new first/last — e.g. a 4-column grid becoming 2-column: items 1 and 3 are now row-starts (no `pl-*`), items 2 and 4 are now row-ends (no `pr-*`); use responsive prefixes like `sm:pl-0` or `lg:pr-0` to override at each breakpoint
+- Dividers must be reconfigured at each breakpoint when grid columns change — use `nth-child` to target items not in the first column: 2 columns use `[&:nth-child(2n)]:border-l-*`; 4 columns use `[&:not(:nth-child(4n+1))]:border-l-*`; adjust the pattern at each breakpoint to match the column count; when collapsing to a single column, remove vertical dividers and add horizontal dividers between rows (`border-t-*` on all items except the first)
+- Whitespace alone is enough when content has inherent contrast (large numbers vs small labels, bold headings vs body text)
+- Never use solid colors for dividers — use opacity-based colors like `divide-gray-950/5` or `border-gray-950/10` instead of `divide-gray-200` or `border-gray-300`

--- a/.claude/skills/design/guidelines/svg.md
+++ b/.claude/skills/design/guidelines/svg.md
@@ -1,0 +1,7 @@
+# SVG
+
+Covers: inline SVG, SVG color styling, `fill`, `stroke`, `currentColor`, and SVG markup conventions.
+
+- Omit `xmlns` on inline `<svg>` elements in HTML/JSX — only needed when the SVG is a standalone `.svg` file
+- Style SVG colors with Tailwind classes (`fill-*`, `stroke-*`, `text-*` with `fill="currentColor"`/`stroke="currentColor"`) instead of hardcoded color attributes or inline ternaries — use `data-*`/`aria-*` variants or conditional classes to switch colors
+- Never combine `fill="currentColor"`/`stroke="currentColor"` attributes with `fill-*`/`stroke-*` classes on the same element — the attribute conflicts with the class; use `fill-current`/`stroke-current` to inherit the text color, or drop the attribute entirely when using a specific color class like `fill-zinc-400`

--- a/.claude/skills/design/guidelines/tables.md
+++ b/.claude/skills/design/guidelines/tables.md
@@ -1,0 +1,27 @@
+# Tables
+
+Covers: data tables, comparison tables, table headings, row dividers, horizontal scrolling tables, and table containers.
+
+## Design Rules
+
+- Never use uppercase text in table headings — use normal sentence case instead
+- Never let table headings wrap — use `whitespace-nowrap` on `<th>` elements
+- Never put tables in containers or cards — place them directly on the background
+- Only use horizontal lines to divide rows — no vertical lines, no outer borders
+- Always use `w-full` so tables fill their container
+- Hide table headings with `sr-only` when the column content is self-explanatory — typically tables with 2–3 columns where headings add no value
+- Always make tables responsive if all columns won't fit on smaller screens — use a two-div wrapper around the table:
+  - Outer div: `overflow-x-auto whitespace-nowrap` with negative horizontal and vertical margins — horizontal margins cancel the page container's padding (e.g. `-mx-4 sm:-mx-6 lg:-mx-8`), vertical margin is always `-my-2`
+  - Inner div: `inline-block min-w-full align-middle` with horizontal padding that matches the container's padding (e.g. `px-4 sm:px-6 lg:px-8`) and `py-2`
+  - Always match the negative horizontal margins and horizontal padding to the actual container padding used in the page layout
+  - Example implementation:
+  ```html
+  <!-- Example assumes container padding of px-4 sm:px-6 lg:px-8 -->
+  <div class="-mx-4 -my-2 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
+    <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
+      <table>
+        …
+      </table>
+    </div>
+  </div>
+  ```

--- a/.claude/skills/design/guidelines/team-sections.md
+++ b/.claude/skills/design/guidelines/team-sections.md
@@ -1,0 +1,13 @@
+# Team Sections
+
+Covers: team grids, team member cards, staff listings, about-us sections, people galleries, photos, names, roles, and bios.
+
+## Design Rules
+
+- Never use landscape aspect ratios for team member images
+- Use a muted color for role/job title text
+
+## Coding Rules
+
+- Render lists of people in a `<ul>` with `<li>` elements
+- Use `alt=""` on team member photos when the person's name is visible nearby

--- a/.claude/skills/design/guidelines/testimonials.md
+++ b/.claude/skills/design/guidelines/testimonials.md
@@ -1,0 +1,11 @@
+# Testimonials
+
+Covers: customer quotes, reviews, social proof sections, testimonial cards, quote punctuation, avatars, and attribution.
+
+## Design Rules
+
+- Use hanging punctuation for quotes — `relative before:absolute before:inline before:-translate-x-full before:content-['\201C'] after:inline after:content-['\201D']`
+- Always bottom-align avatars/names across equal-height testimonial cards — `flex flex-col justify-between` on each card; group quote content and attribution in their own wrapper elements
+- Never add whitespace around quote content in `<p>` tags — write `<p>The quote text</p>` not `<p> The quote text </p>` (breaks hanging punctuation)
+- Follow [avatar rules](./avatars.md) and [placeholder content rules](./placeholder-content.md) for testimonial photos
+- Use unisex names — avatars are random so names must work for any photo

--- a/.claude/skills/design/guidelines/typography.md
+++ b/.claude/skills/design/guidelines/typography.md
@@ -1,0 +1,18 @@
+# Typography
+
+Covers: text sizes, line heights, heading styles, font weights, tracking, text width, `text-pretty`, `text-balance`, and eyebrow text.
+
+## Design Rules
+
+- Never use `text-xs` for body text, paragraph text, or general page content — the smallest acceptable body text size is `text-sm` and only at `sm:` or larger breakpoints; the mobile default must be at least `text-base` (16px)
+- Never use `font-bold` for headings — use `font-semibold` or `font-medium` instead
+- Never add `leading-*` or line-height modifiers to headings — use Tailwind's default line-height (e.g. `text-6xl`, not `text-6xl/tight`)
+- Use `text-balance` on headings; use `text-pretty` on paragraph text
+- Add `tracking-tight` to headings larger than `text-xl` — unless the font is a condensed headline font (tracking is already tight)
+- Never use `uppercase` on eyebrow text unless it uses a monospace font; when using `uppercase` with a monospace font, always add `tracking-wide`
+
+## Coding Rules
+
+- Constrain text width with `max-w-[*ch]` directly on the element — see [Heading Groups](./heading-groups.md) rules for values per `text-*` size
+- Always use the official Inter variable font (`InterVariable`) with `font-display: swap`; enable OpenType features via `font-feature-settings` (e.g. `cv02`, `cv03`, `cv04`, `cv11`, `ss01`, `ss03`)
+- Always read [Custom Fonts](./custom-fonts.md) when using custom fonts

--- a/.claude/skills/gameplan/SKILL.md
+++ b/.claude/skills/gameplan/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: gameplan
+description: "Write a TDD-first gameplan for a Jira ticket (typically PENG-XXXX, Pactima/Snapdocs). Use when the user asks to gameplan, plan, scope, write up, or investigate a ticket — or pastes a Jira issue URL. Fetches the ticket, traces the bug in code, checks Loom recordings, cross-refs the Obsidian vault, then writes a structured doc to the snapdocs vault. Trigger phrases: 'gameplan PENG-...', 'plan this ticket', 'write up <ticket>', 'investigate <ticket>', 'help me think through <ticket>'."
+---
+
+# gameplan — TDD-first ticket investigation and writeup
+
+This skill produces ticket gameplan docs in **Omar's house style** — the format used across `~/Library/CloudStorage/GoogleDrive-omar.shaarawi@snapdocs.com/My Drive/snapdocs/tickets/`. The pattern is **understanding before solutioning**, with a failing test written **before** picking among fix options.
+
+The skill does *not* implement the fix. It produces the doc, the failing-test contract, and a clear list of fix options. Implementation is a separate session.
+
+---
+
+## When to use
+
+- User asks: "gameplan PENG-XXXX," "plan this ticket," "write up <ticket>," "scope <ticket>," "help me think through <ticket>"
+- User pastes a Jira issue URL (`snapdocs-eng.atlassian.net/browse/PENG-...`)
+- User asks for a "TDD plan" or "test-first plan" for a ticket
+
+If the user just asks a question *about* the code, that's not gameplan — answer directly.
+
+---
+
+## Inputs
+
+- A ticket key (`PENG-2587`), a Jira URL, or a one-line description.
+- Optionally, a Loom URL or a path to an extracted Loom (`~/git/loom-extractor/out/loom-<id>/`).
+- Optionally, the answer to "is the API the bug, or the FE?" — but usually you have to figure this out.
+
+---
+
+## Workflow
+
+### Phase 1 — Fetch the ticket
+
+Use the Atlassian MCP server. The cloudId is `snapdocs-eng.atlassian.net`.
+
+```
+mcp__atlassian__getJiraIssue with
+  cloudId = "snapdocs-eng.atlassian.net"
+  issueIdOrKey = "PENG-XXXX"
+  responseContentFormat = "markdown"
+```
+
+Pull: summary, description, priority, status, sprint, reporter, assignee, comments, related links.
+
+**If the ticket description is sparse** (just a Loom or one line), don't bail — Pactima tickets are often this short. Move to Phase 2.
+
+### Phase 2 — Loom recording
+
+If the description has a Loom URL, check for a local extract first:
+
+```
+ls ~/git/loom-extractor/out/loom-<first-12-chars-of-id>/
+```
+
+If `summary.md` and `timeline.md` exist, read them. They give frame-by-frame OCR — usually enough to identify the failing UI surface and the exact error message. Quote the exact error text from the recording in the doc.
+
+If the extract is missing, tell the user and offer to invoke the `loom-extract` skill. Don't try to watch the video directly.
+
+### Phase 3 — Trace the bug
+
+Pactima monorepo lives at `~/git/pactima/{pactima-api, pactima-web-app, pactima-angular-internal}`.
+
+Standard trace order, depending on the surface:
+
+1. **Error string from Loom** → `grep -rn "<error string>" ~/git/pactima/pactima-api/src/assets/errors-catalog/errors-list.ts` to map to its error code, then grep the codebase for `<error code>` to find the throw site.
+2. **Controller** → check the relevant controller (e.g. `eSignaturePackagesCcRecipients.controller.ts`) for status guards, validation, write paths.
+3. **Route** → `pactima-api/src/routes/...` for any middleware (`ScopeAuthorizer`, status middleware) you might have missed.
+4. **Model** → `pactima-api/src/models/...` for pre-save hooks and schema-level validation.
+5. **Utils / shared** → `pactima-api/src/utils/eSignatureUtils.ts` is the access-gate hub.
+6. **Front-end** → `pactima-web-app/src/app/...`. Especially: components/services that call the failing API, plus *sister components* doing the same job correctly (often the bug is in one caller, not in the shared component).
+7. **Tests** → look for adjacent specs. `pactima-api/spec/` and `pactima-web-app/src/**/*.spec.ts`.
+
+**Look for sister implementations.** When the FE has a bug, there is often a sibling component that solves the same problem correctly (e.g. `signing-station-side-bar-live.editSigner` vs `e-signatures-details.handleChangeSignerInfo`). Citing the working sibling shapes the fix.
+
+**Distinguish error codes.** Pactima has many four-digit error codes that look similar (`E_SIGNATURE_SIGNERS.0002` vs `E_SIGNATURE_PACKAGES.0012` vs `E_SIGNATURE_CC_RECIPIENTS.0006`). Quote the exact code in the doc and don't conflate them.
+
+### Phase 4 — Cross-ref the vault
+
+Use `mcp__qmd__query` against the `obsidian` collection. Useful queries:
+
+- The status enum / glossary: `[[17 - Glossary]]`, `[[04 - Database & Models]]`
+- Workflow / state machines: `[[18a - Participant Pools State Transition Matrix]]`, `[[09 - Business Logic & Domain Rules]]`
+- Adjacent tickets: search by feature area
+- Real-time / WS: `[[18h - PENG-2443 Real-Time Pool Updates Testing Guide]]`
+
+Cite each as `[[Title]] — one-line hook`. Don't list cross-refs that aren't actually used in the doc.
+
+### Phase 5 — Reframe the ticket
+
+This is the most distinctive part of the house style. **Read the ticket text adversarially.** The reporter's framing is often loose. Examples:
+
+- "Notaries get the email" might mean "schedule-setter participants get the email" — different code path.
+- "Allow updating X when in SCHEDULED status" might mean "the API already allows it, but the UI routes through the wrong endpoint" — no API status-guard relaxation needed.
+- "Sometimes works, sometimes doesn't" might mean "an iframe parent papers over the bug when a separate condition fires."
+
+If your reading differs from the literal title, **say so explicitly** in the **Acceptance criteria (as I read it)** section. Phrase it as your interpretation, not as a correction. Then preserve the original framing for grep-ability.
+
+### Phase 6 — Write the doc
+
+Save to `~/Library/CloudStorage/GoogleDrive-omar.shaarawi@snapdocs.com/My Drive/snapdocs/tickets/PENG-XXXX.md`.
+
+**Filename rule:**
+- Single-symptom bug: `PENG-XXXX.md`
+- Multi-component or multi-feature: `PENG-XXXX <Short Title>.md`
+- Use the existing folder for inspiration on naming.
+
+**Don't:** write to `~/git/pactima/`. That's the code repo, not the notes vault.
+
+---
+
+## Doc skeleton (in this exact order)
+
+```markdown
+# PENG-XXXX — <one-line restatement of the actual problem, not the Jira title>
+
+**Type:** <Bug|Task|Story> · **Priority:** <P1|P2> · **Sprint:** <N> (ends YYYY-MM-DD) · **Status:** <In Progress>
+**Reporter:** <name> · **Assignee:** <name>
+**Jira:** https://snapdocs-eng.atlassian.net/browse/PENG-XXXX
+**Repo(s):** <pactima-api, pactima-web-app, ...>
+**Bookmark:** feature/PENG-XXXX-<short-slug>
+**Loom:** <url> (extracted: <local path>)  [if applicable]
+**Related:** [[adjacent ticket/note]]  [if applicable]
+
+## The problem
+
+Prose. Concrete user-visible behavior. Quote exact error strings. If the ticket framing is loose, paragraph that re-frames it against the wiring. Distinguish symptoms if there are multiple.
+
+## Acceptance criteria (as I read it)
+
+Numbered list. The phrase "as I read it" is load-bearing — it flags ambiguity in the original AC and forces alignment.
+
+## Where the bug lives
+
+File:line:function with code snippets. Always before any fix strategy.
+Subsections per symptom if there are multiple.
+Cite sister implementations that get it right.
+
+## Why this looks like a <X> problem  [optional, only if reframing]
+
+For tickets where the reporter's framing diverges from the actual defect — explain why the framing is plausible, then where it actually breaks.
+
+## Root cause (summary)
+
+Short, conceptual. Names the underlying error, not the symptom. Often one paragraph.
+
+## Domain context  [optional, longer for new areas]
+
+Tables, ASCII workflow diagrams, "X vs Y" disambiguation. Distinguish similar terms (e.g., `participant-notifier` vs `enrollee-finder`).
+
+## Fix strategy
+
+Options A / B / C with explicit pros and cons. Recommend one. If you've shipped already, add an "As shipped — Option D" with the pivot reason.
+
+## Test plan (TDD)
+
+**The contract.** One sentence. The observable fact (not implementation choice) that the fix must produce.
+
+**Why this contract.** Explain why the chosen assertion holds across all listed fix options. The lowest-common-denominator that survives A/B/C.
+
+**File path** for the new test (use a `peng-XXXX` suffix, e.g. `eSignaturePackagesActions.finishSession.peng-2566.controller.test.ts`).
+
+**Sections:** Setup → Mocks → Act → Assert. The assert that fails today is called out separately from sanity asserts that should still pass.
+
+**Mock at the IO seam, run the real code.** sendHTMLEmail, S3, sendSocketEvent are spies; everything else (Mongo via MongoMemoryServer, the workflow walker, model methods) runs for real.
+
+**Out of scope** — explicit, with follow-up filing intent.
+
+## Interpretation choices
+
+Numbered. Each: *Chose X. Rejected Y because Z.* Locks in every soft spot in the AC.
+
+## Open questions
+
+For reporter / sprint review. Never blockers. *"All answers are compatible with what shipped."*
+
+## Files to change  [if pre-implementation]
+
+Per repo, file-by-file, what will be done. Use this section name when planning.
+
+## Files changed (as-built)  [if post-implementation]
+
+Per repo. Plus the regression sweep command and result count (`44/44 green`).
+
+## Vault context (qmd cross-refs)
+
+`[[Title]]` — one-line "what this note told me." Skip if no real cross-refs.
+
+## Related code (for reference)
+
+Bullet list of file:line pointers for reviewers. Easy navigation.
+```
+
+---
+
+## TDD discipline (the distinctive part)
+
+**Write the test before picking the fix option.** The test goes against a contract that survives across all candidate fix shapes. Recipe:
+
+1. State the **contract** in one sentence — an observable fact, not an implementation choice.
+2. List the **fix options** and explain why the chosen assertion holds across all of them. Pick the lowest-common-denominator.
+3. Give the test file path up front. Naming convention: include the ticket key (`peng-XXXX`) in the filename so it's grep-able.
+4. **Setup → Mocks → Act → Assert**. The asserting-the-bug assertion is called out *separately* from the sanity asserts (which should still pass on `main`).
+5. **Mock at the IO seam, run the real code.** Real `MongoMemoryServer`, real workflow code, real model methods. Spies only on `sendHTMLEmail`, S3, socket emits, etc.
+6. **Two-layer split** when useful: filter-level unit + handler-level e2e. PENG-2559 (13 unit + 7 e2e) is the canonical example.
+7. **Out of scope** — list it with explicit follow-up intent.
+
+---
+
+## What NOT to do
+
+- **Don't implement the fix.** This skill produces the gameplan and the failing-test design. Implementation is a separate, opt-in step.
+- **Don't conflate similar error codes.** Look up each one in `errors-list.ts` and quote it precisely.
+- **Don't skip the reframe.** If your reading differs from the ticket title, that's the most important thing to surface.
+- **Don't write to the pactima repo.** Outputs go to the snapdocs vault.
+- **Don't invent vault cross-refs.** Use qmd to find real ones; if there aren't any, skip the section.
+- **Don't add a fix-option pivot ("As shipped — Option D") at planning time.** That section only appears post-implementation when you actually pivoted away from the planned option.
+- **Don't write a test plan that only works for Option A.** If your assertion only survives one option, you've over-fitted. Generalize.
+
+---
+
+## When the ticket doesn't reproduce
+
+Some tickets resolve into "cannot reproduce" after investigation (PENG-2559 is the canonical case). The doc still ships, but the shape changes:
+
+- Open with a **TL;DR** that states the conclusion ("cannot reproduce; here is what likely happened").
+- Run the reporter's exact configurations as e2e tests anyway — the test file becomes the reproduction harness.
+- Surface the **real edge cases** that match what the reporter probably hit (e.g., owner-as-signer trap).
+- File adjacent issues as follow-up tickets, not in this PR.
+- Recommend closing as Cannot Reproduce with the closure note including the edge cases.
+
+---
+
+## Pactima environment cheatsheet
+
+- **Repos:** `~/git/pactima/{pactima-api, pactima-web-app, pactima-angular-internal}`
+- **Notes vault:** `~/Library/CloudStorage/GoogleDrive-omar.shaarawi@snapdocs.com/My Drive/snapdocs/`
+- **Tickets folder:** `<vault>/tickets/`
+- **Loom extracts:** `~/git/loom-extractor/out/loom-<first-12-chars>/`
+- **Atlassian cloudId:** `snapdocs-eng.atlassian.net`
+- **Test runners:** `vitest` for both API and web-app
+- **API DB-backed tests:** `MongoMemoryServer` (no mocks of model methods)
+- **VCS:** `jj` (load `jujutsu` skill before any VCS write); pactima is a `jj` repo
+
+---
+
+## Reference docs (canonical examples in the vault)
+
+When in doubt about tone, structure, or tradeoff explanation, read these existing tickets:
+
+- `PENG-2566 On-demand Pool Cosigner Email Timing.md` — gold-standard for fix-option enumeration + TDD contract that survives across A/B/C.
+- `PENG-2538 Disable Signer Notifications for Pools.md` — gold-standard for "discovered during implementation, separate follow-up" pattern.
+- `PENG-2559.md` — canonical "cannot reproduce, here's what really happened" doc.
+- `PENG-2532 Data Residency on User Joining.md` — heavy interpretation-choices section.
+- `PENG-2522.md` — short ticket, minimal fix; not every doc needs to be 200 lines.

--- a/.claude/skills/jj-vcs/SKILL.md
+++ b/.claude/skills/jj-vcs/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: jujutsu
+description: "Required for any git/VCS operation. If `.jj/` exists, this is a Jujutsu (jj) repo — raw git commands may desync repository state. Load this skill before running VCS commands."
+allowed-tools: Bash(jj *)
+---
+
+# Jujutsu (jj) Version Control System
+
+A Git-compatible VCS with mutable commits, automatic rebasing, and no staging area.
+
+**Tested with jj v0.42.0** — jj evolves quickly; verify commands against `jj help <subcommand>` if something fails.
+
+---
+
+## Non-Interactive Environment Rules
+
+When running as an agent or in any non-interactive context, several jj commands open an editor or interactive UI and will hang indefinitely. Follow these rules strictly:
+
+| Blocked command | Safe alternative |
+|---|---|
+| `jj desc` (no `-m`) | `jj desc -m "message"` |
+| `jj squash` (no `-m`, inherits parent msg) | `jj squash -m "message"` if you need to set the message |
+| `jj split` | Use `jj restore` to manually redistribute changes |
+| `jj squash -i` | Use `jj restore` and targeted squash instead |
+| `jj resolve` | Edit conflict markers in files directly |
+| `jj commit` (no `-m`) | `jj commit -m "message"` |
+
+**After any mutation** (`squash`, `abandon`, `rebase`, `restore`, `absorb`), run `jj st` to confirm success.
+
+---
+
+## Core Concepts
+
+### The working copy is a commit
+
+Your working directory is always a commit, referenced as `@`. Changes are automatically snapshotted when you run any jj command. There is no staging area and no need to `git add`.
+
+### Commits are mutable
+
+Unlike git, any commit can be freely modified after creation. This means you can refine messages, split or combine commits, and reorder history without ceremony.
+
+### Change IDs vs commit IDs
+
+- **Change ID** (e.g., `tqpwlqmp`): Stable across rewrites. Prefer these in commands.
+- **Commit ID** (e.g., `3ccf7581`): Content hash that changes when the commit is rewritten.
+
+### Revsets
+
+Revsets are jj's language for selecting revisions. A few essential patterns:
+
+```bash
+@              # Working copy
+@-             # Parent of working copy
+@--            # Grandparent
+foo-            # Parent of change "foo"
+foo+            # Children of change "foo"
+foo::bar        # foo through bar (inclusive)
+bookmarks()     # All bookmarked revisions
+mine()          # Your commits
+description(regex)  # Commits matching description
+```
+
+Use revsets anywhere a revision is expected: `jj log -r 'mine() & ~empty()'`
+
+Full reference: `jj help revsets`
+
+---
+
+## First-Time Setup
+
+```bash
+# Set your identity
+jj config set --user user.name "Your Name"
+jj config set --user user.email "you@example.com"
+```
+
+---
+
+## Essential Workflow
+
+### Starting work
+
+```bash
+# Describe what you intend to do
+jj desc -m "Add user authentication to login endpoint"
+
+# Make your changes — they're automatically tracked
+# ... edit files ...
+
+# Check status
+jj st
+```
+
+Alternatively, some people prefer coding first and describing after — jj supports both equally well:
+
+```bash
+# Make changes first
+# ... edit files ...
+
+# Then describe what you did
+jj desc -m "Add user authentication to login endpoint"
+```
+
+### Creating the next commit
+
+```bash
+# Finish current work, start a new empty commit on top
+jj new
+jj desc -m "Next task description"
+```
+
+`jj commit -m "message"` is a shorthand that describes the current commit and creates a new empty one on top in a single step:
+
+```bash
+jj commit -m "Add user authentication to login endpoint"
+# Equivalent to: jj desc -m "..." && jj new
+```
+
+### Viewing history
+
+```bash
+jj log                    # Recent commits
+jj log -p                 # With diffs
+jj log -r 'mine()'       # Only your commits
+jj show <change-id>      # Specific commit details
+jj diff                   # Working copy changes
+jj diff --from @- --to @  # Explicit parent-to-working-copy diff
+```
+
+### Moving between commits
+
+```bash
+jj new                     # New empty commit on top of current
+jj new <change-id>         # New commit on top of a specific revision
+jj new <id1> <id2>         # New merge commit with multiple parents
+jj edit <change-id>        # Switch working copy to an existing commit
+jj prev -e                 # Edit the parent commit
+jj next -e                 # Edit the child commit
+```
+
+---
+
+## Refining Commits
+
+### Squashing
+
+Move changes from the current commit into its parent:
+
+```bash
+jj squash                  # Squash all changes into parent
+jj squash -m "Combined message"  # With explicit message
+jj squash --into <id>      # Squash into a specific ancestor (not just parent)
+```
+
+### Absorbing
+
+Automatically distribute working copy changes to the commits that last modified those lines:
+
+```bash
+jj absorb
+```
+
+This is powerful for fixup workflows — make corrections in your working copy and absorb routes each hunk to the right ancestor commit.
+
+### Restoring and discarding
+
+```bash
+jj restore                          # Discard all working copy changes
+jj restore path/to/file.txt        # Discard changes to specific files
+jj restore --from <id> file.txt    # Restore a file from another revision
+```
+
+### Abandoning
+
+Remove a commit entirely; its descendants are rebased onto its parent:
+
+```bash
+jj abandon <change-id>
+```
+
+### Undoing
+
+Reverse the last jj operation (works for any command):
+
+```bash
+jj undo
+```
+
+### Viewing the operation log
+
+```bash
+jj op log    # See all operations, useful before undo
+```
+
+---
+
+## Rebasing
+
+One of jj's most powerful features. All rebases automatically cascade to descendants.
+
+```bash
+# Rebase current commit onto a new parent
+jj rebase -r @ -d <new-parent>
+
+# Rebase a commit and all its descendants
+jj rebase -s <change-id> -d <new-parent>
+
+# Rebase a range of commits
+jj rebase -s <start> -d <destination>
+```
+
+Common patterns:
+
+```bash
+# Move your work on top of latest main
+jj rebase -s <your-branch-root> -d main
+
+# Reorder commits: move commit X before commit Y
+jj rebase -r <X> -d <Y->   # Place X before Y (on Y's parent)
+```
+
+---
+
+## Bookmarks (Branches)
+
+Bookmarks are jj's equivalent of git branches. **They do not auto-advance** — you must move them manually.
+
+```bash
+jj bookmark create my-feature -r @     # Create at current commit
+jj bookmark move my-feature --to @      # Move to current commit
+jj bookmark list                        # List all bookmarks
+jj bookmark delete my-feature           # Delete a bookmark
+```
+
+---
+
+## Git Integration
+
+### Cloning and initializing
+
+```bash
+jj git clone <url>              # Clone a git repo into a jj repo
+jj git init --colocate          # Initialize jj inside an existing git repo
+```
+
+### Fetching and pushing
+
+```bash
+jj git fetch                    # Fetch from all remotes
+jj git fetch --remote origin    # Fetch from a specific remote
+
+jj git push -b <bookmark-name>  # Push a bookmark
+```
+
+**Before pushing**, always verify:
+1. The bookmark points to the intended commit: `jj bookmark list`
+2. The commits are clean and atomic: `jj log -r <bookmark>`
+3. Move the bookmark if needed: `jj bookmark move <name> --to @`
+
+### Colocated repos (`.jj/` + `.git/`)
+
+This is the most common setup. Both tools see the same repository, but they can get out of sync.
+
+**Rules for colocated repos:**
+- Prefer jj commands for all day-to-day work
+- jj automatically exports bookmarks to git branches and imports git changes
+- If you must use git directly (e.g., for a tool that requires it), ensure jj's working copy is clean first with `jj st`
+- After running git commands, run any jj command (e.g., `jj st`) to trigger re-import
+- Avoid `git commit`, `git rebase`, `git merge` — let jj handle these operations
+
+**If git complains about detached HEAD:** This is normal. jj doesn't use git's HEAD the same way. Use jj commands to navigate.
+
+---
+
+## Trunk-Based Workflow (This Setup)
+
+This machine's jj config (`~/.dotfiles/.config/jj/config.toml`) defines custom aliases for a
+trunk-based, stacked-diff workflow. Prefer these over hand-rolling the equivalent commands.
+
+`trunk()` resolves to the remote's main branch (e.g. `main@origin` / `development@origin`). It
+**only advances when you fetch** — there is no auto-fetch hook, so **always run `jj git fetch`
+before rebasing onto trunk.**
+
+| Alias | Expands to | Use for |
+|---|---|---|
+| `jj nt` | `new trunk()` | Start fresh work on top of trunk |
+| `jj tug` | `bookmark move --from heads(::@- & bookmarks()) --to @-` | Move the nearest bookmark up to `@-` (after `jj new`, before push) |
+| `jj open` | `log -r open()` | List all your open stacks |
+| `jj retrunk -s <rev>` | `rebase -d trunk() -s <rev>` | Rebase a specific revision/stack onto trunk |
+| `jj reheat` | `rebase -d trunk() -s roots(trunk()..stack(@))` | Rebase the *current* stack onto fresh trunk |
+| `jj consume <rev> [paths]` | `squash --into @ --from <rev>` | Pull content from `<rev>` into `@` |
+| `jj eject <rev>` | `squash --from @ --into <rev>` | Push content from `@` into `<rev>` |
+| `jj examine <rev>` | `log -T builtin_log_detailed -p -r <rev>` | Detailed `-p` view of a revision |
+
+Typical loop:
+
+```bash
+jj git fetch            # advance trunk()
+jj nt                   # new work on trunk
+jj desc -m "..."        # describe, then edit files
+# ... iterate, refine ...
+jj tug                  # move the bookmark to your finished commit
+jj git push -b <name>   # push
+```
+
+To pick up new trunk under in-progress work: `jj git fetch && jj reheat`.
+
+**Stale/divergent local bookmark** (e.g. local `development` drifted onto a feature commit):
+reset it to the remote instead of rebasing onto it.
+
+```bash
+jj bookmark set development -r development@origin
+```
+
+⚠️ **Check for unpushed commits FIRST.** Resetting a bookmark onto the remote silently orphans
+any local commits the remote doesn't have — this has destroyed real, verified work (OpenTag,
+2026-07-01: four unpushed commits on `main` dropped by exactly this reset; recovered days later
+from `refs/jj/keep`). Before any `jj bookmark set <name> -r <name>@origin`:
+
+```bash
+jj log -r '<name>@origin..<name>' --no-graph   # anything listed = unpushed local commits
+```
+
+If that prints commits, they are about to be orphaned — push them, re-land them on a dev branch,
+or explicitly decide to discard them. Only reset when it prints nothing.
+
+Because `trunk()` tracks the remote, a drifting local bookmark won't poison rebases — but reset it
+anyway so `jj log` reads true.
+
+**Repo-analytics aliases** also exist (`jj churn`, `jj authors`, `jj hotspots`, `jj velocity`,
+`jj firefights`) — they shell out via `jj util exec` to summarize commit history. Handy for
+investigating a codebase; not part of the day-to-day commit loop.
+
+---
+
+## Handling Conflicts
+
+jj allows you to commit conflicts and resolve them later — they don't block your workflow.
+
+```bash
+# See what's conflicted
+jj st
+
+# View conflict details
+jj diff
+```
+
+**To resolve conflicts in a non-interactive environment:**
+
+1. Open the conflicted file — look for conflict markers:
+   ```
+   <<<<<<< Conflict 1 of 1
+   %%%%%%% Changes from base to side #1
+   -old line
+   +side 1 line
+   +++++++ Contents of side #2
+   side 2 line
+   >>>>>>>
+   ```
+   Note: jj uses a diff-style format, not git's `<<<<<<<`/`=======`/`>>>>>>>` format. The `%%%%%%%` section shows a diff from the base to one side, and the `+++++++` section shows the other side's content.
+
+2. Edit the file to contain the desired result, removing all markers
+
+3. Verify resolution: `jj st` — the file should no longer show as conflicted
+
+---
+
+## Commit Message Style
+
+Use imperative verb phrases in sentence case, no trailing period:
+
+```
+Add validation to user input forms
+Fix null pointer in payment processor
+Remove deprecated API endpoints
+Update dependencies to latest versions
+```
+
+This is a common convention, not a hard rule — match whatever style the project uses.
+
+---
+
+## Quick Reference
+
+| Action | Command |
+|---|---|
+| Describe commit | `jj desc -m "message"` |
+| View status | `jj st` |
+| View log | `jj log` |
+| View diff | `jj diff` |
+| New commit | `jj new` |
+| Commit + new | `jj commit -m "message"` |
+| Edit commit | `jj edit <id>` |
+| Squash to parent | `jj squash` |
+| Squash to target | `jj squash --into <id>` |
+| Auto-distribute | `jj absorb` |
+| Rebase | `jj rebase -r <id> -d <dest>` |
+| Abandon commit | `jj abandon <id>` |
+| Undo last operation | `jj undo` |
+| Operation history | `jj op log` |
+| Restore files | `jj restore [paths]` |
+| Create bookmark | `jj bookmark create <name> -r @` |
+| Move bookmark | `jj bookmark move <name> --to @` |
+| Fetch from remote | `jj git fetch` |
+| Push bookmark | `jj git push -b <name>` |
+| Set config | `jj config set --user <key> "value"` |
+| New work on trunk | `jj nt` |
+| Move bookmark to `@-` | `jj tug` |
+| List open stacks | `jj open` |
+| Rebase stack onto trunk | `jj git fetch && jj reheat` |
+| Rebase rev onto trunk | `jj retrunk -s <rev>` |
+| Reset stale bookmark | `jj bookmark set <name> -r <name>@origin` |

--- a/.claude/skills/loom-extract/SKILL.md
+++ b/.claude/skills/loom-extract/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: loom-extract
+description: "Extract keyframes + OCR from a silent Loom video (or local mp4) for use as Claude Code context. Trigger when the user shares a Loom URL, references a UI bug captured in a screen recording, or points at a folder produced by this tool (contains manifest.json + frames/)."
+allowed-tools: Bash(uv run *), Bash(cd *), Bash(loom-extract *), Read, Glob
+---
+
+# loom-extract
+
+Pipeline that turns a silent Loom video into Claude-readable artifacts: keyframes (PNG), OCR text, structured manifest, human-readable timeline. Built for **debugging UI bugs** captured in Looms with no audio.
+
+The CLI is at `/Users/Shaarawi/git/loom-extractor`. The tool itself does **zero API calls** — output is consumed in-thread by whichever Claude Code session needs it.
+
+## When to use
+
+- User pastes a Loom URL (e.g. `https://www.loom.com/share/...`) and wants you to look at it
+- User describes a UI bug seen in a screen recording
+- User references a folder produced by this tool (it will contain `manifest.json`, `timeline.md`, and a `frames/` directory)
+
+## Running the extractor
+
+```bash
+cd /Users/Shaarawi/git/loom-extractor && uv run loom-extract <URL_OR_PATH>
+```
+
+Options:
+- `--out DIR` — output root (default: `out/`)
+- `--threshold 0.08` — scene-change sensitivity (lower = more frames kept)
+- `--fps N` — regular fps sampling instead of scene detection
+- `--width 1280` — max frame width; frames wider than this get downscaled
+- `--dump-urls` — also write `urls.txt`, a navigation-only trace
+- `--no-ocr` — skip OCR pass
+
+Output lands in `<out>/<video-name>/` containing:
+- `frames/NNNN_HH-MM-SS.png` — keyframes (downscaled to ≤1280px wide), named by index + timestamp
+- `summary.md` — **read this first**: one line per frame with timestamp, detected URL, and a short OCR snippet
+- `urls.txt` — *only if `--dump-urls` was passed*: navigation-only trace, consecutive frames on the same URL collapsed into time ranges. Tiny (~1-2KB) and ideal for tracing user routing through an app.
+- `manifest.json` — full structured metadata + complete OCR text per frame (large; read only when summary is insufficient)
+- `timeline.md` — human-readable, embeds frames inline (for the user, not for you)
+
+If the user passes a Loom URL, the extractor downloads it via `yt-dlp` to `<target>/video.mp4` and reuses it on subsequent runs.
+
+## Output schema
+
+```json
+{
+  "source": "https://loom.com/share/<id>",
+  "extracted_at": "2026-04-28T19:11:00+00:00",
+  "frame_count": 42,
+  "frames": [
+    {
+      "index": 1,
+      "filename": "frames/0001_00-00-03.png",
+      "timestamp_s": 3.0,
+      "timestamp_hms": "0:03",
+      "scene_score": 0.157,
+      "ocr_text": "Sign In\nForgot password?"
+    }
+  ]
+}
+```
+
+Filenames are stable across runs as long as the input is the same — safe to reference from notes or other threads.
+
+## How to consume the output
+
+When the user references an extraction folder or asks about a UI bug from a Loom:
+
+1. **Read `summary.md` first.** It is one line per frame with timestamp, detected URL, and a short OCR snippet — token-cheap and usually enough to find the relevant frames.
+2. **View only the relevant PNGs** from `frames/`. Claude is multimodal and should look at the actual image, not just the OCR text. OCR is a hint, not ground truth.
+3. **Fall back to `manifest.json`** only when summary.md is too sparse and you need full per-frame OCR. The manifest is large (every frame's full OCR) — read it via filtered scripts (jq, python) rather than `Read` whenever possible.
+4. **Cross-reference timestamps** with anything the user describes ("the bug happens around 0:42" → find the frame whose timestamp is closest in summary.md).
+5. `timeline.md` is for the user to scan with their eyes (embeds frames inline). Don't read it yourself unless asked — summary.md gives you the same info more cheaply.
+
+**Token budget rule of thumb:** for a typical Loom (3-5 min, 30-50 keyframes), reading summary.md + viewing 3-6 targeted frames is ~5-10k tokens. If you find yourself viewing more than 10 frames, stop and ask the user which moment they care about.
+
+## Tuning when results are off
+
+- **Too few frames kept** (missed the bug moment): rerun with `--threshold 0.04` or `--threshold 0.02`.
+- **Too many near-duplicate frames**: rerun with `--threshold 0.15`.
+- **Subtle changes missed entirely** (e.g. a single border color flip): rerun with `--fps 2` to force regular sampling, then visually scan.
+- **OCR garbage on a frame**: trust the image, not the text. Low-contrast UI text or icons commonly produce noisy OCR.

--- a/.claude/skills/make-responsive/SKILL.md
+++ b/.claude/skills/make-responsive/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: make-responsive
+description: Adapt existing UI across mobile, tablet, and desktop breakpoints.
+---
+
+# Make Responsive
+
+Use this when the user wants an existing desktop-oriented UI to work well across mobile, tablet, and desktop breakpoints.
+
+## Activation
+
+### Use For
+
+- making an existing UI responsive
+- fixing mobile, tablet, or breakpoint-specific layout issues
+- adapting a desktop-only design to smaller screens
+- resolving overflow, wrapping, clipping, or cramped layout problems on narrow viewports
+
+### Do Not Use For
+
+- brand-new design or layout work
+- code structure or component extraction only
+- dark mode or standalone image adaptation only
+
+## Load First
+
+- No companion files are required.
+- Responsive design guidance is inline below.
+
+## Progress Updates
+
+Keep the user informed so longer runs do not look stuck.
+
+- One-line status update before each major phase.
+- Concrete and lightweight: what you are doing now, not verbose logs.
+
+## Workflow
+
+1. Inspect the current desktop layout and identify overflow, wrapping, clipping, cramped areas, desktop-only navigation, tables, forms, pagination, stat grids, and divider-separated layouts.
+2. Apply mobile-first responsive classes and breakpoint-specific layout changes.
+3. Prefer component-level responsiveness with container queries when layout depends on available component space.
+4. Check mobile, tablet, and desktop viewports.
+
+## Responsive Design Rules
+
+Use these rule groups as an audit order: page shell first, navigation second, then text/forms, overflow, and component-specific patterns.
+
+### Page Shell and Breakpoints
+
+- Every layout must adapt from mobile to desktop — use responsive breakpoint classes (`sm:`, `md:`, `lg:`, etc.) to adjust grid columns, spacing, font sizes, and visibility at different screen sizes
+- Multi-column desktop layouts (sidebars, secondary navigation, filter panels) must collapse to a single-column layout on small screens — use a mobile menu, disclosure, or other compact pattern instead of shrinking columns
+- Use `min-h-dvh`, `min-h-svh`, or `min-h-lvh`; never use `min-h-screen`
+
+### Navigation and Pagination
+
+- Every app must have a mobile navigation menu below `lg`, regardless of whether the desktop nav is in a header or sidebar — use a dialog or disclosure panel with a hamburger toggle; hide header nav with `hidden lg:flex`, hide sidebar nav with `hidden lg:block`, and hide the mobile toggle/menu at desktop widths with `lg:hidden`
+- Horizontal menus (tabs, tab bars, pill navs) must never overflow their parent — use horizontal scrolling when items do not fit
+- Hide page numbers on mobile when pagination includes both page numbers and previous/next buttons
+
+### Text, Forms, and Touch Targets
+
+- Body text, subheadings, form controls, and icons should be **larger on mobile** and scale down at `sm:` — write the mobile (larger) size as the default and the desktop (smaller) size with `sm:` (e.g. `text-2xl/8 sm:text-xl/8`, `text-base/7 sm:text-sm/6`, `text-lg/6 sm:text-sm/6`, `size-5 sm:size-4`, `py-2.5 sm:py-1.5`); this applies to body text, subheadings, stat values, form input labels, badges, buttons, select/input padding, and icons — **not** h1s (page titles stay the same size or get smaller on mobile, not bigger)
+- Body, paragraph, and general page content must be at least `text-base` (16px) on mobile — never use `text-xs`; `text-sm` is only acceptable at `sm:` or larger breakpoints (e.g. `text-base/7 sm:text-sm/6`, never `text-sm/6` without a breakpoint prefix for body copy)
+- If a text input's font size is smaller than `16px`, add `max-sm:text-base/{lh}` to bump it to `16px` on mobile
+- Checkboxes, radio buttons, and toggles should be larger on mobile and scale down at `sm:` — e.g. `size-5 sm:size-4` for checkboxes/radios and `w-11 sm:w-9` for toggles
+- Small/icon buttons must meet the 48×48px minimum touch target — make the button `relative` and add a direct child `<span class="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden" aria-hidden="true" />` when the visual button is smaller
+- Never fix cramped heading groups by constraining the wrapper with `max-w-*` or `max-lg:max-w-*` — constrain each text element directly with `max-w-[*ch]`
+
+### Overflow and Flexible Sizing
+
+- Always add `min-w-0` to flex children that must shrink below their content size, especially fluid content beside fixed sidebars, truncated labels, and flexible inputs beside fixed buttons
+- Always add `shrink-0` to flex children that must not compress — icons, SVGs, images, logos, avatars, and fixed-size controls
+- Always make tables horizontally scroll when all columns will not fit on smaller screens — wrap the table in an outer `overflow-x-auto whitespace-nowrap` div with matching negative container margins and an inner `inline-block min-w-full align-middle` div with matching horizontal padding
+- Never let table headings wrap — add `whitespace-nowrap` to `<th>` elements
+
+### Component Patterns
+
+- Use container queries (`@container`) for component-level responsiveness — anything whose layout depends on available space rather than the viewport (e.g. dashboard widgets, feature cards, pricing tiers, testimonial grids)
+- When using container queries, place the `@container` element as close to the responsive content as possible — ideally a direct wrapper around the items, never on a page-level container
+- Use container queries for responsive dashboard widgets, not media queries; truncate stat and metric card titles so they never wrap
+- Reconfigure divider-separated grids at each breakpoint where columns change — reset first/last item padding, remove vertical dividers when collapsing to one column, and add horizontal dividers between rows
+- Keep wrapped logo clouds balanced on every breakpoint — use a grid or layout that avoids uneven final rows like `5+1`
+- Apply pricing-card emphasis with breakpoint-scoped grid rows and columns, and let pricing cards stack normally below that breakpoint
+- Use `min()` with viewport units for image and screenshot border radii instead of fixed `rounded-*` values — e.g. `rounded-[min(1vw,12px)]`
+
+## Verify
+
+- Confirm the UI works at narrow, medium, and desktop widths.
+- Confirm mobile navigation exists and desktop navigation is hidden below `lg`.
+- Confirm tables, tabs, pagination, form controls, stat grids, and divider-separated grids behave correctly on narrow screens.
+- Run relevant formatting, lint, typecheck, or tests when available.

--- a/.claude/skills/portless/SKILL.md
+++ b/.claude/skills/portless/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: portless
+description: Set up and use portless for named local dev server URLs (e.g. https://myapp.localhost instead of http://localhost:3000). Use when integrating portless into a project, configuring dev server names, setting up the local proxy, working with .localhost domains, or troubleshooting port/proxy issues.
+---
+
+# Portless
+
+Replace port numbers with stable, named .localhost URLs. For humans and agents.
+
+## Why portless
+
+- **Port conflicts**: `EADDRINUSE` when two projects default to the same port
+- **Memorizing ports**: which app is on 3001 vs 8080?
+- **Refreshing shows the wrong app**: stop one server, start another on the same port, stale tab shows wrong content
+- **Monorepo multiplier**: every problem scales with each service in the repo
+- **Agents test the wrong port**: AI agents guess or hardcode the wrong port
+- **Cookie/storage clashes**: cookies on `localhost` bleed across apps; localStorage lost when ports shift
+- **Hardcoded ports in config**: CORS allowlists, OAuth redirects, `.env` files break when ports change
+- **Sharing URLs with teammates**: "what port is that on?" becomes a Slack question
+- **Browser history is useless**: `localhost:3000` history is a mix of unrelated projects
+
+## Installation
+
+Install globally (recommended) or as a project dev dependency. Do NOT use `npx` or `pnpm dlx` for one-off execution.
+
+```bash
+# Global (available everywhere)
+npm install -g portless
+
+# Or per-project dev dependency
+npm install -D portless
+```
+
+When installed per-project, invoke via package.json scripts or `npx portless` (since the package is local, npx will not download anything).
+
+## Quick Start
+
+```bash
+# Install globally (or add -D to a project)
+npm install -g portless
+
+# Run your app (auto-starts the HTTPS proxy on port 443)
+portless run next dev
+# -> https://<project>.localhost
+
+# Or with an explicit name
+portless myapp next dev
+# -> https://myapp.localhost
+```
+
+The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+
+In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
+
+## Integration Patterns
+
+### Zero-config (recommended)
+
+Bare `portless` works out of the box. It runs the `"dev"` script from `package.json` through the proxy, inferring the app name from the package name, git root, or directory:
+
+```bash
+portless        # -> runs "dev" script, https://<project>.localhost
+pnpm dev        # -> works without portless, plain "next dev"
+```
+
+Use an optional `portless.json` to override defaults (name, script, port):
+
+```json
+{ "name": "myapp" }
+```
+
+```bash
+portless        # -> runs "dev" script, https://myapp.localhost
+```
+
+### Monorepo
+
+One `portless.json` at the repo root. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
+
+```json
+{
+  "apps": {
+    "apps/web": { "name": "myapp" },
+    "apps/api": { "name": "api.myapp" }
+  }
+}
+```
+
+```bash
+portless                  # from repo root: start all packages with a "dev" script
+cd apps/web && portless   # start just one package
+portless --script start   # run "start" instead of "dev"
+```
+
+The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names.
+
+Without an `apps` map, hostnames follow `<package>.<project>.localhost`. The project name comes from the most common npm scope (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it uses the bare `<project>.localhost`.
+
+### Turborepo
+
+For turborepo projects, use portless as the `dev` script with the real command in a separate script:
+
+```json
+{
+  "scripts": { "dev": "portless", "dev:app": "next dev" },
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+`pnpm dev` runs turbo, which runs `portless` in each package. Portless detects the package manager and runs `pnpm run dev:app` through the proxy.
+
+### package.json scripts
+
+You can still use portless directly in scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "portless run next dev"
+  }
+}
+```
+
+The proxy auto-starts when you run an app. Or start it explicitly: `portless proxy start`.
+
+### Multi-app setups with subdomains
+
+```bash
+portless myapp next dev          # https://myapp.localhost
+portless api.myapp pnpm start    # https://api.myapp.localhost
+portless docs.myapp next dev     # https://docs.myapp.localhost
+```
+
+By default, only explicitly registered subdomains are routed (strict mode). Start the proxy with `--wildcard` to allow any subdomain of a registered route to fall back to that app (e.g. `tenant1.myapp.localhost` routes to the `myapp` app). Exact matches always take priority over wildcards.
+
+### Git worktrees
+
+`portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain prefix so each worktree gets a unique URL:
+
+```bash
+# Main worktree (no prefix)
+portless run next dev   # -> https://myapp.localhost
+
+# Linked worktree on branch "fix-ui"
+portless run next dev   # -> https://fix-ui.myapp.localhost
+```
+
+No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
+
+### Bypassing portless
+
+Set `PORTLESS=0` to run the command directly without the proxy:
+
+```bash
+PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
+```
+
+## How It Works
+
+1. `portless proxy start` starts an HTTPS reverse proxy on port 443 as a background daemon. Auto-elevates with sudo on macOS/Linux; falls back to port 1355 if sudo is unavailable. Use `--no-tls` for plain HTTP on port 80. Configurable with `-p` / `--port` or the `PORTLESS_PORT` env var. The proxy also auto-starts when you run an app.
+2. `portless <name> <cmd>` assigns a random free port (4000-4999) via the `PORT` env var and registers the app with the proxy
+3. The browser hits `https://<name>.localhost`; the proxy forwards to the app's assigned port
+
+`.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
+
+Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
+
+### State directory
+
+Portless stores its state (routes, PID file, port file) in `~/.portless`. Override with the `PORTLESS_STATE_DIR` environment variable.
+
+### Environment variables
+
+| Variable              | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)       |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
+| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
+| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
+| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
+| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
+| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
+| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
+| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
+
+### HTTP/2 + HTTPS
+
+HTTPS with HTTP/2 is enabled by default (faster page loads for dev servers with many files). First run generates a local CA and adds it to the system trust store. After that, no prompts and no browser warnings.
+
+```bash
+portless proxy start --cert ./c.pem --key ./k.pem  # Use custom certs
+portless proxy start --no-tls                       # Disable HTTPS (plain HTTP)
+portless trust                                      # Add CA to trust store later
+```
+
+On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store.
+
+### LAN mode
+
+```bash
+portless proxy start --lan
+portless proxy start --lan --https
+portless proxy start --lan --ip 192.168.1.42
+```
+
+`--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
+
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+
+LAN mode depends on the system mDNS helpers that portless launches: macOS includes `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s tooling).
+
+- **Next.js**: add your `.local` hostnames to `allowedDevOrigins`:
+
+  ```js
+  // next.config.js
+  module.exports = {
+    allowedDevOrigins: ["myapp.local", "*.myapp.local"],
+  };
+  ```
+
+- **Expo / React Native**: portless always injects `--port`. React Native also gets `--host 127.0.0.1`. Expo gets `--host localhost` outside LAN mode, but in LAN mode portless leaves Metro on its default LAN host behavior instead of forcing `--host` or `HOST`.
+
+### Tailscale sharing
+
+Share dev servers with teammates on your Tailscale network using `--tailscale`, or expose to the public internet with `--funnel`:
+
+```bash
+portless myapp --tailscale next dev
+# -> https://myapp.localhost           (local)
+# -> https://devbox.yourteam.ts.net    (tailnet)
+
+portless myapp --funnel next dev
+# -> https://myapp.localhost           (local)
+# -> https://devbox.yourteam.ts.net    (public internet)
+```
+
+Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` can register HTTPS URLs. Funnel must also be enabled for the tailnet and node before `--funnel` can register the public URL. If either setting is missing, portless exits before starting the child process.
+
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
+
+## OS startup service
+
+Use the service command when users want the proxy to start automatically after reboot:
+
+```bash
+portless service install
+portless service status
+portless service uninstall
+```
+
+The service uses the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+
+## CLI Reference
+
+| Command                                | Description                                                    |
+| -------------------------------------- | -------------------------------------------------------------- |
+| `portless`                             | Run dev script through proxy                                   |
+| `portless`                             | From monorepo root: run all workspace packages                 |
+| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
+| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
+| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
+| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
+| `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
+| `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
+| `portless list`                        | Show active routes                                             |
+| `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
+| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
+| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
+| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
+| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
+| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
+| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
+| `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
+| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
+| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
+| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
+| `portless proxy stop`                  | Stop the proxy                                                 |
+| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
+| `portless service status`              | Show service and proxy status                                  |
+| `portless service uninstall`           | Remove the startup service                                     |
+| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
+| `portless alias <name> <port> --force` | Overwrite an existing route                                    |
+| `portless alias --remove <name>`       | Remove a static route                                          |
+| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
+| `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
+| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
+| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
+| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
+| `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
+| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
+| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
+| `portless --help` / `-h`               | Show help                                                      |
+| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
+| `portless --version` / `-v`            | Show version                                                   |
+
+**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+
+## portless.json
+
+Optional config file. Portless looks for it in the current directory.
+
+| Field     | Type    | Default                    | Description                                              |
+| --------- | ------- | -------------------------- | -------------------------------------------------------- |
+| `name`    | string  | inferred from package.json | Base app name (worktree prefix still applies)            |
+| `script`  | string  | `"dev"`                    | Name of a package.json script to run                     |
+| `appPort` | number  | auto-assigned              | Fixed port for the child process                         |
+| `proxy`   | boolean | auto-detected              | Whether to route through the proxy (`false` for tasks)   |
+| `apps`    | object  |                            | Overrides for workspace packages, keyed by relative path |
+| `turbo`   | boolean | `true`                     | Set `false` to use direct spawning instead of turborepo  |
+
+Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
+
+### package.json "portless" key
+
+Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+
+```json
+{ "portless": "myapp" }
+```
+
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+
+```json
+{ "portless": { "name": "myapp", "script": "dev:app" } }
+```
+
+Precedence (closest wins): CLI flags > package.json `"portless"` key > portless.json app entry > defaults.
+
+## Troubleshooting
+
+### Proxy not running
+
+The proxy auto-starts when you run an app with `portless <name> <cmd>`. If it doesn't start (e.g. port conflict), start it manually:
+
+```bash
+portless proxy start
+```
+
+### Port already in use
+
+Another process is bound to the proxy port. Either stop it first, or use a different port:
+
+```bash
+portless proxy start -p 8080
+```
+
+### Framework not respecting PORT
+
+Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
+
+For other frameworks that don't read `PORT`, pass the port manually:
+
+- **Webpack Dev Server**: use `--port $PORT`
+- **Custom servers**: read `process.env.PORT` and listen on it
+
+### Permission errors
+
+The default ports (80 for HTTP, 443 for HTTPS) require `sudo` on macOS and Linux. Portless auto-elevates with sudo when needed. If sudo is unavailable, it falls back to port 1355 (no sudo needed). On Windows, no elevation is required.
+
+```bash
+portless proxy start --https           # Auto-elevates with sudo for port 443
+portless proxy start -p 1355 --https   # No sudo needed (URLs include :1355)
+portless proxy stop                    # Stop (use sudo if started with sudo)
+```
+
+### Safari can't find .localhost URLs
+
+Safari relies on the system DNS resolver for `.localhost` subdomains, which may not resolve them on all macOS configurations. Chrome, Firefox, and Edge have built-in handling.
+
+Fix:
+
+```bash
+portless hosts sync    # Adds current routes to /etc/hosts
+portless hosts clean   # Remove entries later
+```
+
+Auto-syncs `/etc/hosts` for route hostnames by default. Set `PORTLESS_SYNC_HOSTS=0` to disable.
+
+### Browser shows certificate warning with --https
+
+The local CA may not be trusted yet. Run:
+
+```bash
+portless trust
+```
+
+This adds the portless local CA to your system trust store. After that, restart the browser.
+
+### Remove portless from the machine
+
+```bash
+portless clean
+```
+
+Stops the proxy if needed, removes the portless CA from the trust store (when portless added it), deletes known files under state directories, and removes the portless `/etc/hosts` block. May require `sudo` on macOS/Linux.
+
+### Proxy loop (508 Loop Detected)
+
+If your dev server proxies requests to another portless app (e.g. Vite proxying `/api` to `api.myapp.localhost`), the proxy must rewrite the `Host` header. Without this, portless routes the request back to the original app, creating an infinite loop.
+
+Fix: set `changeOrigin: true` in the proxy config (Vite, webpack-dev-server, etc.):
+
+```ts
+// vite.config.ts
+proxy: {
+  "/api": {
+    target: "https://api.myapp.localhost",
+    changeOrigin: true,
+    ws: true,
+  },
+}
+```
+
+Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=~/.portless/ca.pem`. Alternatively, use `--no-tls` for plain HTTP.
+
+### Tailscale not working
+
+If `--tailscale` or `--funnel` fails:
+
+```bash
+tailscale status     # Check if connected
+tailscale up         # Connect to your tailnet
+```
+
+Requires the Tailscale CLI to be installed (https://tailscale.com/download) and on PATH.
+
+### Requirements
+
+- Node.js 24+
+- macOS, Linux, or Windows
+- `openssl` (for `--https` cert generation; ships with macOS and most Linux distributions; on Windows, install via `winget install -e --id ShiningLight.OpenSSL.Dev` or use the copy bundled with Git for Windows)
+- `tailscale` CLI (optional, for `--tailscale` and `--funnel`)

--- a/.claude/skills/raycast-settings/SKILL.md
+++ b/.claude/skills/raycast-settings/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: raycast-settings
+description: "Read or change Raycast Beta's settings programmatically (they live in encrypted SQLite that only Raycast's own engine can open). Use when the user wants to view or modify Raycast configuration — appearance/theme, global hotkey, window mode, pop-to-root timeout, open-at-login, menu-bar visibility, navigation bindings, hyper key, favicon provider, MCP servers, per-command settings, or any user_defaults value. Trigger phrases: 'change my Raycast setting', 'set Raycast appearance/hotkey/window mode', 'read my Raycast settings', 'what's my Raycast X set to', 'toggle Raycast open at login', 'edit Raycast config'."
+---
+
+# raycast-settings — read/write Raycast Beta's encrypted settings
+
+Raycast Beta stores settings in **fully page-encrypted** SQLite DBs (custom
+SQLite3MultipleCiphers cipher, 12 reserved bytes/page) under
+`~/Library/Application Support/com.raycast-x.macos/`. No off-the-shelf SQLite tool
+can open them — only Raycast's own Rust napi addon, which the CLI here drives.
+
+**Tool:** `~/git/setup/raycast-settings-agent/raycast-settings.cjs` (Node CJS).
+Full docs + key facts: `~/git/setup/raycast-settings-agent/README.md`.
+
+## When to use
+
+- User wants to **read** a Raycast setting ("what's my pop-to-root timeout?", "show my Raycast settings", "list my MCP servers").
+- User wants to **change** a Raycast setting ("set appearance to dark", "turn off open at login", "change window mode to default").
+
+If the user is talking about Raycast *v2 stable* (`com.raycast.macos`, not Beta) this tool is pointed at Beta — confirm before using.
+
+## How to run
+
+```sh
+cd ~/git/setup/raycast-settings-agent
+```
+
+### Reads (safe anytime — even while Raycast is running; run on a temp copy)
+
+```sh
+node raycast-settings.cjs status                 # DB health + key check
+node raycast-settings.cjs get general            # all general settings (default)
+node raycast-settings.cjs get mcp                # MCP servers
+node raycast-settings.cjs get commands           # per-command settings
+node raycast-settings.cjs get extensions         # node-extension settings
+node raycast-settings.cjs ud-get <key>           # a user_defaults value
+node raycast-settings.cjs list-types             # settable Types + current values (for `set`)
+node raycast-settings.cjs list-commands [filter] # command ids + hotkeys (for `hotkey-set`)
+node raycast-settings.cjs hotkey-list            # all command hotkeys (chord + command id)
+node raycast-settings.cjs mcp-list               # MCP servers
+node raycast-settings.cjs apply-hyper-layout --dry-run   # preview the Hyper-key scheme
+```
+
+### Writes (need Raycast quit; `--restart` auto quits + relaunches)
+
+```sh
+node raycast-settings.cjs set <Type> <jsonValue> --restart
+node raycast-settings.cjs ud-set <key> <jsonValue> --restart
+node raycast-settings.cjs ud-delete <key> --restart
+
+# command hotkeys
+node raycast-settings.cjs hotkey-set <commandId> <chord> --restart   # add or update
+node raycast-settings.cjs hotkey-clear <commandId> --restart
+node raycast-settings.cjs apply-hyper-layout --restart               # built-in scheme
+
+# themes (no special cmd — use the theme id)
+node raycast-settings.cjs set ThemeLightId '"<id>"' --restart
+node raycast-settings.cjs set ThemeDarkId  '"<id>"' --restart
+
+# MCP servers
+node raycast-settings.cjs mcp-upsert '<json>' --restart
+
+# extensions / aliases / cloud sync / themes
+node raycast-settings.cjs ext-list                                   # (read) extensions + on/off
+node raycast-settings.cjs ext-disable <extId> --restart              # ext-enable / ext-pref <id> <key> <json>
+node raycast-settings.cjs alias-set <commandId> <alias> --restart    # alias-clear / cmd-enable / cmd-disable
+node raycast-settings.cjs cloud-sync                                 # (read); cloud-sync-set <bool> --restart
+node raycast-settings.cjs theme-list                                 # (read); theme-add '<json>' / theme-rm <id>
+
+# anything else (content: snippets, quicklinks, notes, ai, clipboard, calculator, ...)
+node raycast-settings.cjs repos                                      # list repositories
+node raycast-settings.cjs repo <repo> [method] [json...]             # e.g. repo snippets list ; repo quicklinks insertOne '<json>' --restart
+```
+
+Coverage: General/Launcher/Keyboard/Advanced (`set`/`list-types`), Shortcuts
+(`hotkey-*`), aliases & enable/disable (`alias-*`/`cmd-*`/`ext-*`), MCP, Cloud
+Sync, themes, and ALL content repos via `repo`. Read methods (all/list/get/count/
+search) are safe anytime; everything else needs Raycast quit (`--restart`).
+
+**Hotkeys:** run `hotkey-list` to find the `commandId` (e.g.
+`c:r:window-management::-::leftHalf`, `c:r:applications::*::application::=::/Applications/Ghostty.app`).
+**Chords:** `hyper` (= Ctrl+Alt+Meta, this user's Hyper key), `cmd`, `ctrl`,
+`alt`, `shift`, `meh` + a key, e.g. `hyper+h`, `shift+hyper+m`,
+`ctrl+alt+meta+return`. `apply-hyper-layout` writes the user's standard scheme
+(apps→Hyper+G/Z/S/D, halves→H/L/J/K, maximize→Return, quarters→U/I/N/M);
+edit `HYPER_LAYOUT` in the .cjs to change it.
+
+Examples:
+```sh
+node raycast-settings.cjs set Appearance '"dark"' --restart
+node raycast-settings.cjs set OpenAtLogin false --restart
+node raycast-settings.cjs set PopToRootTimeout 60 --restart
+```
+
+## Rules
+
+1. **Always `get general` first** before a write, to confirm the exact Type name
+   and current value, and to echo the before/after to the user.
+2. Setting **Types** are PascalCase keys from `get general`, e.g.: `Appearance`,
+   `GlobalHotkey`, `OpenAtLogin`, `ShowInMenuBar`, `WindowMode`,
+   `WindowActivationBehavior`, `PopToRootTimeout`, `NavigationBindings`,
+   `PageNavigationKeys`, `RootSearchSensitivity`, `EscapeKeyBehavior`,
+   `EscapeKeyClosesWindow`, `FaviconProvider`, `BuiltinHotkeysPreset`,
+   `HyperKeyCode`, `HyperKeyCapsLockAction`, `HyperKeyIncludeShift`,
+   `AdditionalCertificateAuthorities`, `UseSystemProxySettings`.
+3. `value` is **JSON**: `'"dark"'` (string), `60` (number), `false` (bool), or a
+   nested object (e.g. `GlobalHotkey`). Mirror the shape from `get general`.
+4. **Writes quit Raycast.** Use `--restart` so it relaunches. Warn the user it
+   will briefly restart Raycast. Without `--restart` the tool refuses while
+   Raycast is running.
+5. After a write, re-run `get general` (or the relevant `get`) to confirm it
+   stuck, and report the new value.
+6. If `status` reports a **key mismatch** (Raycast rotated the DB key, or after a
+   Raycast upgrade), run `node raycast-settings.cjs capture-key` — it restarts
+   Raycast once, captures the key, and stores it in the keychain automatically.
+
+## Notes
+
+- Reads never touch live data (they copy the DBs to a temp dir first).
+- Verified: after a `--restart` write, Raycast keeps the externally-written value.
+- The DB key is in the login keychain (`raycast-edit` / `com.raycast-x.macos`),
+  put there by `capture-key`; override with `RAYCAST_EDIT_KEY`. It is NOT a plain
+  keychain value Raycast exposes — it's captured from Raycast's backend at launch.
+- This tool is also packaged for OSS as `raycast-edit` (npm/npx); the local skill
+  invokes it as `node raycast-settings.cjs`.

--- a/.claude/skills/use-railway/SKILL.md
+++ b/.claude/skills/use-railway/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: use-railway
+description: >
+  Operate Railway infrastructure: create projects, provision services and
+  databases, manage object storage buckets, deploy code, configure environments
+  and variables, manage domains, troubleshoot failures, check status and metrics,
+  and query Railway docs. Use this skill whenever the user mentions Railway,
+  deployments, services, environments, buckets, object storage, build failures,
+  or infrastructure operations, even if they don't say "Railway" explicitly.
+allowed-tools: Bash(railway:*), Bash(which:*), Bash(command:*), Bash(npm:*), Bash(npx:*), Bash(curl:*), Bash(python3:*)
+---
+
+# Use Railway
+
+## Railway resource model
+
+Railway organizes infrastructure in a hierarchy:
+
+- **Workspace** is the billing and team scope. A user belongs to one or more workspaces.
+- **Project** is a collection of services under one workspace. It maps to one deployable unit of work.
+- **Environment** is an isolated configuration plane inside a project (for example, `production`, `staging`). Each environment has its own variables, config, and deployment history.
+- **Service** is a single deployable unit inside a project. It can be an app from a repo, a Docker image, or a managed database.
+- **Bucket** is an S3-compatible object storage resource inside a project. Buckets are created at the project level and deployed to environments. Each bucket has credentials (endpoint, access key, secret key) for S3-compatible access.
+- **Deployment** is a point-in-time release of a service in an environment. It has build logs, runtime logs, and a status lifecycle.
+
+Most CLI commands operate on the linked project/environment/service context. Use `railway status --json` to see the context, and `--project`, `--environment`, `--service` flags to override.
+
+## Parsing Railway URLs
+
+Users often paste Railway dashboard URLs. Extract IDs before doing anything else:
+
+```
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>?environmentId=<ENV_ID>
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>
+```
+
+The URL always contains `projectId` and `serviceId`. It may contain `environmentId` as a query parameter. If the environment ID is missing and the user specifies an environment by name (e.g., "production"), resolve it:
+
+```bash
+scripts/railway-api.sh \
+  'query getProject($id: String!) {
+    project(id: $id) {
+      environments { edges { node { id name } } }
+    }
+  }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Match the environment name (case-insensitive) to get the `environmentId`.
+
+**Prefer passing explicit IDs** to CLI commands (`--project`, `--environment`, `--service`) and scripts (`--project-id`, `--environment-id`, `--service-id`) instead of running `railway link`. This avoids modifying global state and is faster.
+
+## Preflight
+
+Before any mutation, verify context:
+
+```bash
+command -v railway                # CLI installed
+RAILWAY_CALLER="skill:use-railway@1.1.3" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+railway --version                 # check CLI version
+```
+
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.1.3` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight just for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+
+**Context resolution — URL IDs always win:**
+- If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.
+- If no URL is given, fall back to `railway status --json` for the linked project/environment/service.
+
+If the CLI is missing, guide the user to install it.
+
+```bash
+bash <(curl -fsSL cli.new) # Shell script (macOS, Linux, Windows via WSL)
+brew install railway # Homebrew (macOS)
+npm i -g @railway/cli # npm (macOS, Linux, Windows). Requires Node.js version 16 or higher.
+```
+
+If not authenticated, run `railway login`. If not linked and no URL was provided, run `railway link --project <id-or-name>`.
+
+If a command is not recognized (for example, `railway environment edit`), the CLI may be outdated. Upgrade with:
+
+```bash
+railway upgrade
+```
+
+## Common quick operations
+
+These are frequent enough to handle without loading a reference:
+
+```bash
+railway status --json                                    # current context
+railway whoami --json                                    # auth and workspace info
+railway project list --json                              # list projects
+railway service status --all --json                      # all services in current context
+railway variable list --service <svc> --json             # list variables
+railway variable set KEY=value --service <svc>           # set a variable
+railway logs --service <svc> --lines 200 --json          # recent logs
+railway up --detach -m "<summary>"                       # deploy current directory
+railway bucket list --json                               # list buckets in current environment
+railway bucket info --bucket <name> --json               # bucket storage and object count
+railway bucket credentials --bucket <name> --json        # S3-compatible credentials
+```
+
+When using these commands from the skill, keep the command shape but prefix the Railway invocation with the telemetry env, for example:
+
+```bash
+RAILWAY_CALLER="skill:use-railway@1.1.3" RAILWAY_AGENT_SESSION="railway-skill-20260508-1234" railway status --json
+```
+
+## Routing
+
+For anything beyond quick operations, load the reference that matches the user's intent. Load only what you need, one reference is usually enough, two at most.
+
+| Intent | Reference | Use for |
+|---|---|---|
+| **Analyze a database** ("analyze \<url\>", "analyze db", "analyze database", "analyze service", "introspect", "check my postgres/redis/mysql/mongo") | [analyze-db.md](references/analyze-db.md) | Database introspection and performance analysis. analyze-db.md directs you to the DB-specific reference. **This takes priority over the status/operate routes when a Railway URL to a database service is provided alongside "analyze".** |
+| Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
+| Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
+| Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
+| Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
+| Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
+
+If the request spans two areas (for example, "deploy and then check if it's healthy"), load both references and compose one response.
+
+## Execution rules
+
+1. Prefer Railway CLI. Fall back to `scripts/railway-api.sh` for operations the CLI doesn't expose.
+2. Use `--json` output where available for reliable parsing.
+3. Resolve context before mutation. Know which project, environment, and service you're acting on.
+4. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
+5. After mutations, verify the result with a read-back command.
+
+## User-only commands (NEVER execute directly)
+
+These commands modify database state and require the user to run them directly in their terminal. **Do NOT execute these with Bash. Instead, show the command and ask the user to run it.**
+
+| Command | Why user-only |
+|---------|---------------|
+| `python3 scripts/enable-pg-stats.py --service <name>` | Modifies shared_preload_libraries, may restart database |
+| `python3 scripts/pg-extensions.py --service <name> install <ext>` | Installs database extension |
+| `python3 scripts/pg-extensions.py --service <name> uninstall <ext>` | Removes database extension |
+| `ALTER SYSTEM SET ...` | Changes PostgreSQL configuration |
+| `DROP EXTENSION ...` | Removes database extension |
+| `CREATE EXTENSION ...` | Installs database extension |
+
+When these operations are needed:
+1. Explain what the command does and any side effects (e.g., restart required)
+2. Show the exact command the user should run
+3. Wait for user confirmation that they ran it
+4. Verify the result with a read-only query
+
+## Composition patterns
+
+Multi-step workflows follow natural chains:
+
+- **Add object storage**: setup (create bucket), setup (get credentials), configure (set S3 variables on app service)
+- **First deploy**: setup (create project + service), configure (set variables and source), deploy, operate (verify healthy)
+- **Fix a failure**: operate (triage logs), configure (fix config/variables), deploy (redeploy), operate (verify recovery)
+- **Add a domain**: configure (add domain + set port), operate (verify DNS and service health)
+- **Docs to action**: request (fetch docs answer), route to the relevant operational reference
+
+When composing, return one unified response covering all steps. Don't ask the user to invoke each step separately.
+
+## Setup decision flow
+
+When the user wants to create or deploy something, determine the right action from current context:
+
+1. Run `railway status --json` in the current directory.
+2. **If linked**: add a service to the existing project (`railway add --service <name>`). Do not create a new project unless the user explicitly says "new project" or "separate project".
+3. **If not linked**: check the parent directory (`cd .. && railway status --json`).
+   - **Parent linked**: this is likely a monorepo sub-app. Add a service and set `rootDirectory` to the sub-app path.
+   - **Parent not linked**: run `railway list --json` and look for a project matching the directory name.
+     - **Match found**: link to it (`railway link --project <name>`).
+     - **No match**: create a new project (`railway init --name <name>`).
+4. When multiple workspaces exist, match by name from `railway whoami --json`.
+
+**Naming heuristic**: app names like "flappy-bird" or "my-api" are service names, not project names. Use the directory or repo name for the project.
+
+## Response format
+
+For all operational responses, return:
+1. What was done (action and scope).
+2. The result (IDs, status, key output).
+3. What to do next (or confirmation that the task is complete).
+
+Keep output concise. Include command evidence only when it helps the user understand what happened.

--- a/.claude/skills/use-railway/references/analyze-db-mongo.md
+++ b/.claude/skills/use-railway/references/analyze-db-mongo.md
@@ -1,0 +1,84 @@
+# MongoDB Analysis
+
+This reference covers MongoDB-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+### What the Script Collects
+
+**Via SSH (mongosh):**
+- **Server Status:** version, storage engine, uptime, connections, opcounters, latency, memory, network, WiredTiger cache/checkpoint/tickets, global lock queues, document operations, query efficiency, cursors, TTL, asserts
+- **DB Stats:** dataSize, storageSize, indexSize, object count, collection count
+- **Collection Stats:** per-collection document count, size, storage size, index size, index count
+- **Current Operations:** active ops with type, namespace, duration
+- **Slow Queries:** from system.profile (if profiling enabled) — op, namespace, duration, plan summary
+- **Replication Info:** oplog size, usage, time window
+- **Top Collections:** per-collection read/write counts and time from `top` admin command
+
+**Via Railway API:** Same infrastructure metrics.
+
+### MongoDB Performance Patterns
+
+**WiredTiger Cache Pressure Pattern:**
+- Cache usage > 80% + app thread evictions > 0 = cache too small for working set
+- Dirty cache > 20% of total = checkpoint falling behind, writes accumulating
+- Read/write tickets depleted = operations queueing at storage engine level
+- Fix: increase service RAM (WiredTiger uses ~50% of available RAM for cache)
+
+**Query Efficiency Pattern:**
+- `scannedObjects >> docsReturned` = collection scans, missing indexes
+- Plan cache misses >> hits = frequent query re-planning, add indexes
+- Sort spill to disk > 0 = sorts exceeding 100MB memory limit, needs index
+
+**Connection Saturation Pattern:**
+- `connectionsCurrent` approaching `connectionsAvailable` = connection pool exhaustion
+- Many active ops with high microsecs_running = slow queries holding connections
+- Queued readers/writers > 0 = global lock contention
+
+**Oplog Pressure Pattern:**
+- Oplog usage > 80% = replication window shrinking
+- High write rate + small oplog = replicas may fall out of sync
+- timeDiffHours < 1 on busy systems = risk of replica resync
+
+### MongoDB Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| WT cache usage | <70% | 70-85% | >85% |
+| WT dirty % | <5% | 5-20% | >20% |
+| App thread evictions | 0 | 1-100 | >100 |
+| Connection usage | <70% | 70-85% | >85% |
+| Queued operations | 0 | 1-10 | >10 |
+| Scan-to-return ratio | <2x | 2-10x | >10x |
+
+## Infrastructure (7d + 24h)
+
+Show both windows side by side to compare trends:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.02 vCPU | 0.02 | 0.00 | 0.12 | stable |
+| Memory | 210 MB | 200 MB | 180 MB | 240 MB | stable |
+| Disk | 1.5 GB | 1.48 GB | 1.42 GB | 1.55 GB | increasing (+6%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.03 vCPU | 0.02 | 0.00 | 0.12 | stable |
+| Memory | 210 MB | 205 MB | 195 MB | 240 MB | stable |
+| Disk | 1.5 GB | 1.49 GB | 1.48 GB | 1.51 GB | stable |
+
+Compare windows to distinguish sustained vs transient trends.
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+## MongoDB Autoscale Note
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For MongoDB specifically:
+- WiredTiger uses ~50% of available RAM for cache by default. As Railway auto-scales the container, the cache ceiling grows automatically.
+- Do NOT recommend limiting WiredTiger cache to a fraction of the Railway memory limit — the limit is the autoscale ceiling, not fixed allocation.
+- If cache usage is consistently >80%, this indicates working set pressure — note it but do not tell the user to increase RAM manually.
+
+## Validated against
+
+- MongoDB serverStatus, db.stats(), system.profile, top admin command

--- a/.claude/skills/use-railway/references/analyze-db-mysql.md
+++ b/.claude/skills/use-railway/references/analyze-db-mysql.md
@@ -1,0 +1,254 @@
+# MySQL Analysis
+
+This reference covers MySQL-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**Via SSH (mysql -B):**
+- **SHOW GLOBAL STATUS:** threads connected/running, max used connections, query counts (select/insert/update/delete), InnoDB buffer pool stats, row lock waits/time, bytes sent/received, temp table stats, handler stats, table lock stats, aborted clients/connects
+- **SHOW VARIABLES:** max_connections, innodb_buffer_pool_size, long_query_time, version
+- **Table Sizes:** per-table rows, data length, index length, total size (top 15)
+- **Processlist:** active queries with user, database, command, time, state
+- **Top Queries (performance_schema):** digest text, call count, avg/total latency, rows examined/sent, temp disk tables, no-index flag
+
+**Via Railway API:** Same infrastructure metrics (CPU, memory, disk, network).
+
+## MySQL Metric Sections — Present ALL of These
+
+When the script returns MySQL data, present **every section below** with its metrics. This matches the full MySQL metrics view. Don't skip sections — if data is present, show it.
+
+### 1. Overview
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Version | `overview.version` | As-is |
+| Uptime | `overview.uptime_seconds` | Format as Xd Xh Xm |
+| Connections | `overview.connection_usage_percent` | `XX%` with `threads_connected / max_connections` as sub-value |
+| Threads Running | `overview.threads_running` | As-is |
+| Aborted Clients | `overview.aborted_clients` | Warn if > 0 — apps not closing connections |
+| Aborted Connects | `overview.aborted_connects` | Warn if > 0 — auth failures or limit hits |
+
+**Presentation:**
+```
+| Metric | Value | Status |
+|--------|-------|--------|
+| Version | 9.4.0 | |
+| Uptime | 3d 12h | |
+| Connections | 45% (9 / 20) | OK |
+| Threads Running | 2 | |
+| Aborted Clients | 0 | OK |
+| Aborted Connects | 0 | OK |
+```
+
+### 2. Query Throughput
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Total Queries | `query_throughput.questions` | Format with K/M suffix |
+| Slow Queries | `query_throughput.slow_queries` | Warn if > 0, show threshold from `long_query_time` |
+| SELECT | `query_throughput.com_select` | Format with K/M suffix |
+| INSERT | `query_throughput.com_insert` | Format with K/M suffix |
+| UPDATE | `query_throughput.com_update` | Format with K/M suffix |
+| DELETE | `query_throughput.com_delete` | Format with K/M suffix |
+
+Show the query mix distribution. A healthy OLTP workload is SELECT-heavy. INSERT/UPDATE-heavy suggests write pressure.
+
+### 3. InnoDB Row Operations
+
+| Metric | JSON Path |
+|--------|-----------|
+| Rows Read | `innodb_row_ops.rows_read` |
+| Rows Inserted | `innodb_row_ops.rows_inserted` |
+| Rows Updated | `innodb_row_ops.rows_updated` |
+| Rows Deleted | `innodb_row_ops.rows_deleted` |
+
+These are cumulative since server start. Compare read vs write ratios. A read-heavy workload with low row reads may indicate queries returning few results (good) or not using indexes (bad — cross-reference with table scan ratio).
+
+### 4. Query Efficiency
+
+| Metric | JSON Path | How to Interpret |
+|--------|-----------|------------------|
+| Temp Tables to Disk | `query_efficiency.tmp_disk_table_percent` | `XX%` (disk/total). > 10% = queries creating large temp results |
+| Table Scan Ratio | `query_efficiency.table_scan_percent` | `XX%`. > 50% = most reads are full scans — missing indexes |
+| Full Joins | `query_efficiency.select_full_join` | Warn if > 0. Joins without indexes — extremely expensive |
+| Range Selects | `query_efficiency.select_range` | Index range scans (good). Higher is better relative to full scans |
+| Sort Merge Passes | `query_efficiency.sort_merge_passes` | Warn if > 0. Sorts exceeding `sort_buffer_size` |
+
+**This section is critical for identifying missing indexes.** If table scan ratio is high AND specific top queries show `no_index_used > 0`, you can give precise index recommendations.
+
+### 5. InnoDB Buffer Pool
+
+| Metric | JSON Path | How to Display |
+|--------|-----------|----------------|
+| Cache Hit Ratio | `innodb_buffer_pool.hit_ratio` | `XX.X%`. The most important single metric |
+| Pool Usage | `innodb_buffer_pool.usage_percent` | `XX.X%` with `bytes_data / buffer_pool_size` as sub-value |
+| Data | `innodb_buffer_pool.bytes_data` | Format as MB/GB |
+| Dirty | `innodb_buffer_pool.bytes_dirty` | Format as MB/GB. Warn if significant |
+| Free Pages | `innodb_buffer_pool.pages_free` | Format with K/M suffix |
+
+**Analysis guidance:**
+- Hit ratio < 99% + usage > 95% = buffer pool too small for the working set
+- Hit ratio < 95% = severe cache pressure — increase `innodb_buffer_pool_size`
+- Dirty pages are modified pages not yet flushed to disk — high dirty count means heavy writes or slow I/O
+
+### 6. InnoDB I/O
+
+| Metric | JSON Path |
+|--------|-----------|
+| Data Reads | `innodb_io.data_reads` |
+| Data Writes | `innodb_io.data_writes` |
+
+Only show this section if reads or writes > 0. High data reads with low buffer pool hit ratio = cache misses causing disk I/O.
+
+### 7. Network
+
+| Metric | JSON Path |
+|--------|-----------|
+| Bytes Received | `network.bytes_received` |
+| Bytes Sent | `network.bytes_sent` |
+
+Format as KB/MB/GB. High bytes sent relative to received suggests large result sets being returned.
+
+### 8. Locks
+
+| Metric | JSON Path | How to Interpret |
+|--------|-----------|------------------|
+| Row Lock Waits | `locks.row_lock_waits` | Warn if > 0. InnoDB row-level lock contention |
+| Row Lock Time (ms) | `locks.row_lock_time` | Total time spent waiting for row locks |
+| Table Lock Waits | `locks.table_locks_waited` | Warn if > 0. Table-level lock contention |
+| Table Lock Contention | `locks.table_lock_contention` | `XX.X%` (waited / total). > 1% = investigate |
+
+Lock contention + long-running queries in processlist = transactions holding locks too long. Check for MyISAM tables if table lock contention is high.
+
+### 9. Table Cache
+
+| Metric | JSON Path |
+|--------|-----------|
+| Open Tables | `table_cache.open_tables` |
+| Opened Tables | `table_cache.opened_tables` |
+| Cache Hit % | `table_cache.cache_hit_percent` |
+
+Low cache hit = table_open_cache may be too small. Many opened_tables relative to open_tables means tables are being repeatedly opened and closed.
+
+### 10. Top Queries (from performance_schema)
+
+**This is the most actionable section.** Present as a table:
+
+```
+| Query | Calls | Avg Latency | Total Latency | Rows Examined | Rows Sent | Flags |
+|-------|-------|-------------|---------------|---------------|-----------|-------|
+| SELECT ... FROM orders WHERE... | 15.2K | 2.3ms | 35.1s | 1.2M | 15.2K | |
+| SELECT ... FROM users JOIN... | 8.1K | 12.5ms | 101.3s | 890K | 8.1K | ! No Index |
+```
+
+**Per-query analysis:**
+- `no_index_used > 0` → Flag with "! No Index" — these are the biggest optimization targets
+- `tmp_disk_tables > 0` → Query creates on-disk temp tables — needs optimization
+- High `rows_examined / rows_sent` ratio → Scanning many rows to return few — missing or suboptimal index
+- Truncate query text to essential parts (tables, WHERE clauses, JOINs). Don't dump full ORM SQL.
+
+**If `top_queries` is empty or null:** performance_schema is likely disabled — this is the default on Railway. Do not suggest enabling it without caveats: it requires ~400MB+ additional memory and is only advisable on larger instances. Just note that query-level data is unavailable.
+
+### 11. Tables
+
+```
+| Table | Rows | Data | Indexes | Total |
+|-------|------|------|---------|-------|
+| orders | 1.2M | 450 MB | 120 MB | 570 MB |
+| users | 50K | 12 MB | 8 MB | 20 MB |
+```
+
+Flag tables where index size is disproportionately large relative to data (possible unused indexes) or tables with many rows but no indexes (check with top queries).
+
+### 12. Active Queries
+
+Show if any non-Sleep, non-Daemon processes are running:
+
+```
+| User | Database | Command | Time (s) | Query |
+|------|----------|---------|----------|-------|
+| app | mydb | Query | 45 | SELECT ... |
+```
+
+Long-running queries (> 30s) warrant investigation. Cross-reference with lock waits — a long query may be holding locks that block others.
+
+## MySQL Performance Patterns
+
+**Buffer Pool Starvation Pattern:**
+- Hit ratio < 99% + pool usage > 95% = buffer pool too small for working set
+- High `Innodb_data_reads` confirms disk I/O from cache misses
+- Fix: increase `innodb_buffer_pool_size` (target 70-80% of available RAM)
+
+**Query Inefficiency Pattern:**
+- Table scan ratio > 50% = most reads are full scans, missing indexes
+- `Select_full_join` > 0 = joins without indexes, extremely expensive
+- Temp tables to disk > 10% = sorts/groups exceeding `tmp_table_size`
+- Top queries with `no_index_used > 0` = specific queries needing indexes
+
+**Lock Contention Pattern:**
+- `row_lock_waits` high + `row_lock_time` high = write contention
+- Table lock contention > 1% = may have MyISAM tables or DDL locks
+- Long-running queries in processlist holding locks
+
+**Connection Pattern:**
+- `connection_usage_percent > 70%` = approaching limit
+- `aborted_clients > 0` = connections not being closed properly (app bug or timeout)
+- `aborted_connects > 0` = authentication failures or connection limit hits
+
+## MySQL Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Buffer pool hit ratio | > 99% | 95-99% | < 95% |
+| Buffer pool usage | < 85% | 85-95% | > 95% |
+| Connection usage | < 70% | 70-90% | > 90% |
+| Temp tables to disk | < 10% | 10-25% | > 25% |
+| Table scan ratio | < 50% | 50-75% | > 75% |
+| Table lock contention | < 1% | 1-5% | > 5% |
+| Full joins | 0 | 1-100 | > 100 |
+| Sort merge passes | 0 | > 0 | — |
+
+## MySQL Tuning Knowledge
+
+| Parameter | Default | Target | What It Does |
+|-----------|---------|--------|--------------|
+| `innodb_buffer_pool_size` | 128MB | 70-80% RAM | InnoDB's main cache. Equivalent to PostgreSQL's shared_buffers but should be much larger (70-80% vs 25%). |
+| `max_connections` | 151 | Based on load | Each connection uses memory. Over-provisioning wastes RAM. |
+| `tmp_table_size` / `max_heap_table_size` | 16MB | 64-256MB | Max size for in-memory temp tables. Larger = fewer disk temp tables. Both must be set together. |
+| `sort_buffer_size` | 256KB | 1-4MB | Per-connection sort buffer. Too large wastes memory (multiplied by connections). |
+| `long_query_time` | 10s | 1-2s | Threshold for slow query log. Lower = more visibility but more log volume. |
+| `table_open_cache` | 4000 | Based on tables | Number of open tables cached. Increase if `Opened_tables` grows rapidly. |
+
+## MySQL-Specific Notes
+
+- **`performance_schema=0` in start command** disables query-level metrics. This is the default on Railway. Note it when detected but do not recommend enabling it without caveats — it adds ~400MB+ memory overhead and is only practical on larger instances (2GB+ RAM).
+- **`disable-log-bin` in start command** means no binary logging — point-in-time recovery is not possible. Note if relevant.
+- **`innodb-use-native-aio=0`** is common on Railway (container filesystem limitation). Not a concern.
+- **Cumulative counters**: All SHOW GLOBAL STATUS values are cumulative since server start. Use uptime to compute rates (e.g., questions/uptime = queries per second).
+
+## Infrastructure (7d + 24h)
+
+Show both windows side by side to compare trends:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.03 vCPU | 0.02 | 0.00 | 0.15 | stable |
+| Memory | 480 MB | 460 MB | 420 MB | 510 MB | stable |
+| Disk | 2.8 GB | 2.7 GB | 2.6 GB | 2.9 GB | increasing (+8%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.05 vCPU | 0.03 | 0.00 | 0.15 | stable |
+| Memory | 480 MB | 465 MB | 450 MB | 510 MB | stable |
+| Disk | 2.8 GB | 2.78 GB | 2.75 GB | 2.81 GB | stable |
+
+Compare windows to distinguish sustained vs transient trends.
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+## Validated against
+
+- MySQL SHOW GLOBAL STATUS, SHOW VARIABLES, information_schema, performance_schema

--- a/.claude/skills/use-railway/references/analyze-db-postgres.md
+++ b/.claude/skills/use-railway/references/analyze-db-postgres.md
@@ -1,0 +1,479 @@
+# PostgreSQL Analysis
+
+This reference covers PostgreSQL-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**`collection_status`** — check this FIRST. Shows what succeeded vs failed:
+- `database_query`: SSH → psql batched query (connections, cache, vacuum, queries, etc.)
+- `metrics_api`: Railway API for disk, CPU, memory
+- `logs_api`: Railway API for recent log lines
+- `ha_cluster`: SSH → Patroni REST API (HA services only)
+
+Each entry has `"status"` (`"success"`, `"error"`, or `"skipped"`) and optional `"error"` or `"reason"` fields.
+
+All in ONE operation (no additional queries needed):
+
+**Connections:**
+- Current/max/available counts
+- States (active, idle, idle_in_transaction)
+- By application name
+- By age (buckets: <1min, 1-5min, 5-60min, 1-24hr, >24hr)
+- Oldest connection age
+
+**Memory & Configuration:**
+- shared_buffers, effective_cache_size, work_mem, maintenance_work_mem
+- WAL settings, parallelism settings, planner settings
+- Autovacuum status
+- track_activity_query_size (tells you if queries are truncated in pg_stat_statements)
+- log_min_duration_statement (tells you if slow query logging is enabled and at what threshold)
+- idle_in_transaction_session_timeout, statement_timeout (safety timeouts)
+- track_io_timing (needed for blk_read_time/blk_write_time in query stats)
+
+**Cache Performance:**
+- Overall table/index hit ratios
+- Per-table: hit %, disk reads, size (this is key for diagnosis)
+
+**Storage:**
+- Database size, WAL size
+- Per-table: total size, data size, index size, row count
+
+**Vacuum Health:**
+- Per-table: dead rows, dead %, vacuum count, last vacuum/analyze, XID age
+- Flags: needs_vacuum, needs_freeze
+
+**Indexes:**
+- Unused indexes (0 scans) with sizes
+- Invalid indexes (failed builds)
+
+**Query Performance (if pg_stat_statements enabled):**
+- Top 100 queries by total execution time
+- Per-query execution: calls, total_min, mean_ms, min_ms, max_ms, stddev_ms
+- Per-query rows: total rows, rows_per_call
+- Per-query planning: total_plan_ms, mean_plan_ms
+- Per-query cache: shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, cache_hit_pct
+- Per-query temp: temp_blks_read, temp_blks_written
+- Per-query I/O timing: blk_read_time_ms, blk_write_time_ms (requires track_io_timing=on)
+- Per-query WAL: wal_records, wal_bytes
+- Per-query local blocks: local_blks_hit, local_blks_read (for temp tables)
+- Temp file stats (cumulative since stats reset, NOT current disk usage)
+
+**Logs & Active Issues:**
+- `recent_logs`: Raw unfiltered logs (1000 lines) - parse these yourself, look for errors, warnings, patterns
+- `recent_errors`: Filtered error-level logs (legacy, for quick reference)
+- `long_running_queries`: Queries running >5s at time of collection
+- `blocked_queries`: Queries waiting on locks
+- `cluster_logs`: HA cluster events (Patroni)
+
+**Important:** Always analyze the raw `recent_logs` array thoroughly. This is 1000 lines of unfiltered database output — treat it as a goldmine.
+
+**Log analysis checklist — go through ALL of these:**
+
+1. **Error/Fatal/Panic messages**: Count them, categorize them, quote the exact messages
+   - `ERROR: deadlock detected` → cross-reference with deadlock count in database_stats
+   - `FATAL: too many connections` → cross-reference with connection usage
+   - `ERROR: canceling statement due to statement timeout` → which queries are timing out?
+   - `FATAL: out of shared memory` → shared_buffers or lock table exhaustion
+   - `ERROR: could not extend file` → disk space issue
+   - `PANIC: ...` → database crash, investigate immediately
+
+2. **Slow query log entries** (if `log_min_duration_statement` is set):
+   - Count how many slow queries appear
+   - Identify which tables/queries are mentioned most often
+   - Cross-reference with top_queries — the same patterns should appear in both
+   - Note the actual durations logged vs mean_ms from pg_stat_statements
+
+3. **Autovacuum activity**:
+   - `LOG: automatic vacuum of table` → is autovacuum running? How often?
+   - `LOG: automatic analyze of table` → statistics being updated
+   - `WARNING: oldest xmin is far in the past` → XID wraparound risk
+   - Absence of autovacuum entries with high dead rows → autovacuum may be blocked or misconfigured
+
+4. **Checkpoint activity**:
+   - `LOG: checkpoint starting` / `LOG: checkpoint complete` → how frequent?
+   - `checkpoint complete: wrote X buffers (Y%)` → high Y% means lots of dirty data
+   - Time between checkpoints — if < 5 minutes, write load is high
+   - `checkpoints are occurring too frequently` → increase max_wal_size
+
+5. **Connection patterns**:
+   - `LOG: connection received` / `LOG: connection authorized` → connection rate
+   - `LOG: disconnection` → normal or unexpected? Check session duration
+   - `FATAL: remaining connection slots are reserved` → max_connections hit
+   - `FATAL: password authentication failed` → unauthorized access attempts
+
+6. **Replication messages**:
+   - `LOG: started streaming WAL` → replica connected
+   - `ERROR: requested WAL segment has already been removed` → replica too far behind
+   - `FATAL: could not receive data from WAL stream` → replication broken
+
+7. **Temporal patterns**:
+   - Are errors clustered in time? (burst vs steady)
+   - Do slow queries correlate with checkpoint times?
+   - Is there a pattern suggesting cron jobs or batch processing?
+
+State what you found with specifics: "Analyzed 1000 log lines covering 2024-01-15 14:00 to 15:30. Found: 23 slow query warnings (all SELECT on UserSession table, 200-800ms), 4 autovacuum runs, 2 checkpoints (normal interval), 0 errors. The slow queries correlate with the UserSession table's 76% cache hit rate."
+
+### Log Interpretation When Only Logs Are Available
+
+When `collection_status.database_query` failed and you only have logs:
+
+**Startup vs steady-state logs:**
+- `LOG: database system is ready to accept connections` — normal startup, NOT evidence of a crash
+- `LOG: started streaming WAL` — normal replication, NOT an error
+- `LOG: checkpoint starting` / `LOG: checkpoint complete` — routine operation
+- `FATAL: the database system is starting up` — transient during restarts, NOT a persistent problem
+
+**What you CAN say from logs alone:**
+- Whether errors or warnings are present and their frequency
+- Whether the database recently restarted (and that this is normal during deploys)
+- Whether there are connection refused errors (possible saturation or startup)
+
+**What you CANNOT say from logs alone:**
+- Whether the database is performing well or poorly
+- Whether cache hit ratios are good
+- Whether vacuum is behind
+- Whether queries are slow
+- Any tuning recommendations
+
+If only logs are available, explicitly state: "No performance conclusions possible — database metrics were not collected."
+
+**Active Issues:**
+- Long-running queries (>5s)
+- Idle in transaction (>30s)
+- Blocked queries (waiting on locks)
+- Lock contention details
+
+**Infrastructure (7d + 24h)** — show both windows so trends can be compared:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.02 vCPU | 0.02 | 0.00 | 0.18 | stable |
+| Memory | 320 MB | 290 MB | 240 MB | 380 MB | stable |
+| Disk | 4.2 GB | 4.1 GB | 3.9 GB | 4.3 GB | increasing (+8%) |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.04 vCPU | 0.02 | 0.00 | 0.18 | stable |
+| Memory | 320 MB | 295 MB | 270 MB | 340 MB | stable |
+| Disk | 4.2 GB | 4.15 GB | 4.1 GB | 4.2 GB | stable |
+
+Compare: "Disk growing slowly over 7d but stable over 24h → gradual data growth, not an acute event."
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+**Replication / HA (if applicable):**
+- Replication status
+- HA cluster status (Patroni)
+- Background writer stats
+- WAL archiver status
+
+## PostgreSQL Tuning Knowledge
+
+Use this to reason about configuration issues:
+
+### Memory Parameters
+
+| Parameter | Default | Target | What It Does |
+|-----------|---------|--------|--------------|
+| `shared_buffers` | 128MB | 25% RAM | The database's main cache. Pages read from disk go here. Too small = constant disk I/O. |
+| `effective_cache_size` | 4GB | 75% RAM | NOT memory allocation - a hint to the planner about OS cache. Too low = planner avoids indexes. |
+| `work_mem` | 4MB | 16-64MB | Memory per sort/hash/join operation. Too low = temp files on disk. Caution: multiplied by concurrent operations. |
+| `maintenance_work_mem` | 64MB | 256MB-1GB | Memory for VACUUM, CREATE INDEX. Higher = faster maintenance. |
+
+### Tuning Formulas
+
+```
+shared_buffers = RAM × 0.25 (max 40%)
+  1GB RAM  → 256MB
+  4GB RAM  → 1GB
+  16GB RAM → 4GB
+
+work_mem = (RAM / max_connections) / 4
+  4GB RAM, 100 conns → 10MB
+  8GB RAM, 200 conns → 10MB
+
+effective_cache_size = RAM × 0.75
+  4GB RAM  → 3GB
+  16GB RAM → 12GB
+```
+
+### Settings Requiring Restart vs Immediate
+
+**Restart required:**
+- shared_buffers
+- max_connections
+- max_parallel_workers
+
+**Immediate (SIGHUP):**
+- work_mem
+- effective_cache_size
+- random_page_cost
+- checkpoint_completion_target
+
+### SSD vs HDD
+
+Railway uses SSDs. If `random_page_cost = 4.0` (HDD default), the planner thinks random reads are 4x more expensive than sequential - it avoids index scans. Set to 1.1-2.0 for SSDs.
+
+### Railway auto-scales vertically
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For PostgreSQL specifically:
+
+- Tune parameters relative to the **current** RAM from `metrics_history.memory.current`, not `memory_limit`.
+- If shared_buffers is undersized relative to current RAM, recommend increasing it to 25% of current RAM.
+- If the working set far exceeds what 25% of current RAM can hold, note this as a limitation of the current memory footprint — but do NOT tell the user to increase RAM. The platform handles that automatically.
+
+## Thresholds for Reasoning
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Cache hit ratio | >99% | 95-99% | <95% |
+| Per-table cache hit | >95% | 80-95% | <80% with high reads |
+| Connection usage | <70% | 70-90% | >90% |
+| Disk usage | <70% | 70-85% | >85% |
+| Dead rows % | <5% | 5-20% | >20% |
+| XID age | <100M | 100-150M | >150M (emergency at 2B) |
+
+### Vacuum Priority Matrix
+
+Dead row percentage alone doesn't determine urgency. Use this matrix:
+
+| Table Size | Dead Rows | Priority |
+|------------|-----------|----------|
+| > 100 MB | > 10,000 | High - real bloat affecting performance |
+| > 50 MB | > 5,000 | Medium - worth addressing |
+| < 10 MB | Any | Low - negligible impact, ignore |
+| Any | < 1,000 | Low - autovacuum will handle it |
+
+A 1 MB table with 25% dead rows has ~250 KB of bloat. Not worth mentioning as "critical".
+
+## Applying Fixes
+
+When recommending changes, include the actual SQL and **always explain side effects** — especially for settings that add overhead or change behavior.
+
+```sql
+-- Memory tuning (example for 4GB RAM)
+ALTER SYSTEM SET shared_buffers = '1GB';
+ALTER SYSTEM SET effective_cache_size = '3GB';
+ALTER SYSTEM SET work_mem = '32MB';
+ALTER SYSTEM SET random_page_cost = 1.5;
+SELECT pg_reload_conf();
+-- Note: shared_buffers requires restart
+```
+
+```sql
+-- Vacuum specific tables
+VACUUM ANALYZE "TableName";
+
+-- Emergency XID freeze
+VACUUM FREEZE "TableName";
+```
+
+### Side effects to document per setting
+
+| Setting | Side Effect to Explain |
+|---------|----------------------|
+| `track_io_timing` | Adds a system call (gettimeofday) per block read/write. On most modern systems the overhead is <1%, but on systems with slow clock sources it can be measurable. Worth it for the diagnostic value in pg_stat_statements (blk_read_time, blk_write_time). |
+| `shared_buffers` | Requires restart. Allocates memory at startup — over-allocating can starve OS cache and other processes. |
+| `work_mem` | Multiplied by concurrent operations (sorts, hashes, joins). 64MB × 50 concurrent ops = 3.2 GB. Recommend conservatively. |
+| `log_min_duration_statement` | Logging slow queries adds I/O. A threshold too low (e.g., 100ms) on a high-throughput DB can generate massive log volume. Start at 1000ms. |
+| `idle_in_transaction_session_timeout` / `statement_timeout` | Will kill queries/transactions that exceed the timeout. Existing application code that relies on long-running transactions or queries will break. Warn the user to verify their application can handle this. |
+
+## Enabling pg_stat_statements
+
+**ONLY suggest this if BOTH conditions are true:**
+1. `pg_stat_statements_installed` is `false` in the JSON output
+2. `top_queries` is empty or missing
+
+If these conditions are met, tell the user to run (do NOT execute with Bash):
+
+```
+python3 scripts/enable-pg-stats.py --service <name>
+```
+
+This may require a brief restart.
+
+**If `pg_stat_statements_installed: true` and `top_queries` has data, DO NOT suggest enabling it.**
+
+---
+
+## PostgreSQL-Specific Guidance
+
+The sections below apply specifically to PostgreSQL analysis via `scripts/analyze-postgres.py`.
+
+## How to Think About PostgreSQL Performance
+
+### The Core Question
+
+When you see a problem, ask: **What is the chain of causation?**
+
+Example chain:
+1. Cache hit is 89% (symptom)
+2. Email table has 6% cache hit with 1.19B disk reads (deeper symptom)
+3. Email table is 1.7GB, shared_buffers is 128MB (root cause)
+4. The table is 13x larger than the buffer pool - it will NEVER fit in cache
+5. Every query touching Email forces disk I/O
+
+**This reasoning is what you provide. The script gives you the data points - you connect them.**
+
+### Patterns to Look For
+
+**Memory Starvation Pattern:**
+- Low cache hit + large tables + small shared_buffers = working set doesn't fit
+- High temp files + low work_mem = sorts/hashes spilling to disk
+- These often occur together - both indicate the database needs more memory
+
+**Important:** Temp file stats (`temp_files`, `temp_bytes`) are **cumulative since the last stats reset**, not current disk usage. When reporting, say "X GB written to temp files since stats reset" - not "X GB on disk right now".
+
+**Vacuum Neglect Pattern:**
+- High dead rows % + "never" vacuum timestamps = autovacuum isn't keeping up
+- Multiple tables with >10% dead rows = systemic issue, not one-off
+- High XID age + vacuum issues = potential wraparound emergency
+
+**Important:** Consider **absolute impact**, not just percentage. A tiny table (< 10 MB) with 20% dead rows has negligible impact - vacuuming it reclaims almost nothing. Prioritize tables with BOTH high dead row counts (thousands+) AND meaningful size (tens of MB+). Don't mark small tables as "critical" just because of a high percentage.
+
+**Missing Index Pattern:**
+- High seq_scan count + 0 idx_scans on large tables = queries scanning full tables
+- Low cache hit on specific tables + high seq_scans = indexes would help AND reduce I/O
+
+**Connection Pressure Pattern:**
+- High connection % + many idle connections = connection pooling needed
+- Old connections (days) + idle_in_transaction = potential connection leaks or stuck transactions
+
+### Slow Query Analysis — Go Deep
+
+The `top_queries` array is the **most valuable data** for customers. This is where you can give the most actionable, specific advice. Don't skim it — analyze every query in the top 10-15 thoroughly.
+
+#### Per-Query Fields and What Each Tells You
+
+| Field | What It Means | How to Interpret |
+|-------|---------------|------------------|
+| `calls` | Number of times this query pattern executed | High calls × even small mean_ms = huge cumulative impact. A 5ms query called 10M times = 833 minutes of DB time |
+| `total_min` | Total execution time in minutes | The primary sort key. This is the query's total footprint on the database |
+| `mean_ms` | Average execution time per call | Compare with stddev — if stddev >> mean, the query has wildly variable performance |
+| `min_ms` / `max_ms` | Fastest and slowest execution | A 2ms min with 30,000ms max means the query sometimes hits pathological cases (lock waits, cache misses, bloated tables) |
+| `stddev_ms` | Standard deviation of execution time | High stddev = unpredictable. The query probably performs well when data is cached but terribly when it's not. This is often the query causing random user-visible latency spikes |
+| `rows_per_call` | Average rows returned per execution | 0.01 rows/call means the query usually returns nothing — might be a polling pattern or existence check that could use EXISTS instead. 50,000 rows/call suggests missing pagination or bulk fetch |
+| `mean_plan_ms` | Average planning time | If plan time is >5ms, the planner is spending significant time. Could indicate: too many partitions, complex joins needing better statistics (`ALTER TABLE SET STATISTICS`), or pg_catalog bloat |
+| `cache_hit_pct` | % of blocks found in shared_buffers | <90% = query is constantly going to disk. Cross-reference with the table it touches in `cache_per_table` |
+| `shared_blks_read` | Blocks read from disk (not cache) | This is the raw I/O cost. Each block = 8KB. 1M blocks read = 8GB of disk I/O |
+| `shared_blks_dirtied` | Blocks this query modified | High dirtied blocks = write-heavy query. These blocks will need to be flushed to disk during checkpoints |
+| `shared_blks_written` | Blocks this query had to flush to disk itself | Should be 0 in a healthy system. >0 means the query was forced to do its own I/O because shared_buffers was full of dirty pages — a sign of severe memory pressure |
+| `temp_blks_read` / `temp_blks_written` | Blocks spilled to temp files | Any nonzero value means the query exceeded work_mem. Each block = 8KB. temp_blks_written of 1M = 8GB spilled to disk for sorts/hashes |
+| `blk_read_time_ms` / `blk_write_time_ms` | Time spent on actual disk I/O (requires `track_io_timing`) | If available and high, this tells you exactly how much time was spent waiting on disk vs CPU. If 0, track_io_timing may be off |
+| `wal_records` / `wal_bytes` | WAL generated by this query | High WAL = write-heavy. If one query generates most WAL, it's driving replication lag and checkpoint pressure |
+| `local_blks_hit` / `local_blks_read` | Blocks for temporary tables | If nonzero, query uses temp tables — common in complex CTEs or materialized subqueries |
+
+#### Red Flags — What Demands Explanation
+
+| Signal | What It Means | Example | What to Tell the Customer |
+|--------|---------------|---------|---------------------------|
+| Low cache_hit_pct (< 90%) | Query hitting disk constantly | `cache_hit_pct: 47.19` | "This query reads X blocks from disk each call. The table it touches (Y) is Z GB but shared_buffers is only W MB — the data physically cannot stay cached" |
+| High temp_blks (any nonzero) | Query spilling sorts/hashes to disk | `temp_blks_written: 39102928` | "This query spills ~X GB to temp files per execution because work_mem (Y MB) is too small for its sort/hash. Each spill means disk I/O instead of memory" |
+| Huge rows_per_call (>1000) | Missing pagination or bulk fetch | `rows_per_call: 12177` | "Each call returns ~12K rows. If this is a user-facing query, it likely needs LIMIT/OFFSET or cursor-based pagination. If it's a batch job, it's expected" |
+| Near-zero rows_per_call with high calls | Polling or existence check pattern | 0.01 rows/call, 500K calls | "This query runs 500K times but almost never finds data. If it's checking for new work, consider LISTEN/NOTIFY instead of polling. If it's an existence check, ensure it uses EXISTS with LIMIT 1" |
+| stddev >> mean | Wildly variable performance | mean=15ms, stddev=2400ms, max=45000ms | "This query averages 15ms but sometimes takes 45 SECONDS. The high stddev means unpredictable latency. Likely causes: lock contention, cache misses on cold data, or table bloat causing variable scan times" |
+| High mean_plan_ms (>5ms) | Expensive query planning | `mean_plan_ms: 23.4` | "The planner spends 23ms just deciding HOW to run this query, before executing it. With X calls, that's Y minutes of pure planning overhead. Consider: PREPARE'd statements, simpler joins, or increasing default_statistics_target for better stats" |
+| shared_blks_written > 0 | Memory pressure forcing query I/O | `shared_blks_written: 50000` | "This query was forced to flush dirty pages to disk itself because shared_buffers was full. This is a sign of severe buffer pool pressure — increase shared_buffers" |
+| High wal_bytes relative to others | Write-heavy query driving replication | `wal_bytes: 5000000000` | "This query generates X GB of WAL, which is Y% of total WAL. It's the primary driver of replication lag and checkpoint I/O" |
+| max_ms >> 10× mean_ms | Pathological worst cases | mean=50ms, max=120000ms | "The worst execution was 2400× slower than average. Investigate: was it blocked by a lock? Did it hit a cold cache after restart? Is there table bloat causing some scans to be much longer?" |
+
+#### How to Present Slow Queries
+
+**Show the full table first** with all available metrics (the report already includes these columns):
+
+```
+| Query (truncated) | Calls | Total (min) | Mean (ms) | Min/Max (ms) | Stddev | Rows/Call | Cache Hit | Temp R/W | Plan (ms) | I/O Time |
+|-------------------|-------|-------------|-----------|--------------|--------|-----------|-----------|----------|-----------|----------|
+| SELECT Email.ccFull... | 78K | 132 | 101 | 0.3/8200 | 340 | 0.05 | 47% | 0/0 | 1.2 | 45000 |
+| SELECT Thread... ORDER BY | 48K | 223 | 279 | 2.1/45000 | 2400 | 12,177 | 98.8% | 0/39M | 0.4 | 800 |
+| SELECT Content... | 1.3K | 12 | 563 | 180/3200 | 420 | 0.65 | 1.8% | 0/0 | 8.3 | 31000 |
+```
+
+**Then analyze EACH query** — this is the most valuable part. For each of the top 10 queries, explain:
+
+1. **What the query does** — identify the tables, the pattern (lookup, join, aggregation, pagination)
+2. **Why it's slow** — connect the specific metrics to a root cause
+3. **The cascading impact** — how this query affects overall database health
+4. **Specific fix** — not generic advice, but targeted to what the metrics show
+
+Example deep analysis:
+
+> **Query 1: Email.ccFull join** (78K calls, 101ms mean, 132 min total)
+> - **Pattern**: Joins Email → EmailThreadKind → Thread → EmailEntry. ORM-generated N+1 or bulk join.
+> - **Root cause**: 47% cache hit means 53% of blocks come from disk. The Email table is 1.7GB but shared_buffers is 128MB — only 7.5% of this table can be cached at once. Every call displaces other data from cache, creating a cascading eviction problem.
+> - **The stddev of 340ms** with max of 8200ms means some calls take 80× longer — likely when the needed pages were just evicted by another query.
+> - **I/O time of 45,000ms** total confirms this: the query has spent 45 seconds just waiting for disk across all calls.
+> - **rows_per_call = 0.05** means it almost never finds a match — it's doing all this I/O for an existence-check pattern. An `EXISTS()` subquery with proper index could eliminate the full table scan.
+> - **Fix**: (a) Increase shared_buffers to 1GB so the hot portion stays cached. (b) Add index on Email(ccFull, threadId) to avoid the sequential scan. (c) Rewrite as EXISTS if the app only needs presence, not the full row.
+
+> **Query 2: Thread pagination** (48K calls, 279ms mean, 223 min total)
+> - **Pattern**: SELECT Thread... ORDER BY with large result set. Pagination query.
+> - **Root cause**: rows_per_call = 12,177 — returning 12K rows per call is a pagination bug (missing LIMIT) or an admin/batch endpoint.
+> - **temp_blks_written = 39M** (312 GB of temp files!) — the ORDER BY creates a sort that exceeds work_mem (4MB), so it spills to disk every single time.
+> - **stddev = 2400ms with max = 45,000ms** — some executions take 45 seconds, likely when disk temp files compete with other I/O.
+> - **Cache hit is 98.8%** — the data itself is cached, but the sort still spills because work_mem is separate from shared_buffers.
+> - **Fix**: (a) Add `LIMIT` if this is user-facing. (b) Create an index matching the ORDER BY clause to eliminate the sort entirely. (c) Increase work_mem to 32-64MB so the sort fits in memory.
+
+#### Truncate Long Queries Intelligently
+- Show the table names and key operations (JOIN, WHERE, ORDER BY)
+- Don't dump 2000-character ORM-generated SQL
+- Identify the pattern: "Thread zone assignment lookup" not the full SQL
+- For ORM queries with `$1, $2, ...` parameters, note that the actual values aren't available — the pattern matters more than specific values
+- **Note on query truncation**: pg_stat_statements stores full query text up to `track_activity_query_size` (default 1024 chars). ORM-generated queries often exceed this — if a query ends abruptly, it was truncated by PostgreSQL, not by our script. The JSON output preserves the full text from pg_stat_statements; only the human-readable text report truncates for display
+
+#### Query Workload Profile
+
+After analyzing individual queries, summarize the overall workload:
+- **Read vs write ratio**: Use tup_returned/tup_fetched vs tup_inserted/tup_updated/tup_deleted from database_stats
+- **Top 3 time consumers**: Which queries dominate total_min? If 3 queries account for 80% of execution time, that's where to focus
+- **Cache pressure sources**: Which queries have the most shared_blks_read? They're driving cache misses for everything else
+- **Temp file culprits**: Which specific queries create temp files? Don't say "increase work_mem" generically — say "Query X creates Y GB of temp files per day"
+- **WAL generators**: If applicable, which queries generate the most WAL bytes? They're driving replication lag
+
+### Correlate Across Sections
+
+The script collects many data points. Look for correlations:
+
+| If you see... | Check also... | Because... |
+|---------------|---------------|------------|
+| Low table cache hit | per-table cache rates, table sizes vs shared_buffers | One large table may be thrashing the cache |
+| High temp files | work_mem value, top queries | Specific queries may be the culprits |
+| Dead rows building up | vacuum health, XID age | Autovacuum may be blocked or misconfigured |
+| Seq scans on large tables | unused indexes, index hit rates | May have indexes but planner isn't using them |
+| High connection usage | connection age, idle_in_transaction | May be leaks, not actual load |
+
+### Synthesize Insights the Script Can't
+
+The script flags individual issues. You should:
+
+1. **Identify the PRIMARY bottleneck** - What's the #1 thing hurting performance right now?
+2. **Explain cascading effects** - How does one problem cause others?
+3. **Prioritize fixes** - What should they do first, second, third?
+4. **Warn about risks** - What happens if they don't fix this?
+
+**Important:** Synthesis is prose that EXPLAINS the data tables you already showed. Don't hide data in prose - the tables make it visible, the prose connects the dots.
+
+Example flow:
+1. Show config table: `shared_buffers = 128 MB` vs recommended `1 GB`
+2. Show cache table: `Email` table at 6% cache hit with 1.19B disk reads
+3. THEN explain: "Your buffer pool (128 MB) is 13x smaller than your Email table (1.7 GB). This single table is dragging down your overall 89% cache hit rate."
+
+The user sees the data, understands the relationship, then gets the explanation. Don't make them trust your conclusions without seeing the evidence first.
+
+## Common Errors to Avoid (PostgreSQL-Specific)
+
+- Saying "enable pg_stat_statements" when `pg_stat_statements_installed: true` and `top_queries` has data
+- Misreporting connection usage (check `percent` field, not just `current`)
+- Ignoring the `oldest_connections` details when flagging old connections
+- Saying "746 GB of temp files on disk" when temp_bytes is cumulative since stats reset
+- Marking tiny tables (< 10 MB) as "critical" for vacuum just because of high dead row percentage
+- Listing slow queries by total_time only without analyzing cache_hit_pct, temp_blks, and rows returned
+- Dumping full ORM-generated SQL instead of summarizing the query pattern
+
+## Validated against
+
+- PostgreSQL system views: pg_stat_activity, pg_stat_statements, pg_statio_user_tables, pg_stat_user_tables
+- Patroni REST API for HA clusters

--- a/.claude/skills/use-railway/references/analyze-db-redis.md
+++ b/.claude/skills/use-railway/references/analyze-db-redis.md
@@ -1,0 +1,208 @@
+# Redis Analysis
+
+This reference covers Redis-specific metrics, tuning, and analysis guidance.
+For common analysis patterns (output structure, collection status handling, performance thinking), see [analyze-db.md](analyze-db.md).
+
+## What the Script Collects
+
+**Via SSH (`INFO ALL`):**
+- **Overview:** version, uptime, connected/blocked clients, rejected connections
+- **Memory:** used/RSS/peak memory, fragmentation ratio, maxmemory, eviction policy
+- **Throughput:** ops/sec, total commands processed, total connections
+- **Cache Performance:** keyspace hits/misses, hit rate, expired/evicted keys
+- **Persistence:** RDB last save time/status, AOF enabled/status
+- **Command Stats:** per-command call count, avg latency, total time (sorted by calls)
+- **Keyspace:** per-database key count, expires, avg TTL
+- **Slow Log:** count via `SLOWLOG LEN` + actual entries via `SLOWLOG GET 20` (command, duration, timestamp)
+- **Biggest Keys:** via `redis-cli --bigkeys` — runs **remotely over SSH** on the Railway service, not locally
+
+**Via Railway API:** Same infrastructure metrics (disk, CPU, memory, network with **7d and 24h trends**).
+
+## Presentation Template
+
+Present Redis analysis using grouped stat cards that mirror the sections below. Each section is a labeled group with key-value stat cards. Flag values with status indicators (healthy/warning/critical) using the thresholds table.
+
+### Full Report (SSH + Metrics + Logs all succeeded)
+
+**Overview**
+| Version | Uptime | Connected Clients | Blocked Clients | Rejected Connections | Total Keys |
+|---------|--------|-------------------|-----------------|----------------------|------------|
+| 7.2.4 | 14d 6h | 23 | 0 | 0 | 48,291 |
+
+Flag: blocked clients > 0 = warning, rejected connections > 0 = critical.
+
+**Memory**
+| Used Memory | RSS Memory | Peak Memory | Fragmentation Ratio | Max Memory | Eviction Policy |
+|-------------|------------|-------------|---------------------|------------|-----------------|
+| 12.4 MB | 18.2 MB | 15.1 MB | 1.47 | Unlimited | noeviction |
+
+Flag: fragmentation > 1.5 = warning, > 2.0 or < 1.0 = critical. Evicted keys > 0 with noeviction = problem.
+
+**Throughput**
+| Ops/sec | Total Commands | Total Connections | Slow Log Entries |
+|---------|----------------|-------------------|------------------|
+| 1,240 | 8.4M | 12,491 | 3 |
+
+Flag: slow log > 100 = warning.
+
+**Cache Performance**
+| Hit Rate | Hits | Misses | Expired Keys | Evicted Keys |
+|----------|------|--------|--------------|--------------|
+| 97.2% | 6.1M | 178K | 892K | 0 |
+
+Flag: hit rate >= 95% = healthy, 80-95% = warning, < 80% = critical. Evicted > 0 = warning.
+
+**Persistence**
+| RDB Last Save | RDB Status | AOF Enabled | AOF Rewrite Status |
+|---------------|------------|-------------|-------------------|
+| 2 min ago | ok | Yes | ok |
+
+Flag: RDB status != ok = critical. AOF rewrite status != ok = critical.
+
+**Command Stats** (top 20 by calls)
+| Command | Calls | Avg Latency | Total Time |
+|---------|-------|-------------|------------|
+| GET | 4.2M | 3.1µs | 13.0s |
+| SET | 2.1M | 4.8µs | 10.1s |
+| HGET | 890K | 5.2µs | 4.6s |
+| EXPIRE | 620K | 2.1µs | 1.3s |
+
+**Slow Log Entries** (if collected — up to 20 most recent)
+| # | Timestamp | Duration | Command |
+|---|-----------|----------|---------|
+| 1 | 2m ago | 12.3ms | GET user:session:abc123... |
+| 2 | 5m ago | 10.1ms | GET cache:render:page/home... |
+| 3 | 12m ago | 8.7ms | HGETALL product:catalog:main |
+
+Analysis: correlate slow commands with command stats and big keys. If slowlog shows GET and bigkeys shows large strings, the diagnosis is "large values causing high GET latency" — confirmed without user intervention.
+
+**Biggest Keys** (if collected — one per type)
+| Type | Key | Size/Count |
+|------|-----|------------|
+| string | cache:render:page/dashboard | 2.1 MB |
+| hash | user:sessions | 14,291 fields |
+| list | queue:notifications | 8,402 items |
+
+Analysis: large keys cause latency spikes on read/write/delete. Cross-reference with slowlog — if the slow commands target these keys, that's the root cause. If bigkeys shows nothing large (all < 1KB), latency issues are likely volume-driven, not value-size-driven.
+
+**Keyspace**
+| Database | Keys | Expires | Avg TTL |
+|----------|------|---------|---------|
+| db0 | 48,291 | 31,204 | 2.4h |
+
+**Infrastructure (7d + 24h)** — show both windows so trends can be compared:
+
+**7-Day Trends**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.01 vCPU | 0.01 | 0.00 | 0.10 | stable |
+| Memory | 70 MB | 40 MB | 30 MB | 90 MB | stable |
+| Disk | 1.1 GB | 1.11 GB | 1.07 GB | 1.16 GB | stable |
+
+**Last 24 Hours**
+| Metric | Current | Avg | Min | Max | Trend |
+|--------|---------|-----|-----|-----|-------|
+| CPU | 0.01 vCPU | 0.01 | 0.00 | 0.07 | stable |
+| Memory | 70 MB | 55 MB | 30 MB | 90 MB | increasing (+58%) |
+| Disk | 1.1 GB | 1.11 GB | 1.07 GB | 1.16 GB | stable |
+
+Compare: "Memory increasing in 24h but stable over 7d → temporary spike, not a sustained trend."
+
+Do NOT show cpu_limit/memory_limit columns or utilization %. Railway auto-scales — these limits are just the ceiling. See [analyze-db.md](analyze-db.md) autoscale rules.
+
+### Partial Report (Introspection failed, only Metrics + Logs)
+
+When introspection fails, you have NO Redis INFO data — all overview, memory, throughput, cache, persistence, command stats, and keyspace fields will be null/empty.
+
+**NEVER suggest running `redis-cli` without pointing to the remote Railway service host.** There is no local Redis instance — all redis-cli commands must target the Railway service. If you cannot connect, the fix is to restore remote access (see `analyze-db.md`), not to run commands locally.
+
+**You MUST:**
+1. State clearly: "Redis introspection failed — could not connect to the service"
+2. Show collection status errors
+3. Show ONLY infrastructure metrics and log analysis — do not show empty stat card sections
+4. Do NOT produce recommendations based on null Redis metrics
+
+**Show the infrastructure table** (same as full report).
+
+**Analyze logs thoroughly:**
+- AOF rewrite frequency and growth % triggers
+- fsync warnings ("disk is busy?")
+- OOM warnings
+- Connection errors
+- Startup/restart events (note these are normal during deploys)
+- Summarize with counts: "Analyzed 1000 lines: 18 AOF rewrites, 1 fsync warning, 0 errors"
+
+**State what you cannot determine** without SSH:
+- Connection health (clients, blocked, rejected)
+- Memory usage and fragmentation
+- Cache hit rate
+- Eviction status
+- Command workload profile
+- Keyspace composition
+- Slow log entries and actual slow commands
+- Biggest keys per type
+
+## Redis Performance Patterns
+
+**Memory Fragmentation Pattern:**
+- `mem_fragmentation_ratio > 1.5` = memory is fragmented, RSS much higher than used
+- Caused by frequent small key deletions creating memory holes
+- Fix: restart Redis, or enable `activedefrag yes` (Redis 4.0+)
+- Ratio < 1.0 means Redis is using swap — critical performance issue
+
+**Cache Thrashing Pattern:**
+- Hit rate < 80% + evicted keys > 0 = working set exceeds maxmemory
+- Check maxmemory_policy — `noeviction` will reject writes, `allkeys-lru` will evict
+- If maxmemory is 0 (unlimited), Redis will consume all RAM until OOM killed
+
+**Connection Rejection Pattern:**
+- rejected_connections > 0 = maxclients limit hit
+- Check connected_clients vs maxclients default (10,000)
+- Blocked clients = operations waiting on BLPOP/BRPOP/WAIT
+
+**Persistence Risk Pattern:**
+- RDB last save failed + no AOF = data loss risk on restart
+- Check disk space if saves are failing
+- Long time since last save = more data at risk
+
+**AOF Rewrite Churn Pattern:**
+- Frequent AOF rewrites (every 1-2 hours) with high growth % triggers (100-800%)
+- Indicates high write-to-data-size ratio — small dataset with heavy writes
+- Check Fork CoW size to gauge actual data size vs AOF overhead
+- If rewrites are fast (<1s) and CoW is small (<10 MB), this is noisy but harmless
+- If rewrites are slow or CoW is large, investigate write patterns
+
+**Disk Sawtooth Pattern:**
+- Disk usage oscillating in a regular pattern = AOF growing between rewrites, then compacting
+- Normal behavior — the baseline is volume overhead + AOF base file
+- If the amplitude is growing over time, data size is increasing
+
+## Redis Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Hit rate | >95% | 80-95% | <80% |
+| Fragmentation ratio | 1.0-1.5 | 1.5-2.0 | >2.0 or <1.0 |
+| Evicted keys | 0 | >0 | Growing rapidly |
+| Blocked clients | 0 | 1-5 | >5 |
+| Connected clients | <80% maxclients | 80-90% | >90% |
+
+## Redis Command Stats Analysis
+
+The top commands by call count reveal the workload pattern:
+- **GET/SET dominant** = simple key-value cache
+- **HGET/HSET dominant** = hash-based data model (sessions, objects)
+- **LPUSH/RPOP dominant** = queue pattern
+- **High KEYS/SCAN** = application iterating keys (potential performance issue at scale)
+- **High latency on simple commands** (>100µs for GET) = memory pressure or CPU saturation
+
+## Redis Autoscale Note
+
+See [analyze-db.md](analyze-db.md) for full autoscale rules. For Redis specifically:
+- If `maxmemory` is set, compare it against actual memory usage — not the Railway memory limit.
+- If `maxmemory` is 0 (unlimited), Redis will grow until the OS kills it. This is the default Railway config and works fine with autoscaling — Redis uses what it needs and Railway scales the container.
+- Do NOT recommend setting maxmemory to a fraction of the Railway memory limit — the limit is the autoscale ceiling, not fixed allocation.
+
+## Validated against
+
+- Redis INFO command, SLOWLOG LEN, SLOWLOG GET, and --bigkeys

--- a/.claude/skills/use-railway/references/analyze-db.md
+++ b/.claude/skills/use-railway/references/analyze-db.md
@@ -1,0 +1,339 @@
+# Database Analysis
+
+## Your Role
+
+You are a database performance expert. The script collects raw data - your job is to **think deeply** about what you see, identify root causes, correlate symptoms, and explain the "why" behind problems.
+
+**Don't just report metrics. Analyze them.**
+
+## Context Resolution
+
+The user's request is the source of truth. Use this decision table:
+
+| What the user provided | Action |
+|------------------------|--------|
+| Railway URL | Extract IDs directly from the URL — do NOT run `railway status --json` |
+| Service name + environment name | Proceed — intent is clear. Resolve IDs via API. |
+| Service name only (no environment) | Find the service by name via API. If multiple matches exist across projects, ask: "Which project do you mean?" Otherwise confirm: "Do you mean `<service>` in `<project>` / `<env>`?" — only proceed on confirmation |
+| Raw UUID(s) | Resolve to human-readable names via API, then confirm before running |
+| Vague request ("analyze my database", "check postgres") | Run `railway status --json` to see what's linked. If it's a database service, confirm: "Do you mean `<service>` in `<project>` / `<env>`?". If it's not a database service or nothing is linked, ask: "Which service and environment should I analyze?" |
+| No context at all | List workspaces (`railway whoami --json`), then projects (`railway project list --json`), then environments and services for the chosen project, narrowing down until you have a specific service and environment |
+
+`railway status --json` is a hint to form a specific question, not a trigger to act without confirmation.
+
+**When the user provides a Railway URL**, extract IDs directly from it:
+
+```
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>?environmentId=<ENV_ID>
+https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>/database?environmentId=<ENV_ID>
+```
+
+Then query the API for the service name and database type in a **single call**:
+
+```bash
+scripts/railway-api.sh \
+  'query getServiceAndConfig($serviceId: String!, $environmentId: String!) {
+    service(id: $serviceId) { name }
+    environment(id: $environmentId) {
+      config(decryptVariables: false)
+    }
+  }' \
+  '{"serviceId": "<SERVICE_ID>", "environmentId": "<ENV_ID>"}'
+```
+
+From the response, get:
+- **Service name**: `data.service.name`
+- **Database image**: `data.environment.config.services.<SERVICE_ID>.source.image`
+
+Then match the image to the database type:
+
+| Image pattern | Database Type |
+|--------------|---------------|
+| `postgres*`, `ghcr.io/railway/postgres*` | PostgreSQL |
+| `mysql*`, `ghcr.io/railway/mysql*` | MySQL |
+| `redis*`, `ghcr.io/railway/redis*`, `railwayapp/redis*` | Redis |
+| `mongo*`, `ghcr.io/railway/mongo*` | MongoDB |
+
+**If `environmentId` is empty in the URL** (e.g., `?environmentId=` or no query param at all), skip the `environment.config` query — it requires a valid ID. Instead, list the project's environments:
+
+```bash
+scripts/railway-api.sh \
+  'query getEnvs($id: String!) { project(id: $id) { environments { edges { node { id name } } } } }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Use the `production` environment by default. If multiple non-PR environments exist and the user hasn't specified one, ask which environment to analyze.
+
+## Database Type Detection and Script Selection
+
+| Database Type | Script |
+|---------------|--------|
+| PostgreSQL | `scripts/analyze-postgres.py` |
+| MySQL | `scripts/analyze-mysql.py` |
+| Redis | `scripts/analyze-redis.py` |
+| MongoDB | `scripts/analyze-mongo.py` |
+
+**All scripts share the same CLI interface** (use the script name from the table above):
+```bash
+python3 scripts/analyze-<script>.py \
+  --service <name> \
+  --json \
+  --project-id <project-id> \
+  --environment-id <env-id> \
+  --service-id <service-id>
+```
+
+Common options across all scripts:
+- `--json` — JSON output for programmatic processing
+- `--quiet` — Suppress progress messages
+- `--skip-logs` — Skip log collection
+- `--metrics-hours <N>` — Hours of metrics history (default: 24, max: 168)
+- `--step <step>` — Debug individual collection steps (ssh-test, query, logs, metrics)
+
+## Before You Analyze: Check Collection Status
+
+**ALWAYS check `collection_status` and `errors[]` FIRST before interpreting any data.** The script collects data from multiple independent sources. Any of them can fail.
+
+### Decision Table
+
+| database_query | metrics_api | logs_api | Report Type |
+|---------------|-------------|----------|-------------|
+| success | success | success | Full analysis — use all sections |
+| success | error | success | Full analysis — note missing infrastructure metrics |
+| **error** | success | success | **Partial report** — only infrastructure metrics + log analysis. NO performance conclusions. |
+| **error** | error | success | **Logs-only report** — state what logs show, note everything else failed. NO diagnosis. |
+| **error** | **error** | **error** | **Collection failure** — report the errors, do not analyze. |
+
+### When database_query failed — SSH key errors
+
+If the error contains `"No SSH keys found"` or `"SSH key registration required"`, handle it proactively — don't just tell the user to fix it themselves.
+
+**If error contains `"Key found but not registered"` or `"No SSH keys found"`:**
+
+Run these two commands to understand what's available:
+
+```bash
+railway ssh keys          # list keys already registered with Railway
+ls ~/.ssh/*.pub 2>/dev/null  # list local public keys
+```
+
+Then present the user with their options and ask which to use:
+
+```
+SSH introspection needs a registered key. Here's what I found:
+
+Registered with Railway: <list from `railway ssh keys`, or "none">
+Local keys available:    <list from ~/.ssh/*.pub, or "none">
+
+Options:
+  1. Register a local key — `railway ssh keys add` (uses your default key)
+  2. Import from GitHub  — `railway ssh keys github`
+  3. Generate a new key  — `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_railway`
+
+Which would you like to do?
+```
+
+Once the user chooses and the key is registered, re-run the full analysis.
+
+### When database_query failed — CLI outdated or missing
+
+If the error contains `"--native SSH flag is not supported"` or `"Railway CLI not found"`, the script detected an unrecoverable CLI problem. Tell the user directly:
+
+- **Outdated CLI:** "Your Railway CLI doesn't support native SSH. Update it: `npm i -g @railway/cli@latest` or `brew upgrade railway`"
+- **Missing CLI:** "Railway CLI not installed. Install it: `npm i -g @railway/cli` or `brew install railway`"
+
+Then ask if they'd like to proceed with a partial analysis (metrics + logs only) while they update, or wait until the CLI is fixed and re-run the full analysis.
+
+### When database_query failed — other SSH errors
+
+This means SSH could not reach the database or the query failed. You have NO connection stats, NO cache hit ratios, NO vacuum health, NO query performance data. All those fields will be null/empty.
+
+**You MUST:**
+1. State clearly: "Database introspection failed — SSH could not connect to the service"
+2. Show the `collection_status` errors
+3. Show only the data that DID succeed (metrics, logs)
+4. Do NOT produce recommendations based on null metrics
+5. Do NOT diagnose performance issues from logs alone
+
+**Partial report template:**
+```
+Service: <name>
+Status: Data collection partially failed
+
+## Collection Status
+| Source | Status |
+|--------|--------|
+| Database Query (SSH) | ERROR: <error from collection_status> |
+| Metrics API | <status> |
+| Logs API | <status> |
+
+## Available Data
+<Show metrics and log summary from sources that succeeded>
+
+## What We Cannot Determine
+<List what requires the database query: connection health, cache performance, vacuum health, query analysis, etc.>
+```
+
+## Output Structure: Data First, Actions Second
+
+**Always present information in this order:**
+
+### 1. Context Header
+```
+Service: <name> (<project> <environment>)
+Status: <deployment health>, <RAM>, <disk used>
+```
+
+### 2. Consolidated Data Tables
+
+Before any analysis, show the raw metrics in tables so the user sees their actual state. The DB-specific reference defines exactly which tables to show for each database type — present the relevant health sections first, then connections, then query performance.
+
+**Logs & Active Issues:**
+- Parse the `recent_logs` array (1000 lines of raw logs) - don't just check if empty
+- Summarize: "Analyzed 1000 log lines: 3 errors (connection timeouts), 0 critical issues"
+- Show specific concerning log entries if found
+- **Categorize log entries**: group by type (errors, warnings, connection events, replication, crashes/restarts)
+- **Count patterns**: note if a single type dominates the log output
+- **Quote actual log lines** for errors — don't just say "errors found", show the exact message so the user can search their codebase
+
+### 3. Analysis
+
+After showing the data, explain the chain of causation. Connect the dots between tables.
+
+### 4. Recommended Actions
+
+Group by urgency. For databases that support configuration changes without restart vs those that require one, call that out explicitly.
+
+### 5. Expected Outcomes
+
+What metrics should change after fixes.
+
+---
+
+**Why this order matters:**
+- Users can verify the data matches their understanding
+- They see the full picture before being told what to do
+- Actions have context - they know WHY each fix is recommended
+- No valuable data is hidden in prose or omitted
+
+## CRITICAL: Use the Actual Data
+
+**NEVER fabricate or assume values.** The script outputs JSON with exact numbers. Before stating any metric:
+
+1. **Read the actual JSON output** - Don't truncate or skim
+2. **Quote the exact values** - e.g., `"max": 5000` not "100"
+3. **Investigate outliers** - Dig into any field that seems unusually high or low
+
+Common errors to avoid (all database types):
+- **Not parsing `recent_logs`** - always analyze the raw log lines, don't just report "no errors"
+- **Diagnosing performance issues from logs when all metrics are null** — logs show what happened, not how the database is performing
+- **Treating startup/restart log entries as evidence of failure** — databases restart for many normal reasons (deploys, config changes, scaling)
+- **Producing recommendations when all database metrics are null** — if `collection_status.database_query` is "error", you have no basis for tuning advice
+
+See the DB-specific reference for additional errors to avoid per database type.
+
+## Running the Analysis
+
+Pass project, environment, and service IDs directly — no `railway link` needed:
+
+```bash
+# From plugins/railway/skills/use-railway directory:
+# Use the script name from the "Database Type Detection" table above
+python3 scripts/analyze-postgres.py --service <name> --json \
+  --project-id <project-id> --environment-id <env-id> --service-id <service-id>
+```
+
+All three IDs come from the URL (see "Context: URL First" above). The service name comes from the API query.
+
+**Options:**
+- `--metrics-hours <N>` — Hours of metrics history to fetch (default: 24, max: 168). Use `--metrics-hours 168` for 7-day trends, `--metrics-hours 1` for recent snapshot.
+
+**SSH retry:** The script automatically retries SSH connectivity up to 3 times with increasing timeouts (30s, 60s, 90s). Each individual SSH command (database query, slowlog, bigkeys, etc.) also retries up to 3 times on failure — covering transient errors like `exec request failed on channel 0`. Progress is logged to stderr.
+
+**Output:** Progress messages go to stderr. JSON results go to stdout. Do not redirect or pipe stderr — just run the command as-is and read the full output.
+
+### Resolving environment by name
+
+If the URL has no `environmentId` and the user specifies an environment by name (e.g., "production"), resolve it:
+
+```bash
+scripts/railway-api.sh \
+  'query getProject($id: String!) {
+    project(id: $id) {
+      environments { edges { node { id name } } }
+    }
+  }' \
+  '{"id": "<PROJECT_ID>"}'
+```
+
+Match the environment name (case-insensitive) to get the `environmentId`.
+
+### Debugging individual steps
+
+```bash
+# Use the script name from the "Database Type Detection" table above
+python3 scripts/analyze-postgres.py --service <name> \
+  --project-id <pid> --environment-id <eid> --service-id <sid> \
+  --step ssh-test    # Test SSH connectivity
+  --step query       # Run only the database query
+  --step metrics     # Fetch only API metrics
+  --step logs        # Fetch only logs
+```
+
+## Database-Specific References
+
+After running the script and checking collection status, load the reference for the specific database type:
+
+| Database | Reference | What It Covers |
+|----------|-----------|----------------|
+| PostgreSQL | [analyze-db-postgres.md](analyze-db-postgres.md) | What psql collects, log analysis checklist, tuning formulas, vacuum priority, pg_stat_statements, applying fixes |
+| MySQL | [analyze-db-mysql.md](analyze-db-mysql.md) | All 12 metric sections (overview, query throughput, InnoDB, efficiency, buffer pool, I/O, network, locks, cache, top queries, tables, active queries), patterns, tuning |
+| Redis | [analyze-db-redis.md](analyze-db-redis.md) | INFO ALL metrics, memory fragmentation, cache thrashing, persistence, command stats |
+| MongoDB | [analyze-db-mongo.md](analyze-db-mongo.md) | serverStatus, WiredTiger cache, query efficiency, connection saturation, oplog |
+
+**Always load the DB-specific reference** — it contains the metric sections, thresholds, and tuning knowledge needed for proper analysis.
+
+## Infrastructure Metrics (All Database Types)
+
+All scripts collect the same infrastructure metrics via Railway API:
+
+**Metrics History (`metrics_history`):**
+The script fetches **7 days** (168 hours) of time-series data from Railway's metrics API by default and produces **two analysis windows**:
+
+```json
+{
+  "metrics_history": {
+    "windows": {
+      "7d": { "window_hours": 168, "metrics": { "cpu": {...}, "memory": {...}, ... } },
+      "24h": { "window_hours": 24, "metrics": { "cpu": {...}, "memory": {...}, ... } }
+    }
+  }
+}
+```
+
+Each window independently computes:
+- **Summary stats**: current, min, max, avg for each metric
+- **Trend analysis**: compares first-quarter avg to last-quarter avg — reports direction (increasing/decreasing/stable) and % change
+- **Spike detection**: flags values > avg + 2*stddev with timestamps of peaks
+- **Downsampled series**: ~48 data points per window
+
+Available metrics: CPU, memory (with limits), disk, network RX/TX.
+
+**Comparing windows reveals whether a trend is new or sustained:**
+- "Memory increasing in 24h but stable over 7d" → temporary spike, likely a batch job
+- "Memory increasing in both 24h AND 7d" → sustained growth, may need investigation
+- "CPU spike in 24h, no spikes in 7d" → new issue
+- "Disk growing over 7d" → data accumulation trend
+
+Use `--metrics-hours N` to change the long window (default: 168, max: 168). The 24h window is always produced when the long window is > 24h.
+
+### Railway auto-scales vertically
+
+Railway services auto-scale CPU, RAM, and disk based on actual usage. Users do NOT pick or control resource sizes. The `cpu_limit` and `memory_limit` values from metrics are the **autoscale ceiling** (typically 32 vCPU / 32 GB), not user-provisioned allocations. Users are billed for actual usage, not the ceiling.
+
+**Rules for ALL database types:**
+- **Never say "right-size the instance"** or suggest reducing CPU/RAM — it's not a user action.
+- **Never flag low utilization % against the limit as waste** — a service showing 0.01 vCPU / 70 MB actual usage against a 32 vCPU / 32 GB ceiling is normal, not over-provisioned.
+- **Disk does NOT auto-scale** — Railway volumes have a fixed capacity. Paid users (Hobby and Pro) can expand them live without downtime, but it requires a manual resize. Flag high disk utilization as actionable. Users are billed for actual disk utilization, not the full volume size.
+- **Focus on actual usage values**, not the ratio to limits. Analyze whether 70 MB of memory is healthy for this workload — don't compare it to the 32 GB ceiling.
+- When tuning database parameters (shared_buffers, innodb_buffer_pool_size, maxmemory, etc.), base recommendations on the **current actual RAM** from `metrics_history.memory`, not the limit.

--- a/.claude/skills/use-railway/references/configure.md
+++ b/.claude/skills/use-railway/references/configure.md
@@ -1,0 +1,285 @@
+# Configure
+
+Manage environments, variables, service config, domains, and networking.
+
+## Environments
+
+### List and switch
+
+```bash
+railway environment list --json
+railway environment link <environment>           # switch active environment
+```
+
+### Create
+
+```bash
+railway environment new <name>
+railway environment new <name> --duplicate <source-environment>    # clone config from existing
+```
+
+Duplicating copies all service configurations and variables from the source environment.
+
+## Variables
+
+### Read, set, and delete
+
+```bash
+railway variable list --service <service> --environment <env> --json
+railway variable set KEY=value --service <service> --environment <env>
+railway variable delete KEY --service <service> --environment <env>
+```
+
+Variable changes trigger a redeployment by default. This is usually the desired behavior, since the service picks up the values on restart.
+
+### Template syntax
+
+Railway supports interpolation between services and shared variables:
+
+```text
+${{KEY}}                                         # same-service variable
+${{shared.API_KEY}}                              # shared variable
+${{postgres.DATABASE_URL}}                       # variable from another service
+${{api.RAILWAY_PRIVATE_DOMAIN}}                  # another service's private domain
+```
+
+Wiring example, a frontend connecting to a backend over private networking:
+
+```text
+BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
+```
+
+### Wiring services together
+
+Each managed database creates connection variables automatically. Reference them from other services using template syntax:
+
+| Database | Variable reference |
+|---|---|
+| Postgres | `${{Postgres.DATABASE_URL}}` |
+| Redis | `${{Redis.REDIS_URL}}` |
+| MySQL | `${{MySQL.MYSQL_URL}}` |
+| MongoDB | `${{MongoDB.MONGO_URL}}` |
+
+Service names in references are case-sensitive and must match the service name exactly as it appears in the project.
+
+**Public vs private networking decision:**
+
+| Traffic path | Use |
+|---|---|
+| Browser → API | Public domain |
+| Service → Service | Private domain (`RAILWAY_PRIVATE_DOMAIN`) |
+| Service → Database | Private (automatic, uses internal DNS) |
+
+**Frontend apps cannot use private networking.** Frontends run in the user's browser, not on Railway's network. They cannot reach `RAILWAY_PRIVATE_DOMAIN` or internal database URLs. Options:
+
+1. **Backend proxy** (recommended): frontend calls a backend API on a public domain, backend connects to the database over the private network.
+2. **Public database URL**: use the public connection variable (for example, `${{Postgres.DATABASE_PUBLIC_URL}}`). This requires a TCP proxy on the database service and exposes the database to the internet — only appropriate for development or low-sensitivity data.
+
+### Railway-provided variables
+
+These are set automatically at runtime. Availability depends on resource configuration.
+
+**Networking:**
+
+| Variable | Available when |
+|---|---|
+| `RAILWAY_PUBLIC_DOMAIN` | Public domain is configured |
+| `RAILWAY_PRIVATE_DOMAIN` | Always (internal DNS for service-to-service traffic) |
+| `RAILWAY_TCP_PROXY_DOMAIN` | TCP proxy is enabled |
+| `RAILWAY_TCP_PROXY_PORT` | TCP proxy is enabled |
+
+**Context:**
+
+| Variable | Available when |
+|---|---|
+| `RAILWAY_PROJECT_ID` | Always |
+| `RAILWAY_ENVIRONMENT_ID` | Always |
+| `RAILWAY_ENVIRONMENT_NAME` | Always |
+| `RAILWAY_SERVICE_ID` | Always |
+| `RAILWAY_SERVICE_NAME` | Always |
+| `RAILWAY_DEPLOYMENT_ID` | Always |
+| `RAILWAY_REPLICA_ID` | Replicas configured |
+| `RAILWAY_REPLICA_REGION` | Multi-region configured |
+
+**Git (present when deployed from a linked repo):**
+
+| Variable | Description |
+|---|---|
+| `RAILWAY_GIT_COMMIT_SHA` | Full commit hash of the deployed revision |
+| `RAILWAY_GIT_AUTHOR` | Commit author name |
+| `RAILWAY_GIT_COMMIT_MESSAGE` | First line of the commit message |
+| `RAILWAY_GIT_BRANCH` | Branch that triggered the deploy |
+
+**Storage (present when a volume is attached):**
+
+| Variable | Description |
+|---|---|
+| `RAILWAY_VOLUME_MOUNT_PATH` | Filesystem path where the volume is mounted |
+| `RAILWAY_VOLUME_NAME` | Name of the attached volume |
+
+Sealed variables are write-only. Their values don't appear in CLI output.
+
+## Service config
+
+Service configuration controls source, build, deploy, and networking settings. There are two ways to mutate it.
+
+### Dot-path patch
+
+For single-field changes:
+
+```bash
+railway environment edit --service-config <service> deploy.startCommand "npm start"
+railway environment edit --service-config <service> build.buildCommand "npm run build"
+railway environment edit --service-config <service> source.rootDirectory "/apps/api"
+railway environment edit --service-config <service> deploy.numReplicas 2
+```
+
+### JSON patch
+
+For multi-field changes or complex structures:
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"build":{"buildCommand":"npm run build"},"deploy":{"startCommand":"npm start"}}}}
+JSON
+```
+
+Resolve exact service IDs from `railway status --json` before constructing JSON patches. Using names in the JSON payload doesn't work.
+
+### Config schema (typed paths)
+
+Include only keys you're changing. The full shape:
+
+**Source**: `source.image` (string), `source.repo` (string), `source.branch` (string), `source.rootDirectory` (string), `source.checkSuites` (boolean), `source.commitSha` (string), `source.autoUpdates.type` (string: `disabled`, `patch`, `minor`)
+
+**Build**: `build.builder` (string: `RAILPACK`, `NIXPACKS`, `DOCKERFILE`), `build.buildCommand` (string), `build.dockerfilePath` (string), `build.watchPatterns` (string array), `build.nixpacksConfigPath` (string)
+
+**Deploy**: `deploy.startCommand` (string), `deploy.preDeployCommand` (string), `deploy.healthcheckPath` (string), `deploy.healthcheckTimeout` (integer), `deploy.numReplicas` (integer), `deploy.restartPolicyType` (string: `ON_FAILURE`, `ALWAYS`, `NEVER`), `deploy.restartPolicyMaxRetries` (integer), `deploy.sleepApplication` (boolean), `deploy.cronSchedule` (string), `deploy.multiRegionConfig` (object)
+
+**Multi-region config** structure for `deploy.multiRegionConfig`:
+
+```json
+{ "us-west2": { "numReplicas": 2 }, "europe-west4-drams3a": { "numReplicas": 1 } }
+```
+
+| Region identifier | Location |
+|---|---|
+| `us-west2` | US West (Oregon) |
+| `us-east4-eqdc4a` | US East (Virginia) |
+| `europe-west4-drams3a` | Europe (Netherlands) |
+| `asia-southeast1-eqsg3a` | Asia (Singapore) |
+
+Natural language mapping: "add replicas in Europe" → `europe-west4-drams3a`, "US East" → `us-east4-eqdc4a`. When the user doesn't specify a region, query current config first with `railway environment config --json` to see existing region assignments before modifying.
+
+**Variables**: `variables.<KEY>.value` (string), `variables.<KEY>.isOptional` (boolean), `variables.<KEY>.isSealed` (boolean). Delete a variable by setting it to `null`.
+
+**Lifecycle**: `isDeleted` (boolean) removes the service. `isCreated` (boolean) marks as new.
+
+**Storage**: `volumeMounts.<volume-id>.mountPath` (string), `volumes.<volume-id>.isDeleted` (boolean)
+
+**Buckets**: `buckets.<bucket-id>.region` (string: `sjc`, `iad`, `ams`, `sin`), `buckets.<bucket-id>.isCreated` (boolean), `buckets.<bucket-id>.isDeleted` (boolean). Buckets are created at the project level via `railway bucket create` and deployed to environments via config patches. The CLI handles this automatically — use `railway bucket` commands
+
+### Shared variables and project-level config
+
+```bash
+railway environment edit --json <<'JSON'
+{"sharedVariables":{"API_BASE":{"value":"https://example.com"}}}
+JSON
+```
+
+Shared variables are accessible from any service via `${{shared.KEY}}`.
+
+### Read config
+
+Always inspect before mutating. Config patches merge, so you need to know the state to avoid overwriting fields unintentionally:
+
+```bash
+railway environment config --json
+```
+
+Verify after mutation to confirm the change took effect:
+
+```bash
+railway environment config --json
+railway service status --all --json
+```
+
+## Domains
+
+### Railway domain
+
+One Railway-provided domain per service, generated automatically:
+
+```bash
+railway domain --service <service> --json
+```
+
+### Custom domain
+
+```bash
+railway domain example.com --service <service> --json
+```
+
+This returns the DNS records you need to configure at your DNS provider. Multiple custom domains per service are supported.
+
+### Target port
+
+If the service listens on a non-default port:
+
+```bash
+railway domain example.com --service <service> --port 8080 --json
+```
+
+### Private networking
+
+For service-to-service traffic within a project, use private domain references instead of public URLs. This avoids egress and is faster:
+
+```text
+BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
+```
+
+### Read current domains
+
+Domain configuration lives in `config.services.<service-id>.networking` under `serviceDomains` (Railway-provided) and `customDomains`. Inspect with:
+
+```bash
+railway environment config --json
+```
+
+### Remove a domain
+
+Remove domains via JSON config patch by setting the domain ID to `null`:
+
+**Remove a custom domain:**
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"networking":{"customDomains":{"<domain-id>":null}}}}}
+JSON
+```
+
+**Remove a Railway-provided domain:**
+
+```bash
+railway environment edit --json <<'JSON'
+{"services":{"<service-id>":{"networking":{"serviceDomains":{"<domain-id>":null}}}}}
+JSON
+```
+
+Get the domain IDs from `railway environment config --json` under the service's `networking` object.
+
+## Troubleshoot configuration
+
+- **Invalid dot-path**: check field names and types in the config schema section above
+- **Wrong service key in JSON patch**: resolve service IDs from `railway status --json`
+- **Variable change didn't take effect**: verify with `railway variable list`, changes trigger redeploy by default
+- **Domain returns errors**: verify the service has a healthy deployment and the target port is correct
+- **DNS propagation delay**: custom domains take time to propagate, this is normal
+- **Cloudflare proxy issues**: align SSL/TLS mode per Railway's domain guidance
+- **Private networking failing**: verify the service is listening on the referenced port and that the private domain variable reference is correct
+- **Multi-region patch ignored**: verify region names match the exact identifiers (`us-west2`, `us-east4-eqdc4a`, `europe-west4-drams3a`, `asia-southeast1-eqsg3a`)
+
+## Validated against
+
+- Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [variables.md](https://docs.railway.com/variables), [domains.md](https://docs.railway.com/networking/domains), [public-networking.md](https://docs.railway.com/networking/public-networking), [private-networking.md](https://docs.railway.com/networking/private-networking)
+- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/domain.rs), [controllers/config/patch.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/controllers/config/patch.rs)

--- a/.claude/skills/use-railway/references/deploy.md
+++ b/.claude/skills/use-railway/references/deploy.md
@@ -1,0 +1,184 @@
+# Deploy
+
+Ship code, manage releases, and configure builds.
+
+## Deploy code
+
+### Standard deploy
+
+```bash
+railway up --detach -m "<release summary>"
+```
+
+`--detach` returns immediately instead of streaming build logs. Without it, the deploy blocks execution until the build finishes. Always include `-m` with a release summary for auditability.
+
+### Watch the build
+
+```bash
+railway up --ci -m "<release summary>"
+```
+
+`--ci` streams build logs and exits when the build completes. Use this when the user wants to see build output or when you need to triage build failures immediately.
+
+### Targeted deploy
+
+When multiple services exist, target explicitly:
+
+```bash
+railway up --service <service> --environment <environment> --detach -m "<summary>"
+```
+
+### Deploy to an unlinked project
+
+For CI or cross-project deploys where the directory isn't linked:
+
+```bash
+railway up --project <project-id> --environment <environment> --detach -m "<summary>"
+```
+
+`--project` requires `--environment`. Railway needs both to resolve context.
+
+## Manage releases
+
+### Redeploy and restart
+
+```bash
+railway redeploy --service <service> --yes       # rebuild and deploy from same source
+railway restart --service <service> --yes         # restart without rebuilding
+```
+
+Redeploy triggers a full build cycle. Restart only restarts the running container. Use restart when the code hasn't changed but the service needs a fresh process (for example, after variable changes).
+
+### Remove latest deployment
+
+```bash
+railway down --service <service> --yes
+```
+
+This removes the latest successful deployment but doesn't delete the service. To delete a service entirely, use environment config patching (see [configure.md](configure.md)).
+
+## Deployment history and logs
+
+```bash
+railway deployment list --service <service> --limit 20 --json
+railway logs --service <service> --lines 200 --json              # runtime logs
+railway logs --service <service> --build --lines 200 --json      # build logs
+railway logs --latest --lines 200 --json                         # latest deployment
+```
+
+`railway logs` streams indefinitely when no bounding flags are given. An open stream blocks execution and never returns. Always use `--lines`, `--since`, or `--until` to get a bounded fetch.
+
+## Build configuration
+
+Railway uses Railpack as the default builder. It detects language and framework from repo contents and assembles a build plan automatically.
+
+### Builder selection
+
+Three builder options, set via service config:
+
+- **RAILPACK** auto-detects language and framework, builds from source (default)
+- **NIXPACKS** is the legacy builder. DO NOT USE THIS, use RAILPACK instead.
+- **DOCKERFILE** uses a Dockerfile you provide
+
+```bash
+railway environment edit --service-config <service> build.builder RAILPACK
+railway environment edit --service-config <service> build.builder DOCKERFILE
+railway environment edit --service-config <service> build.dockerfilePath "docker/Dockerfile.prod"
+```
+
+### Build and start commands
+
+Override when auto-detection gets it wrong:
+
+```bash
+railway environment edit --service-config <service> build.buildCommand "npm run build"
+railway environment edit --service-config <service> deploy.startCommand "npm start"
+```
+
+Common reasons to override: wrong package manager detected, multiple build targets in a monorepo, framework-specific output paths.
+
+### Railpack environment variables
+
+Control Railpack behavior by setting these as service variables:
+
+| Variable | Purpose |
+|---|---|
+| `RAILPACK_NODE_VERSION` | Pin Node.js version (e.g., `20`, `22.1.0`) |
+| `RAILPACK_PYTHON_VERSION` | Pin Python version (e.g., `3.12`) |
+| `RAILPACK_GO_BIN` | Go binary name to build |
+| `RAILPACK_STATIC_FILE_ROOT` | Directory for static site output (e.g., `dist`, `build`) |
+| `RAILPACK_SPA_OUTPUT_DIR` | SPA output directory with client-side routing support |
+| `RAILPACK_PACKAGES` | Additional system packages for the build |
+| `RAILPACK_BUILD_APT_PACKAGES` | Apt packages available during build only |
+| `RAILPACK_DEPLOY_APT_PACKAGES` | Apt packages available at runtime only |
+
+For full Railpack documentation including language-specific detection, config files, and framework support: https://railpack.com/llms.txt
+
+### Static sites
+
+Railpack detects static sites from `Staticfile`, `index.html`, or `RAILPACK_STATIC_FILE_ROOT` and serves them with a built-in static file server. If the build outputs to a non-standard directory (for example, `dist/`, `build/`), set `RAILPACK_STATIC_FILE_ROOT` as a variable so Railpack knows where to find the output.
+
+## Monorepo patterns
+
+### Isolated monorepo
+
+When services don't share code, isolate each with its own root directory:
+
+```bash
+railway environment edit --service-config <service> source.rootDirectory "/packages/api"
+```
+
+Each service sees only its subdirectory. This approach is clean but breaks if services import from shared packages.
+
+### Shared monorepo
+
+When services depend on shared packages or root-level workspace config, keep the full repo context and scope via build/start commands instead:
+
+```bash
+# pnpm workspaces
+railway environment edit --service-config <service> build.buildCommand "pnpm --filter api build"
+railway environment edit --service-config <service> deploy.startCommand "pnpm --filter api start"
+
+# yarn workspaces
+railway environment edit --service-config <service> build.buildCommand "yarn workspace api build"
+railway environment edit --service-config <service> deploy.startCommand "yarn workspace api start"
+
+# bun workspaces
+railway environment edit --service-config <service> build.buildCommand "bun run --filter api build"
+railway environment edit --service-config <service> deploy.startCommand "bun run --filter api start"
+
+# turborepo (works with any package manager)
+railway environment edit --service-config <service> build.buildCommand "npx turbo run build --filter=api"
+railway environment edit --service-config <service> deploy.startCommand "npx turbo run start --filter=api"
+```
+
+Don't set a restrictive `rootDirectory` in this case. The build needs access to the workspace root.
+
+### Watch paths
+
+Prevent unrelated package changes from redeploying every service:
+
+```bash
+railway environment edit --service-config <service> build.watchPatterns '["packages/api/**","packages/shared/**"]'
+```
+
+### Common monorepo pitfalls
+
+- **Using `rootDirectory` with shared imports**: if service A imports from `packages/shared/`, setting `rootDirectory: "/packages/a"` hides the shared code. Use the shared monorepo pattern instead.
+- **Forgetting watch paths**: without watch paths, every push redeploys all services, even when only one package changed.
+- **Wrong filter target**: `pnpm --filter api` uses the `name` field in each package's `package.json`, not the directory name. Verify the package name matches.
+
+## Troubleshoot deploys
+
+- **No project/service context**: run `railway link` or pass `--project` with `--environment`
+- **Build fails before compile**: check dependency graph, lockfiles, and whether the right builder is selected
+- **Build succeeds but app crashes**: verify start command and required runtime variables
+- **Wrong files in build**: check root directory and watch patterns
+- **`railway down` treated as delete**: `down` only removes the latest deployment. For full service deletion, use `isDeleted` in config patch (see [configure.md](configure.md))
+- **Wrong Node/Python version detected**: set `RAILPACK_NODE_VERSION` or `RAILPACK_PYTHON_VERSION` as a service variable to pin the version
+- **Missing system package at runtime**: add the package to `RAILPACK_DEPLOY_APT_PACKAGES`
+
+## Validated against
+
+- Docs: [up.md](https://docs.railway.com/cli/up), [deploying.md](https://docs.railway.com/cli/deploying), [deployment.md](https://docs.railway.com/cli/deployment), [down.md](https://docs.railway.com/cli/down), [railpack.md](https://docs.railway.com/builds/railpack), [monorepo.md](https://docs.railway.com/deployments/monorepo)
+- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/restart.rs)

--- a/.claude/skills/use-railway/references/operate.md
+++ b/.claude/skills/use-railway/references/operate.md
@@ -1,0 +1,175 @@
+# Operate
+
+Check health, read logs, query metrics, and troubleshoot failures.
+
+## Health snapshot
+
+Start broad, then narrow:
+
+```bash
+railway status --json                                    # linked context
+railway service status --all --json                      # all services, deployment states
+railway deployment list --limit 10 --json                # recent deployments
+```
+
+Deployment statuses: `SUCCESS`, `BUILDING`, `DEPLOYING`, `FAILED`, `CRASHED`, `REMOVED`.
+
+For projects with buckets, include bucket status:
+
+```bash
+railway bucket list --json                                       # buckets in current environment
+railway bucket info --bucket <name> --json                       # storage size, object count, region
+```
+
+If everything looks healthy, return a summary and stop. If something is degraded or failing, continue to log inspection.
+
+## Logs
+
+### Recent logs
+
+```bash
+railway logs --service <service> --lines 200 --json              # runtime logs
+railway logs --service <service> --build --lines 200 --json      # build logs
+railway logs --latest --lines 200 --json                         # latest deployment
+```
+
+`railway logs` streams indefinitely when no bounding flags are given. Always use `--lines`, `--since`, or `--until` to get a bounded fetch. Open streams block execution.
+
+### Time-bounded queries
+
+```bash
+railway logs --service <service> --since 1h --lines 400 --json
+railway logs --service <service> --since 30m --until 10m --lines 400 --json
+```
+
+### Filtered queries
+
+Use `--filter` to narrow logs without scanning everything manually:
+
+```bash
+railway logs --service <service> --lines 200 --filter "@level:error" --json
+railway logs --service <service> --lines 200 --filter "@level:warn AND timeout" --json
+railway logs --service <service> --lines 200 --filter "connection refused" --json
+```
+
+Filter syntax supports text search (`"error message"`), attribute filters (`@level:error`, `@level:warn`), and boolean operators (`AND`, `OR`, `-` for negation). Full syntax: https://docs.railway.com/guides/logs
+
+### Scoped by environment
+
+```bash
+railway logs --service <service> --environment <env> --lines 200 --json
+```
+
+## Metrics
+
+Resource usage metrics (CPU, memory, network, disk) are only available through the GraphQL API:
+
+```bash
+scripts/railway-api.sh \
+  'query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $groupBy: [MetricTag!], $measurements: [MetricMeasurement!]!) {
+    metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, groupBy: $groupBy, measurements: $measurements) {
+      measurement tags { serviceId deploymentId region } values { ts value }
+    }
+  }' \
+  '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
+```
+
+Available measurements: `CPU_USAGE`, `CPU_LIMIT`, `MEMORY_USAGE_GB`, `MEMORY_LIMIT_GB`, `NETWORK_RX_GB`, `NETWORK_TX_GB`, `DISK_USAGE_GB`, `EPHEMERAL_DISK_USAGE_GB`, `BACKUP_USAGE_GB`.
+
+Omit `serviceId` and add `"groupBy": ["SERVICE_ID"]` to query all services in the environment at once. Get the environment and service IDs from `railway status --json`.
+
+## Database inspection
+
+For database-level metrics and introspection, always use the analysis scripts. See [analyze-db.md](analyze-db.md) for comprehensive database analysis including:
+
+- Deep Postgres analysis (pg_stat_statements, vacuum health, index health, cache hit ratios)
+- HA cluster checks (Patroni, etcd, HAProxy)
+- Redis, MySQL, and MongoDB introspection
+- Combined analysis via `scripts/analyze-<type>.py` (postgres, mysql, redis, mongo)
+
+## Failure triage
+
+When something is broken, classify the failure first. The fix depends on the class.
+
+### Build failures
+
+The service failed to build. Look at build logs:
+
+```bash
+railway logs --latest --build --lines 400 --json
+```
+
+Common causes and fixes:
+- **Missing dependencies**: check lockfiles, verify package manager detection
+- **Wrong build command**: override with `railway environment edit --service-config <service> build.buildCommand "<command>"`
+- **Builder mismatch**: switch builders with `railway environment edit --service-config <service> build.builder RAILPACK`
+- **Wrong root directory** (monorepo): set `source.rootDirectory` to the correct package path
+
+### Runtime failures
+
+The build succeeded but the service crashes or misbehaves:
+
+```bash
+railway logs --latest --lines 400 --json
+railway logs --service <service> --since 1h --lines 400 --json
+```
+
+Common causes and fixes:
+- **Bad start command**: override with `railway environment edit --service-config <service> deploy.startCommand "<command>"`
+- **Missing runtime variable**: check `railway variable list --service <service> --json` and set missing values
+- **Port mismatch**: the service must listen on `$PORT` (Railway injects this). Verify with logs.
+- **Upstream dependency down**: check other services' status and logs
+
+### Config-driven failures
+
+Something worked before and broke after a config change:
+
+```bash
+railway environment config --json
+railway variable list --service <service> --json
+```
+
+Compare the config against expected values. Look for changes that may have introduced the regression.
+
+### Networking failures
+
+Domain returns errors, or service-to-service calls fail:
+
+```bash
+railway domain --service <service> --json
+railway logs --service <service> --lines 200 --json
+```
+
+Check: target port matches what the service listens on, domain status is healthy, private domain variable references are correct.
+
+## Recovery
+
+After identifying the cause, fix and verify:
+
+```bash
+# Fix (examples)
+railway environment edit --service-config <service> deploy.startCommand "<correct-command>"
+railway variable set MISSING_VAR=value --service <service>
+
+# Redeploy
+railway redeploy --service <service> --yes
+
+# Verify
+railway service status --service <service> --json
+railway logs --service <service> --lines 200 --json
+```
+
+Always verify after fixing. Don't assume the redeploy succeeded.
+
+## Troubleshoot common blockers
+
+- **Unlinked context**: `railway link --project <id-or-name>`
+- **Missing service scope for logs**: pass `--service` and `--environment` explicitly
+- **No deployments found**: the service exists but has never deployed, create an initial deploy first
+- **Metrics query returns empty**: verify IDs from `railway status --json` and check the time window
+- **Config patch type error**: check the typed paths in [configure.md](configure.md), for example, `numReplicas` is an integer, not a string
+
+## Validated against
+
+- Docs: [status.md](https://docs.railway.com/cli/status), [logs.md](https://docs.railway.com/cli/logs), [observability.md](https://docs.railway.com/observability), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
+- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/status.rs), [logs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/logs.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs)

--- a/.claude/skills/use-railway/references/request.md
+++ b/.claude/skills/use-railway/references/request.md
@@ -1,0 +1,238 @@
+# Request
+
+Official documentation and community endpoints. GraphQL operations for things the CLI doesn't expose.
+
+## Official documentation
+
+Primary sources for authoritative Railway information:
+
+- **Full LLM docs**: `https://docs.railway.com/api/llms-docs.md`
+- **LLM summary**: `https://railway.com/llms.txt`
+- **Templates**: `https://railway.com/llms-templates.md`
+- **Changelog**: `https://railway.com/llms-changelog.md`
+- **Blog**: `https://blog.railway.com/llms-blog.md`
+- **Direct doc pages**: `https://docs.railway.com/<path>` (for example, `cli/up`, `networking/domains`, `observability/logs`)
+
+Tip: append `.md` to any `docs.railway.com` page URL to get a markdown version suitable for LLM consumption.
+
+Common doc paths:
+
+| Topic | Path |
+|---|---|
+| Projects | `guides/projects` |
+| Deployments | `guides/deployments` |
+| Volumes | `guides/volumes` |
+| Variables | `guides/variables` |
+| CLI reference | `reference/cli-api` |
+| Pricing | `reference/pricing` |
+| Public networking | `networking/public-networking` |
+| Private networking | `networking/private-networking` |
+
+Fetch official docs first for product behavior questions. Use Central Station only when you need community evidence, prior incidents, or implementation anecdotes.
+
+
+## Central Station (community)
+
+Search and browse Railway's community platform for prior discussions, issue patterns, and field solutions.
+
+### Recent threads
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, sort: recent_activity) { edges { node { slug subject status upvoteCount createdAt topic { slug displayName } } } } }"}'
+```
+
+Filter by topic with the `topic` parameter (`"questions"`, `"feedback"`, `"community"`, `"billing"`):
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, sort: recent_activity, topic: \"questions\") { edges { node { slug subject status topic { displayName } upvoteCount } } } }"}'
+```
+
+Sort options: `recent_activity` (default), `newest`, `highest_votes`.
+
+### Search threads
+
+```bash
+curl -s 'https://station-server.railway.com/gql' \
+  -H 'content-type: application/json' \
+  -d '{"query":"{ threads(first: 10, search: \"<search-term>\") { edges { node { slug subject status } } } }"}'
+```
+
+### LLM data export
+
+Bulk search alternative — fetches all public threads with full content:
+
+```bash
+curl -s 'https://station-server.railway.com/api/llms-station'
+```
+
+### Read a full thread
+
+```bash
+curl -s 'https://station-server.railway.com/api/threads/<slug>?format=md'
+```
+
+Thread URLs follow the format: `https://station.railway.com/{topic_slug}/{thread_slug}`
+
+Community threads are anecdotal. Always pair with official docs when the answer informs an operational decision.
+
+
+## GraphQL helper
+
+All GraphQL operations use the API helper script, which handles authentication automatically:
+
+```bash
+scripts/railway-api.sh '<query>' '<variables-json>'
+```
+
+The script reads the API token from `~/.railway/config.json` and sends requests to `https://backboard.railway.com/graphql/v2`.
+
+For the full API schema, see: https://docs.railway.com/api/llms-docs.md
+
+## Project mutations
+
+The CLI doesn't expose project setting updates (rename, PR deploys, visibility). Use GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
+    projectUpdate(id: $id, input: $input) { id name isPublic prDeploys botPrEnvironments }
+  }' \
+  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+```
+
+Common `ProjectUpdateInput` fields: `name`, `isPublic`, `prDeploys`, `botPrEnvironments`.
+
+
+## Service mutations
+
+The CLI can create services (`railway add`) but cannot rename them or change icons. Use GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateService($id: String!, $input: ServiceUpdateInput!) {
+    serviceUpdate(id: $id, input: $input) { id name icon }
+  }' \
+  '{"id":"<service-id>","input":{"name":"new-name"}}'
+```
+
+`ServiceUpdateInput` fields: `name`, `icon` (image URL, animated GIF, or devicons URL like `https://devicons.railway.app/postgres`).
+
+Get the service ID from `railway status --json`.
+
+
+## Service creation via GraphQL
+
+Prefer `railway add` for most cases. Use GraphQL for programmatic or advanced use:
+
+```bash
+scripts/railway-api.sh \
+  'mutation createService($input: ServiceCreateInput!) {
+    serviceCreate(input: $input) { id name }
+  }' \
+  '{"input":{"projectId":"<project-id>","name":"my-service","source":{"image":"nginx:latest"}}}'
+```
+
+`ServiceCreateInput` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `projectId` | String! | Target project (required) |
+| `name` | String | Service name (auto-generated if omitted) |
+| `source.image` | String | Docker image (for example, `nginx:latest`) |
+| `source.repo` | String | GitHub repo (for example, `user/repo`) |
+| `branch` | String | Git branch for repo source |
+| `environmentId` | String | Create only in a specific environment |
+
+After creating a service via GraphQL, configure it with a JSON config patch including `isCreated: true` (see [configure.md](configure.md)).
+
+
+## Metrics queries
+
+Resource usage metrics are only available via GraphQL:
+
+```bash
+scripts/railway-api.sh \
+  'query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $endDate: DateTime, $sampleRateSeconds: Int, $averagingWindowSeconds: Int, $groupBy: [MetricTag!], $measurements: [MetricMeasurement!]!) {
+    metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, endDate: $endDate, sampleRateSeconds: $sampleRateSeconds, averagingWindowSeconds: $averagingWindowSeconds, groupBy: $groupBy, measurements: $measurements) {
+      measurement tags { serviceId deploymentId region } values { ts value }
+    }
+  }' \
+  '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
+```
+
+Available `MetricMeasurement` values: `CPU_USAGE`, `CPU_LIMIT`, `MEMORY_USAGE_GB`, `MEMORY_LIMIT_GB`, `NETWORK_RX_GB`, `NETWORK_TX_GB`, `DISK_USAGE_GB`, `EPHEMERAL_DISK_USAGE_GB`, `BACKUP_USAGE_GB`.
+
+Optional parameters: `endDate` (defaults to now), `sampleRateSeconds`, `averagingWindowSeconds`. Use `groupBy: ["SERVICE_ID"]` without `serviceId` to query all services in an environment at once. Valid `MetricTag` values for `groupBy`: `SERVICE_ID`, `DEPLOYMENT_ID`, `DEPLOYMENT_INSTANCE_ID`, `REGION`.
+
+Get environment and service IDs from `railway status --json`.
+
+## Template search
+
+Search Railway's template marketplace:
+
+```bash
+scripts/railway-api.sh \
+  'query templates($query: String!, $verified: Boolean, $recommended: Boolean) {
+    templates(query: $query, verified: $verified, recommended: $recommended) {
+      edges { node { code name description category } }
+    }
+  }' \
+  '{"query":"redis","verified":true}'
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | String | Search term |
+| `verified` | Boolean | Only verified templates |
+| `recommended` | Boolean | Only recommended templates |
+| `first` | Int | Number of results (max ~100) |
+
+Common template codes: `ghost`, `strapi`, `minio`, `n8n`, `uptime-kuma`, `umami`, `postgres`, `redis`, `mysql`, `mongodb`.
+
+Deploy a found template via CLI:
+
+```bash
+railway deploy --template <template-code>
+```
+
+### GraphQL template deployment
+
+For deploying into a specific environment or tracking the workflow, use the two-step GraphQL flow:
+
+**Step 1** — Fetch the template config:
+
+```bash
+scripts/railway-api.sh \
+  'query template($code: String!) {
+    template(code: $code) { id serializedConfig }
+  }' \
+  '{"code":"postgres"}'
+```
+
+**Step 2** — Deploy with `templateDeployV2`:
+
+```bash
+scripts/railway-api.sh \
+  'mutation deploy($input: TemplateDeployV2Input!) {
+    templateDeployV2(input: $input) { projectId workflowId }
+  }' \
+  '{"input":{
+    "templateId":"<id-from-step-1>",
+    "serializedConfig":<config-object-from-step-1>,
+    "projectId":"<project-id>",
+    "environmentId":"<env-id>",
+    "workspaceId":"<workspace-id>"
+  }}'
+```
+
+`serializedConfig` is the raw JSON object from the template query, not a string. Get `workspaceId` via `scripts/railway-api.sh 'query { project(id: "<project-id>") { workspaceId } }' '{}'`.
+
+
+## Validated against
+
+- Docs: [api docs](https://docs.railway.com/api/llms-docs.md), [community.md](https://docs.railway.com/community), [cli/docs.md](https://docs.railway.com/cli/docs)
+- CLI source: [docs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/docs.rs)

--- a/.claude/skills/use-railway/references/setup.md
+++ b/.claude/skills/use-railway/references/setup.md
@@ -1,0 +1,288 @@
+# Setup
+
+Create, link, and organize Railway projects, services, databases, and workspaces.
+
+## Projects
+
+### List and discover
+
+```bash
+railway project list --json        # projects in current workspace
+railway list --json                # all projects across workspaces with service metadata
+railway whoami --json              # current user, workspace memberships
+```
+
+### Link to an existing project
+
+Linking sets the working context for all subsequent CLI commands in this directory.
+
+```bash
+railway link --project <project-id-or-name>
+railway status --json              # confirm linked context
+```
+
+Without `--project`, `railway link` runs interactively. For scripted or CI use, always pass explicit flags.
+
+### Link to a specific service
+
+Switch the linked service within an already-linked project:
+
+```bash
+railway service link              # interactive service picker
+railway service link <name>       # link directly by name
+```
+
+### Create a new project
+
+```bash
+railway init --name <project-name>
+railway init --name <project-name> --workspace <workspace-id-or-name>
+```
+
+`railway init` both creates and links in one step. In CI or multi-workspace setups, pass `--workspace` explicitly to avoid ambiguity.
+
+### Update project settings
+
+Settings like project name, PR deploys, and visibility aren't exposed through the CLI. Use the GraphQL API helper (see [request.md](request.md)):
+
+```bash
+scripts/railway-api.sh \
+  'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
+    projectUpdate(id: $id, input: $input) { id name isPublic prDeploys }
+  }' \
+  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+```
+
+## Services
+
+### Create a service
+
+```bash
+railway add --service <service-name>          # empty service
+railway add --database postgres               # managed database (postgres, redis, mysql, mongodb)
+railway add                                   # interactive, prompts for type
+```
+
+Before adding a database, check for existing database services to avoid duplicates. Run `railway environment config --json` and inspect `source.image` for each service:
+
+| Image pattern | Database |
+|---|---|
+| `ghcr.io/railway/postgres*` or `postgres:*` | Postgres |
+| `ghcr.io/railway/redis*` or `redis:*` | Redis |
+| `ghcr.io/railway/mysql*` or `mysql:*` | MySQL |
+| `ghcr.io/railway/mongo*` or `mongo:*` | MongoDB |
+
+If a matching database already exists, skip creation and wire the existing service's variables to the app.
+
+Empty services have no source until you configure one. This is the right pattern when you need to set source repo, branch, or build config before the first deploy.
+
+### Connect a database to a service
+
+After `railway add --database <type>`, the database creates connection variables automatically. Wire them to your app service using variable references:
+
+| Database | Connection variable |
+|---|---|
+| Postgres | `${{Postgres.DATABASE_URL}}` |
+| Redis | `${{Redis.REDIS_URL}}` |
+| MySQL | `${{MySQL.MYSQL_URL}}` |
+| MongoDB | `${{MongoDB.MONGO_URL}}` |
+
+```bash
+railway variable set DATABASE_URL='${{Postgres.DATABASE_URL}}' --service <app-service>
+```
+
+Service names in variable references are case-sensitive and must match exactly. For full wiring details including public/private networking decisions, see [configure.md](configure.md).
+
+When creating new service instances via JSON config patches, include `isCreated: true` in the service block to mark it as a new service.
+
+### Deploy from a template
+
+Templates provision pre-configured services with sensible defaults, faster than creating an empty service and configuring it manually:
+
+```bash
+railway deploy --template <template-code>
+```
+
+Common template codes: `postgres`, `redis`, `mysql`, `mongodb`, `minio`, `umami`. For the full list, search via the GraphQL API (see [request.md](request.md)).
+
+Template deployments typically create:
+
+- A service with pre-configured image or source
+- Environment variables (connection strings, secrets)
+- A volume for persistent data (databases)
+- A TCP proxy for external access (where applicable)
+
+### Bootstrap source for an empty service
+
+After creating an empty service, wire it to a repo:
+
+```bash
+railway environment edit --service-config <service> source.repo <repo-url>
+railway environment edit --service-config <service> source.branch <branch>
+```
+
+### Deploy a Docker image
+
+When you have a built image (for example, from a private registry or Docker Hub), skip source builds entirely:
+
+```bash
+railway environment edit --service-config <service> source.image <image:tag>
+```
+
+This sets the service to pull from a container registry instead of building from source.
+
+## Buckets
+
+Buckets are S3-compatible object storage. They are created at the project level and deployed to environments via config patches.
+
+### List buckets
+
+```bash
+railway bucket list --json                                # buckets in current environment
+railway bucket list --environment production --json       # buckets in a specific environment
+```
+
+### Create a bucket
+
+```bash
+railway bucket create my-bucket --region sjc              # create with name and region
+railway bucket create --region iad --json                 # auto-named, JSON output
+```
+
+Available regions:
+
+| Code | Location |
+|---|---|
+| `sjc` | US West (California) |
+| `iad` | US East (Virginia) |
+| `ams` | EU West (Amsterdam) |
+| `sin` | Asia Pacific (Singapore) |
+
+Without `--region`, the CLI prompts interactively. For scripted use, always pass `--region`.
+
+### Delete a bucket
+
+Deletion is permanent and destroys all objects in the bucket.
+
+```bash
+railway bucket delete --bucket my-bucket --yes            # non-interactive
+railway bucket delete --bucket my-bucket --yes --2fa-code 123456   # with 2FA
+```
+
+### Rename a bucket
+
+```bash
+railway bucket rename --bucket my-bucket --name new-name --json
+```
+
+### Bucket info
+
+Check storage usage and object count:
+
+```bash
+railway bucket info --bucket my-bucket --json
+```
+
+Returns storage size (bytes), object count, region, and environment.
+
+### Bucket credentials
+
+Get S3-compatible credentials for connecting your app to a bucket:
+
+```bash
+railway bucket credentials --bucket my-bucket --json
+```
+
+Returns: `endpoint`, `accessKeyId`, `secretAccessKey`, `bucketName`, `region`, `urlStyle`.
+
+Without `--json`, output uses `AWS_*=value` lines suitable for `eval $(railway bucket credentials)` or piping into `.env` files.
+
+To reset credentials (invalidates existing ones):
+
+```bash
+railway bucket credentials --bucket my-bucket --reset --yes
+railway bucket credentials --bucket my-bucket --reset --yes --2fa-code 123456  # with 2FA
+```
+
+### Connect a bucket to a service
+
+After creating a bucket, wire the S3 credentials to your app service as environment variables:
+
+```bash
+# Get credentials
+railway bucket credentials --bucket my-bucket --json
+
+# Set them on your app service
+railway variable set \
+  AWS_ENDPOINT_URL=<endpoint> \
+  AWS_ACCESS_KEY_ID=<access-key> \
+  AWS_SECRET_ACCESS_KEY=<secret-key> \
+  AWS_S3_BUCKET_NAME=<bucket-name> \
+  AWS_DEFAULT_REGION=<region> \
+  --service <app-service>
+```
+
+All subcommands support `--bucket (-b)` and `--environment (-e)` as global flags to skip interactive prompts.
+
+## Analyze codebase before setup
+
+When setting up a new service from source, detect the project type from marker files:
+
+| Marker file | Type |
+|---|---|
+| `package.json` | Node.js |
+| `requirements.txt` or `pyproject.toml` | Python |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `index.html` (no package.json) | Static site |
+
+### Monorepo detection
+
+| Marker | Monorepo type |
+|---|---|
+| `pnpm-workspace.yaml` | pnpm workspace (shared) |
+| `package.json` with `workspaces` field | npm/yarn workspace (shared) |
+| `turbo.json` | Turborepo (shared) |
+| Multiple subdirectories with separate `package.json`, no workspace config | Isolated monorepo |
+
+**Isolated monorepo** (apps don't share code): set `rootDirectory` to the app's subdirectory (for example, `/apps/api`).
+
+**Shared monorepo** (TypeScript workspaces, shared packages): do not set `rootDirectory`. Set custom build and start commands instead:
+
+- pnpm: `pnpm --filter <package> build`
+- npm: `npm run build --workspace=packages/<package>`
+- yarn: `yarn workspace <package> build`
+- Turborepo: `turbo run build --filter=<package>`
+
+### Scaffolding hints
+
+When no code exists, minimal starting points for common types:
+
+- **Static site**: create `index.html` in the root directory.
+- **Vite React**: `npm create vite@latest . -- --template react`
+- **Python FastAPI**: create `main.py` with a FastAPI app and `requirements.txt` with `fastapi` and `uvicorn`.
+- **Go**: create `main.go` with an HTTP server that reads `PORT` from the environment.
+
+## Workspaces
+
+Workspaces scope billing and team access. Most users have one personal workspace and possibly team workspaces.
+
+```bash
+railway whoami --json              # lists workspace memberships
+```
+
+When creating projects, Railway uses the default workspace unless `--workspace` is specified.
+
+## Troubleshoot setup issues
+
+- **CLI missing**: install via `brew install railway` or `curl -fsSL https://railway.com/install.sh | sh`
+- **Not authenticated**: `railway login`
+- **Project not found**: verify with `railway project list --json`, check workspace context
+- **Service not found**: `railway service status --all --json` to list all services in the project
+- **Wrong workspace**: inspect `railway whoami --json`, re-run with explicit `--workspace`
+- **Permission denied**: check workspace role, mutations require member or admin access
+
+## Validated against
+
+- Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
+- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/project.rs), [list.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/feat/bucket-command/src/commands/bucket.rs)

--- a/.claude/skills/use-railway/scripts/analyze-mongo.py
+++ b/.claude/skills/use-railway/scripts/analyze-mongo.py
@@ -1,0 +1,1549 @@
+#!/usr/bin/env python3
+"""
+MongoDB analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status & overview
+- Connections & operations
+- Latency (opLatencies)
+- Memory & WiredTiger cache
+- Storage & collection stats
+- Replication / oplog
+- Slow queries & active operations
+- Top collections by activity
+- Recommendations
+
+Usage:
+    analyze-mongo.py --service <name>
+    analyze-mongo.py --service <name> --json
+    analyze-mongo.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _trend_indicator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MongoAnalysisResult:
+    """Container for MongoDB analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Server overview
+    version: Optional[str] = None
+    storage_engine: Optional[str] = None
+    uptime_seconds: Optional[int] = None
+
+    # Connections
+    connections: Optional[Dict[str, Any]] = None
+
+    # Operations
+    opcounters: Optional[Dict[str, Any]] = None
+    opcounters_repl: Optional[Dict[str, Any]] = None
+
+    # Latency
+    op_latencies: Optional[Dict[str, Any]] = None
+
+    # Memory
+    memory: Optional[Dict[str, Any]] = None
+    page_faults: Optional[int] = None
+
+    # Network
+    network: Optional[Dict[str, Any]] = None
+
+    # WiredTiger
+    wiredtiger_cache: Optional[Dict[str, Any]] = None
+    wiredtiger_checkpoint: Optional[Dict[str, Any]] = None
+    wiredtiger_tickets: Optional[Dict[str, Any]] = None
+
+    # Global lock
+    global_lock: Optional[Dict[str, Any]] = None
+
+    # Document metrics
+    document_metrics: Optional[Dict[str, Any]] = None
+
+    # Query efficiency
+    query_executor: Optional[Dict[str, Any]] = None
+
+    # Plan cache (7.0+)
+    plan_cache: Optional[Dict[str, Any]] = None
+
+    # Sort (7.0+)
+    sort_metrics: Optional[Dict[str, Any]] = None
+
+    # Cursors
+    cursors: Optional[Dict[str, Any]] = None
+
+    # TTL
+    ttl_metrics: Optional[Dict[str, Any]] = None
+
+    # Asserts
+    asserts: Optional[Dict[str, Any]] = None
+
+    # Replication
+    replication: Optional[Dict[str, Any]] = None
+    oplog: Optional[Dict[str, Any]] = None
+
+    # Storage (db.stats)
+    storage: Optional[Dict[str, Any]] = None
+
+    # Collection stats
+    collection_stats: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Top collections
+    top_collections: Optional[List[Dict[str, Any]]] = None
+
+    # Slow queries
+    slow_queries: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Active operations
+    active_ops: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Logs
+    recent_logs: List[str] = field(default_factory=list)
+    recent_errors: List[str] = field(default_factory=list)
+
+    # Railway metrics (CPU, memory, disk, network trends)
+    cpu_memory: Optional[Dict[str, Any]] = None
+    disk_usage: Optional[Dict[str, Any]] = None
+    metrics_history: Optional[Dict[str, Any]] = None
+
+    # Status tracking
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# MongoDB-specific helpers
+# ---------------------------------------------------------------------------
+
+def run_mongosh_query(service: str, js_expr: str, timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a mongosh query via SSH and return (returncode, stdout, stderr).
+
+    The query is wrapped in EJSON.stringify and executed through mongosh
+    connecting to the local MongoDB instance using container env vars.
+    """
+    # Escape single quotes in the JS expression for the shell
+    escaped = js_expr.replace("'", "'\\''")
+    command = (
+        f'''bash +H -c 'mongosh "mongodb://$MONGOUSER:$MONGOPASSWORD@localhost:27017" '''
+        f'''--quiet --norc --eval "EJSON.stringify({escaped})"' '''
+    )
+    return run_ssh_query(service, command, timeout)
+
+
+
+# ---------------------------------------------------------------------------
+# MongoDB queries
+# ---------------------------------------------------------------------------
+
+QUERY_SERVER_STATUS = """(function(){ var s = db.serverStatus(); return { connections: s.connections, opcounters: s.opcounters, opcountersRepl: s.opcountersRepl || null, repl: s.repl || null, mem: s.mem, network: s.network, uptime: s.uptime, opLatencies: s.opLatencies, wiredTiger: s.wiredTiger ? { cache: s.wiredTiger.cache, concurrentTransactions: s.wiredTiger.concurrentTransactions, transaction: s.wiredTiger.transaction || null } : null, globalLock: s.globalLock, metrics: s.metrics ? { document: s.metrics.document, queryExecutor: s.metrics.queryExecutor, cursor: s.metrics.cursor, ttl: s.metrics.ttl || null, query: s.metrics.query || null } : null, extra_info: s.extra_info ? { page_faults: s.extra_info.page_faults } : null, version: s.version, storageEngine: s.storageEngine, asserts: s.asserts }; })()"""
+
+QUERY_DB_STATS = """db.stats()"""
+
+QUERY_CURRENT_OP = """db.currentOp({ active: true })"""
+
+QUERY_COLLECTION_STATS = """db.getCollectionNames().map(function(c) { var s = db.getCollection(c).stats(); return { name: c, count: s.count || 0, size: s.size || 0, storageSize: s.storageSize || 0, indexSize: s.totalIndexSize || 0, nindexes: s.nindexes || 0 }; })"""
+
+QUERY_SLOW_QUERIES = """(function(){ try { var logs = db.system.profile.find().sort({ts: -1}).limit(10).toArray(); return logs.map(function(l) { return { op: l.op, ns: l.ns, millis: l.millis, ts: l.ts, command: JSON.stringify(l.command || l.query || {}).substring(0, 200), planSummary: l.planSummary || '' }; }); } catch(e) { return []; } })()"""
+
+QUERY_REPL_INFO = """(function(){ try { var info = db.getReplicationInfo(); return { logSizeMB: info.logSizeMB, usedMB: info.usedMB, timeDiffHours: info.timeDiffHours }; } catch(e) { return null; } })()"""
+
+QUERY_TOP = """(function(){ try { var t = db.adminCommand({top:1}); var totals = t.totals; var result = []; for (var ns in totals) { if (ns.indexOf('.') > 0 && ns.indexOf('system.') === -1) { var c = totals[ns]; result.push({ ns: ns, reads: c.readLock ? c.readLock.count : 0, readTimeUs: c.readLock ? c.readLock.time : 0, writes: c.writeLock ? c.writeLock.count : 0, writeTimeUs: c.writeLock ? c.writeLock.time : 0 }); } } return result; } catch(e) { return null; } })()"""
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _safe_json(raw: str) -> Any:
+    """Parse JSON from mongosh EJSON output, returning None on failure."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    # mongosh may emit warnings before the JSON; find the first { or [
+    for i, ch in enumerate(raw):
+        if ch in ('{', '['):
+            raw = raw[i:]
+            break
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _parse_server_status(data: Dict[str, Any], result: MongoAnalysisResult) -> None:
+    """Extract metrics from serverStatus into result."""
+    # Overview
+    result.version = data.get("version")
+    se = data.get("storageEngine")
+    if se:
+        result.storage_engine = se.get("name")
+    result.uptime_seconds = data.get("uptime")
+
+    # Connections
+    conn = data.get("connections")
+    if conn:
+        result.connections = {
+            "current": conn.get("current", 0),
+            "available": conn.get("available", 0),
+            "totalCreated": conn.get("totalCreated", 0),
+        }
+
+    # Opcounters
+    result.opcounters = data.get("opcounters")
+    result.opcounters_repl = data.get("opcountersRepl")
+
+    # Replication info from serverStatus
+    repl = data.get("repl")
+    if repl:
+        result.replication = {
+            "setName": repl.get("setName"),
+            "isWritablePrimary": repl.get("isWritablePrimary"),
+            "primary": repl.get("primary"),
+            "hosts": repl.get("hosts"),
+        }
+
+    # Latency
+    lat = data.get("opLatencies")
+    if lat:
+        result.op_latencies = {}
+        for key in ("reads", "writes", "commands"):
+            entry = lat.get(key, {})
+            ops = entry.get("ops", 0)
+            latency = entry.get("latency", 0)
+            result.op_latencies[key] = {
+                "latency": latency,
+                "ops": ops,
+                "avg_us": round(latency / ops, 1) if ops > 0 else 0,
+            }
+
+    # Memory
+    mem = data.get("mem")
+    if mem:
+        result.memory = {
+            "resident_mb": mem.get("resident", 0),
+            "virtual_mb": mem.get("virtual", 0),
+        }
+
+    extra = data.get("extra_info")
+    if extra:
+        result.page_faults = extra.get("page_faults", 0)
+
+    # Network
+    net = data.get("network")
+    if net:
+        result.network = {
+            "bytesIn": net.get("bytesIn", 0),
+            "bytesOut": net.get("bytesOut", 0),
+            "numRequests": net.get("numRequests", 0),
+        }
+
+    # WiredTiger
+    wt = data.get("wiredTiger")
+    if wt:
+        cache = wt.get("cache", {})
+        result.wiredtiger_cache = {
+            "bytes_in_cache": cache.get("bytes currently in the cache", 0),
+            "max_bytes": cache.get("maximum bytes configured", 0),
+            "dirty_bytes": cache.get("tracked dirty bytes in the cache", 0),
+            "pages_read": cache.get("pages read into cache", 0),
+            "pages_written": cache.get("pages written from cache", 0),
+            "app_evictions": cache.get("pages evicted by application threads", 0),
+        }
+
+        txn = wt.get("transaction", {})
+        if txn:
+            result.wiredtiger_checkpoint = {
+                "most_recent_time_ms": txn.get("transaction checkpoint most recent time (msecs)", 0),
+            }
+
+        ct = wt.get("concurrentTransactions", {})
+        if ct:
+            read_info = ct.get("read", {})
+            write_info = ct.get("write", {})
+            result.wiredtiger_tickets = {
+                "read_available": read_info.get("available", 0),
+                "read_total": read_info.get("totalTickets", 0),
+                "write_available": write_info.get("available", 0),
+                "write_total": write_info.get("totalTickets", 0),
+            }
+
+    # Global lock
+    gl = data.get("globalLock")
+    if gl:
+        cq = gl.get("currentQueue", {})
+        ac = gl.get("activeClients", {})
+        result.global_lock = {
+            "queue_readers": cq.get("readers", 0),
+            "queue_writers": cq.get("writers", 0),
+            "active_readers": ac.get("readers", 0),
+            "active_writers": ac.get("writers", 0),
+        }
+
+    # Metrics
+    metrics = data.get("metrics")
+    if metrics:
+        doc = metrics.get("document")
+        if doc:
+            result.document_metrics = {
+                "inserted": doc.get("inserted", 0),
+                "updated": doc.get("updated", 0),
+                "deleted": doc.get("deleted", 0),
+                "returned": doc.get("returned", 0),
+            }
+
+        qe = metrics.get("queryExecutor")
+        if qe:
+            result.query_executor = {
+                "scanned": qe.get("scanned", 0),
+                "scannedObjects": qe.get("scannedObjects", 0),
+            }
+
+        cursor = metrics.get("cursor")
+        if cursor:
+            open_cursors = cursor.get("open", {})
+            result.cursors = {
+                "open_total": open_cursors.get("total", 0),
+                "timed_out": cursor.get("timedOut", 0),
+            }
+
+        ttl = metrics.get("ttl")
+        if ttl:
+            result.ttl_metrics = {
+                "deletedDocuments": ttl.get("deletedDocuments", 0),
+                "passes": ttl.get("passes", 0),
+            }
+
+        query_metrics = metrics.get("query")
+        if query_metrics:
+            pc = query_metrics.get("planCache", {})
+            if pc:
+                result.plan_cache = {
+                    "hits": pc.get("hits", 0),
+                    "misses": pc.get("misses", 0),
+                }
+            sort = query_metrics.get("sort", {})
+            if sort:
+                result.sort_metrics = {
+                    "spillToDisk": sort.get("spillToDisk", 0),
+                    "totalBytesSorted": sort.get("totalBytesSorted", 0),
+                }
+
+    # Asserts
+    result.asserts = data.get("asserts")
+
+
+def _parse_db_stats(data: Dict[str, Any], result: MongoAnalysisResult) -> None:
+    """Extract metrics from db.stats()."""
+    result.storage = {
+        "dataSize": data.get("dataSize", 0),
+        "storageSize": data.get("storageSize", 0),
+        "indexSize": data.get("indexSize", 0),
+        "objects": data.get("objects", 0),
+        "collections": data.get("collections", 0),
+    }
+
+
+def _parse_current_op(data: Any, result: MongoAnalysisResult) -> None:
+    """Extract active operations from currentOp."""
+    if not data:
+        return
+    inprog = data.get("inprog", []) if isinstance(data, dict) else []
+    ops = []
+    for op in inprog:
+        ops.append({
+            "opid": op.get("opid"),
+            "type": op.get("type", op.get("op", "")),
+            "ns": op.get("ns", ""),
+            "microsecs_running": op.get("microsecs_running", 0),
+            "desc": op.get("desc", ""),
+        })
+    result.active_ops = ops
+
+
+def _parse_collection_stats(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse per-collection stats."""
+    if not isinstance(data, list):
+        return
+    result.collection_stats = data
+
+
+def _parse_slow_queries(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse slow queries from profiler."""
+    if not isinstance(data, list):
+        return
+    result.slow_queries = data
+
+
+def _parse_repl_info(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse oplog replication info."""
+    if not data or not isinstance(data, dict):
+        return
+    result.oplog = {
+        "logSizeMB": data.get("logSizeMB", 0),
+        "usedMB": data.get("usedMB", 0),
+        "timeDiffHours": data.get("timeDiffHours", 0),
+    }
+
+
+def _parse_top(data: Any, result: MongoAnalysisResult) -> None:
+    """Parse top collection activity."""
+    if not isinstance(data, list):
+        return
+    result.top_collections = data
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_bytes(b: int) -> str:
+    """Format bytes as human-readable."""
+    if b >= 1024 * 1024 * 1024:
+        return f"{b / 1024 / 1024 / 1024:.1f} GB"
+    elif b >= 1024 * 1024:
+        return f"{b / 1024 / 1024:.1f} MB"
+    elif b >= 1024:
+        return f"{b / 1024:.1f} KB"
+    return f"{b} B"
+
+
+def _fmt_count(n: int) -> str:
+    """Format large numbers with K/M suffix."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    elif n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def _fmt_uptime(seconds: int) -> str:
+    """Format seconds as Xd Yh."""
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
+    if days > 0:
+        return f"{days}d {hours}h"
+    elif hours > 0:
+        return f"{hours}h {(seconds % 3600) // 60}m"
+    return f"{seconds // 60}m"
+
+
+def _fmt_us(microseconds: float) -> str:
+    """Format microseconds as human-readable latency."""
+    if microseconds >= 1_000_000:
+        return f"{microseconds / 1_000_000:.1f}s"
+    elif microseconds >= 1_000:
+        return f"{microseconds / 1_000:.1f}ms"
+    return f"{microseconds:.0f}us"
+
+
+# ---------------------------------------------------------------------------
+# Main analysis
+# ---------------------------------------------------------------------------
+
+def analyze_mongo(service: str, timeout: int = 300, quiet: bool = False,
+                  skip_logs: bool = False, metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> MongoAnalysisResult:
+    """Run complete MongoDB analysis."""
+    if not quiet:
+        print(f"Analyzing MongoDB database: {service}", file=sys.stderr)
+
+    result = MongoAnalysisResult(
+        service=service,
+        db_type="mongo",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === CONTEXT ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # === DEPLOYMENT STATUS ===
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL DATA COLLECTION ===
+    progress(3, 5, "Running analysis (metrics, mongo queries, logs in parallel)...", quiet)
+
+    def task_metrics():
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_mongo_batch1():
+        """serverStatus + dbStats + collectionStats."""
+        if not ssh_available:
+            return ("error", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        results = {}
+        # serverStatus
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SERVER_STATUS, timeout=30)
+        if code == 0:
+            results["serverStatus"] = _safe_json(stdout)
+        else:
+            results["serverStatus_error"] = stderr or stdout or "unknown"
+        # dbStats
+        code, stdout, stderr = run_mongosh_query(service, QUERY_DB_STATS, timeout=30)
+        if code == 0:
+            results["dbStats"] = _safe_json(stdout)
+        else:
+            results["dbStats_error"] = stderr or stdout or "unknown"
+        # collectionStats
+        code, stdout, stderr = run_mongosh_query(service, QUERY_COLLECTION_STATS, timeout=30)
+        if code == 0:
+            results["collStats"] = _safe_json(stdout)
+        else:
+            results["collStats_error"] = stderr or stdout or "unknown"
+        return ("ok", results)
+
+    def task_mongo_batch2():
+        """slowQueries + currentOp + replInfo + top."""
+        if not ssh_available:
+            return ("error", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        results = {}
+        # slow queries
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SLOW_QUERIES, timeout=30)
+        if code == 0:
+            results["slowQueries"] = _safe_json(stdout)
+        else:
+            results["slowQueries_error"] = stderr or stdout or "unknown"
+        # currentOp
+        code, stdout, stderr = run_mongosh_query(service, QUERY_CURRENT_OP, timeout=30)
+        if code == 0:
+            results["currentOp"] = _safe_json(stdout)
+        else:
+            results["currentOp_error"] = stderr or stdout or "unknown"
+        # replication info
+        code, stdout, stderr = run_mongosh_query(service, QUERY_REPL_INFO, timeout=30)
+        if code == 0:
+            results["replInfo"] = _safe_json(stdout)
+        else:
+            results["replInfo_error"] = stderr or stdout or "unknown"
+        # top
+        code, stdout, stderr = run_mongosh_query(service, QUERY_TOP, timeout=30)
+        if code == 0:
+            results["top"] = _safe_json(stdout)
+        else:
+            results["top_error"] = stderr or stdout or "unknown"
+        return ("ok", results)
+
+    def task_logs():
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_batch1 = executor.submit(task_mongo_batch1)
+        future_batch2 = executor.submit(task_mongo_batch2)
+        future_logs = executor.submit(task_logs)
+
+        metrics_result = future_metrics.result()
+        batch1_result = future_batch1.result()
+        batch2_result = future_batch2.result()
+        logs_result = future_logs.result()
+
+    # === PROCESS METRICS ===
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data"
+        }
+
+    # === PROCESS BATCH 1 (serverStatus, dbStats, collStats) ===
+    if batch1_result[0] == "ok":
+        b1 = batch1_result[1]
+        ss = b1.get("serverStatus")
+        if ss:
+            _parse_server_status(ss, result)
+            result.collection_status["server_status"] = {"status": "success"}
+        else:
+            err = b1.get("serverStatus_error", "no data")
+            result.errors.append(f"serverStatus failed: {err}")
+            result.collection_status["server_status"] = {"status": "error", "error": err}
+
+        dbs = b1.get("dbStats")
+        if dbs:
+            _parse_db_stats(dbs, result)
+            result.collection_status["db_stats"] = {"status": "success"}
+        else:
+            err = b1.get("dbStats_error", "no data")
+            result.collection_status["db_stats"] = {"status": "error", "error": err}
+
+        cs = b1.get("collStats")
+        if cs:
+            _parse_collection_stats(cs, result)
+            result.collection_status["collection_stats"] = {"status": "success"}
+        else:
+            err = b1.get("collStats_error", "no data")
+            result.collection_status["collection_stats"] = {"status": "error", "error": err}
+    else:
+        error_msg = batch1_result[1] if len(batch1_result) > 1 else "unknown"
+        result.errors.append(f"Batch 1 (serverStatus/dbStats/collStats) failed: {error_msg}")
+        for src in ("server_status", "db_stats", "collection_stats"):
+            result.collection_status[src] = {"status": "error", "error": error_msg}
+
+    # === PROCESS BATCH 2 (slowQueries, currentOp, replInfo, top) ===
+    if batch2_result[0] == "ok":
+        b2 = batch2_result[1]
+
+        sq = b2.get("slowQueries")
+        if sq is not None:
+            _parse_slow_queries(sq, result)
+            result.collection_status["slow_queries"] = {"status": "success"}
+        else:
+            err = b2.get("slowQueries_error", "no data")
+            result.collection_status["slow_queries"] = {"status": "error", "error": err}
+
+        co = b2.get("currentOp")
+        if co is not None:
+            _parse_current_op(co, result)
+            result.collection_status["current_op"] = {"status": "success"}
+        else:
+            err = b2.get("currentOp_error", "no data")
+            result.collection_status["current_op"] = {"status": "error", "error": err}
+
+        ri = b2.get("replInfo")
+        if ri is not None:
+            _parse_repl_info(ri, result)
+            result.collection_status["repl_info"] = {"status": "success"}
+        else:
+            err = b2.get("replInfo_error", "no data or not a replica set")
+            result.collection_status["repl_info"] = {"status": "skipped", "reason": err}
+
+        top = b2.get("top")
+        if top is not None:
+            _parse_top(top, result)
+            result.collection_status["top"] = {"status": "success"}
+        else:
+            err = b2.get("top_error", "no data or insufficient privileges")
+            result.collection_status["top"] = {"status": "skipped", "reason": err}
+    else:
+        error_msg = batch2_result[1] if len(batch2_result) > 1 else "unknown"
+        result.errors.append(f"Batch 2 (slowQueries/currentOp/replInfo/top) failed: {error_msg}")
+        for src in ("slow_queries", "current_op", "repl_info", "top"):
+            result.collection_status[src] = {"status": "error", "error": error_msg}
+
+    # === PROCESS LOGS ===
+    progress(4, 5, "Processing logs...", quiet)
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {"status": "success", "lines": len(logs_result)}
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if 'ERROR' in line.upper() or 'FATAL' in line.upper() or 'PANIC' in line.upper()
+        ][:100]
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {"status": "error", "error": "Logs API returned no data"}
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Recommendations engine
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: MongoAnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on analysis results."""
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"server_status", "db_stats", "collection_stats",
+                       "slow_queries", "current_op", "repl_info", "top"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: WiredTiger cache, connections, "
+                           f"collection stats, and replication health could not be evaluated.",
+            })
+
+    # --- WiredTiger cache usage ---
+    wt = result.wiredtiger_cache
+    if wt:
+        max_bytes = wt.get("max_bytes", 0)
+        used_bytes = wt.get("bytes_in_cache", 0)
+        dirty_bytes = wt.get("dirty_bytes", 0)
+        app_evictions = wt.get("app_evictions", 0)
+
+        if max_bytes > 0:
+            usage_pct = round(100.0 * used_bytes / max_bytes, 1)
+            if usage_pct > 80:
+                recs.append({
+                    "priority": "immediate",
+                    "issue": f"WiredTiger cache is {usage_pct}% full ({_fmt_bytes(used_bytes)} of {_fmt_bytes(max_bytes)})",
+                    "action": "Consider increasing service RAM. WiredTiger cache defaults to 50% of RAM minus 1 GB.",
+                    "explanation": "When the WiredTiger cache is nearly full, MongoDB must evict pages more aggressively, "
+                                   "increasing latency for reads and writes. Increasing RAM gives WiredTiger more room to cache data.",
+                })
+
+            if used_bytes > 0:
+                dirty_pct = round(100.0 * dirty_bytes / max_bytes, 1)
+                if dirty_pct > 20:
+                    recs.append({
+                        "priority": "short-term",
+                        "issue": f"High dirty cache ({dirty_pct}% of total cache). Checkpoint may be falling behind.",
+                        "action": "Monitor checkpoint duration and consider increasing RAM or reducing write throughput.",
+                        "explanation": "Dirty pages must be written to disk during checkpoints. A high dirty ratio means "
+                                       "checkpoints have more work, potentially causing latency spikes.",
+                    })
+
+        if app_evictions and app_evictions > 0:
+            recs.append({
+                "priority": "immediate",
+                "issue": f"Application threads performing evictions ({app_evictions:,} pages). WiredTiger cache under pressure.",
+                "action": "Increase RAM to give WiredTiger more cache space.",
+                "explanation": "Normally the WiredTiger eviction threads handle cache pressure. When application threads "
+                               "must evict pages themselves, queries stall waiting for cache space. This directly increases latency.",
+            })
+
+    # --- Connection usage ---
+    conn = result.connections
+    if conn:
+        current = conn.get("current", 0)
+        available = conn.get("available", 0)
+        total = current + available
+        if total > 0:
+            pct = round(100.0 * current / total, 1)
+            if pct > 80:
+                recs.append({
+                    "priority": "immediate" if pct > 90 else "short-term",
+                    "issue": f"Connection usage at {pct}% ({current} of {total}). Approaching connection limit.",
+                    "action": "Review application connection pooling. Consider using a connection pooler or increasing maxIncomingConnections.",
+                    "explanation": "Running out of connections will cause new client connections to be refused. "
+                                   "Most applications should use connection pooling to limit concurrent connections.",
+                })
+
+    # --- Page faults ---
+    if result.page_faults and result.page_faults > 10000:
+        recs.append({
+            "priority": "short-term",
+            "issue": f"Significant page faults ({result.page_faults:,}). Working set may exceed available RAM.",
+            "action": "Increase service RAM or optimize queries to reduce working set size.",
+            "explanation": "Page faults occur when MongoDB accesses data not in memory, requiring disk reads. "
+                           "High page faults indicate the working set is larger than available RAM.",
+        })
+
+    # --- Queued operations ---
+    gl = result.global_lock
+    if gl:
+        qr = gl.get("queue_readers", 0)
+        qw = gl.get("queue_writers", 0)
+        if qr > 0 or qw > 0:
+            recs.append({
+                "priority": "immediate" if (qr + qw) > 10 else "short-term",
+                "issue": f"Operations queuing detected (readers: {qr}, writers: {qw}). Database may be under resource pressure.",
+                "action": "Investigate slow operations and consider increasing RAM or CPU.",
+                "explanation": "Queued operations mean requests are waiting for a lock. This can be caused by slow queries, "
+                               "write-heavy workloads, or insufficient resources.",
+            })
+
+    # --- Query efficiency ---
+    qe = result.query_executor
+    dm = result.document_metrics
+    if qe and dm:
+        scanned = qe.get("scannedObjects", 0)
+        returned = dm.get("returned", 0)
+        if returned > 0 and scanned > returned * 10:
+            ratio = round(scanned / returned, 1)
+            recs.append({
+                "priority": "immediate" if ratio > 100 else "short-term",
+                "issue": f"Query efficiency concern: {_fmt_count(scanned)} objects scanned vs {_fmt_count(returned)} returned (ratio: {ratio}x).",
+                "action": "Create indexes for frequently queried fields. Review slow query log for full collection scans.",
+                "explanation": "A high scan-to-return ratio means MongoDB is examining many documents to satisfy queries. "
+                               "Adding appropriate indexes dramatically reduces the number of documents examined.",
+            })
+
+    # --- Plan cache ---
+    pc = result.plan_cache
+    if pc:
+        hits = pc.get("hits", 0)
+        misses = pc.get("misses", 0)
+        total = hits + misses
+        if total > 100 and misses > hits:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"High plan cache miss ratio ({misses:,} misses vs {hits:,} hits). Queries may not be using optimal plans.",
+                "action": "Consider creating indexes for frequent query patterns to stabilize query plans.",
+                "explanation": "Plan cache misses mean MongoDB must re-evaluate query plans. Stable indexes help the planner "
+                               "pick consistent, efficient plans.",
+            })
+
+    # --- Sort spill to disk ---
+    sm = result.sort_metrics
+    if sm:
+        spill = sm.get("spillToDisk", 0)
+        if spill > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Sorts spilling to disk ({spill:,} times). Queries performing in-memory sorts exceeding limit.",
+                "action": "Add indexes to support sort operations, or increase RAM.",
+                "explanation": "When a sort operation exceeds the memory limit (100 MB by default), MongoDB spills to disk. "
+                               "Creating an index that matches the sort key avoids the in-memory sort entirely.",
+            })
+
+    # --- Cursor timeouts ---
+    cur = result.cursors
+    if cur:
+        timed_out = cur.get("timed_out", 0)
+        if timed_out > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Cursor timeouts detected ({timed_out:,}). Long-running queries may need optimization.",
+                "action": "Review application code for unbounded queries or missing pagination.",
+                "explanation": "Cursors time out after 10 minutes of inactivity by default. Frequent timeouts suggest "
+                               "clients are not consuming results quickly enough or queries are returning too much data.",
+            })
+
+    # --- Asserts ---
+    asserts = result.asserts
+    if asserts:
+        regular = asserts.get("regular", 0)
+        warning = asserts.get("warning", 0)
+        user = asserts.get("user", 0)
+        msg = asserts.get("msg", 0)
+        if regular > 0 or warning > 0 or user > 0:
+            recs.append({
+                "priority": "short-term",
+                "issue": f"Database asserts detected (regular: {regular}, warning: {warning}, user: {user}, msg: {msg}). Investigate error conditions.",
+                "action": "Check MongoDB logs for assert details. User asserts often indicate client errors; regular/warning asserts may signal server issues.",
+                "explanation": "Asserts are internal consistency checks. Regular and warning asserts may indicate bugs or data issues. "
+                               "User asserts are typically client-side errors (e.g., duplicate key violations).",
+            })
+
+    # --- Oplog usage ---
+    oplog = result.oplog
+    if oplog:
+        log_size = oplog.get("logSizeMB", 0)
+        used = oplog.get("usedMB", 0)
+        if log_size > 0:
+            oplog_pct = round(100.0 * used / log_size, 1)
+            if oplog_pct > 80:
+                recs.append({
+                    "priority": "short-term",
+                    "issue": f"Oplog is {oplog_pct}% full ({used:.0f} MB of {log_size:.0f} MB). May impact replication if oplog window is too small.",
+                    "action": "Consider increasing the oplog size to maintain a larger replication window.",
+                    "explanation": "The oplog stores recent write operations for replication. If it fills up and wraps around too quickly, "
+                                   "replica set members that fall behind may need a full resync instead of incremental replication.",
+                })
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_report(result: MongoAnalysisResult) -> str:
+    """Format analysis result as human-readable markdown report."""
+    lines: List[str] = []
+    lines.append("=" * 60)
+    lines.append(f"# MongoDB Analysis: {result.service}")
+    lines.append("=" * 60)
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Status: {result.deployment_status}")
+    lines.append("")
+
+    # --- Data Collection Status ---
+    if result.collection_status:
+        lines.append("## Data Collection Status")
+        lines.append("")
+        lines.append("| Source | Status | Details |")
+        lines.append("|--------|--------|---------|")
+        source_labels = {
+            "server_status": "Server Status (SSH)",
+            "db_stats": "Database Stats (SSH)",
+            "collection_stats": "Collection Stats (SSH)",
+            "slow_queries": "Slow Queries (SSH)",
+            "current_op": "Current Operations (SSH)",
+            "repl_info": "Replication Info (SSH)",
+            "top": "Top Collections (SSH)",
+            "metrics_api": "Metrics API",
+            "logs_api": "Logs API",
+        }
+        for source in ["server_status", "db_stats", "collection_stats",
+                        "slow_queries", "current_op", "repl_info", "top",
+                        "metrics_api", "logs_api"]:
+            if source in result.collection_status:
+                info = result.collection_status[source]
+                status = info["status"].upper()
+                details = ""
+                if info.get("error"):
+                    details = info["error"]
+                elif info.get("reason"):
+                    details = info["reason"]
+                elif info.get("lines"):
+                    details = f"{info['lines']} lines collected"
+                elif status == "SUCCESS":
+                    details = "OK"
+                label = source_labels.get(source, source)
+                lines.append(f"| {label} | {status} | {details} |")
+        lines.append("")
+
+    # --- Overview ---
+    lines.append("## Overview")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    if result.version:
+        lines.append(f"| Version | {result.version} |")
+    if result.storage_engine:
+        lines.append(f"| Storage Engine | {result.storage_engine} |")
+    if result.uptime_seconds is not None:
+        lines.append(f"| Uptime | {_fmt_uptime(result.uptime_seconds)} |")
+    status_icon = "Healthy" if result.deployment_status == "SUCCESS" else "Warning"
+    lines.append(f"| Deployment | {result.deployment_status} | {status_icon} |")
+    lines.append("")
+
+    # --- Connections ---
+    if result.connections:
+        lines.append("## Connections")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        c = result.connections
+        current = c.get("current", 0)
+        available = c.get("available", 0)
+        total = current + available
+        pct = round(100.0 * current / total, 1) if total > 0 else 0
+        status = "Critical" if pct > 90 else "Warning" if pct > 80 else ""
+        lines.append(f"| Current | {current:,} | {status} |")
+        lines.append(f"| Available | {available:,} | |")
+        lines.append(f"| Total Created | {c.get('totalCreated', 0):,} | |")
+        lines.append("")
+
+    # --- Operations (since startup) ---
+    if result.opcounters:
+        lines.append("## Operations (since startup)")
+        lines.append("")
+        lines.append("| Operation | Count |")
+        lines.append("|-----------|-------|")
+        for op in ("insert", "query", "update", "delete", "getmore", "command"):
+            val = result.opcounters.get(op, 0)
+            lines.append(f"| {op} | {_fmt_count(val)} |")
+        lines.append("")
+
+    # --- Replication opcounters ---
+    if result.opcounters_repl:
+        any_repl = any(v > 0 for v in result.opcounters_repl.values() if isinstance(v, (int, float)))
+        if any_repl:
+            lines.append("## Replication Operations")
+            lines.append("")
+            lines.append("| Operation | Count |")
+            lines.append("|-----------|-------|")
+            for op in ("insert", "query", "update", "delete", "getmore", "command"):
+                val = result.opcounters_repl.get(op, 0)
+                lines.append(f"| {op} | {_fmt_count(val)} |")
+            lines.append("")
+
+    # --- Latency ---
+    if result.op_latencies:
+        lines.append("## Latency")
+        lines.append("")
+        lines.append("| Operation | Avg Latency | Total Ops |")
+        lines.append("|-----------|-------------|-----------|")
+        for key, label in [("reads", "Reads"), ("writes", "Writes"), ("commands", "Commands")]:
+            entry = result.op_latencies.get(key, {})
+            avg_us = entry.get("avg_us", 0)
+            ops = entry.get("ops", 0)
+            lines.append(f"| {label} | {_fmt_us(avg_us)} | {_fmt_count(ops)} |")
+        lines.append("")
+
+    # --- Memory ---
+    if result.memory:
+        lines.append("## Memory")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Resident | {result.memory.get('resident_mb', 0):,} MB |")
+        lines.append(f"| Virtual | {result.memory.get('virtual_mb', 0):,} MB |")
+        if result.page_faults is not None:
+            lines.append(f"| Page Faults | {result.page_faults:,} |")
+        lines.append("")
+
+    # --- WiredTiger Cache ---
+    wt = result.wiredtiger_cache
+    if wt:
+        lines.append("## WiredTiger Cache")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        used = wt.get("bytes_in_cache", 0)
+        max_b = wt.get("max_bytes", 0)
+        dirty = wt.get("dirty_bytes", 0)
+        app_evict = wt.get("app_evictions", 0)
+        lines.append(f"| Used | {_fmt_bytes(used)} | |")
+        lines.append(f"| Maximum | {_fmt_bytes(max_b)} | |")
+        if max_b > 0:
+            usage_pct = round(100.0 * used / max_b, 1)
+            cache_status = "Critical" if usage_pct > 90 else "Warning" if usage_pct > 80 else "OK"
+            lines.append(f"| Usage | {usage_pct}% | {cache_status} |")
+        lines.append(f"| Dirty | {_fmt_bytes(dirty)} | |")
+        evict_status = "Warning" if app_evict > 0 else "OK"
+        lines.append(f"| App Thread Evictions | {app_evict:,} | {evict_status} |")
+        lines.append(f"| Pages Read Into Cache | {wt.get('pages_read', 0):,} | |")
+        lines.append(f"| Pages Written From Cache | {wt.get('pages_written', 0):,} | |")
+        lines.append("")
+
+    # --- WiredTiger Checkpoint ---
+    cp = result.wiredtiger_checkpoint
+    if cp:
+        ms = cp.get("most_recent_time_ms", 0)
+        lines.append("## WiredTiger Checkpoint")
+        lines.append("")
+        lines.append(f"| Most Recent Checkpoint Time | {ms:,} ms |")
+        lines.append("")
+
+    # --- WiredTiger Tickets ---
+    tk = result.wiredtiger_tickets
+    if tk:
+        lines.append("## WiredTiger Tickets")
+        lines.append("")
+        lines.append("| Metric | Available | Total |")
+        lines.append("|--------|-----------|-------|")
+        lines.append(f"| Read | {tk.get('read_available', 0)} | {tk.get('read_total', 0)} |")
+        lines.append(f"| Write | {tk.get('write_available', 0)} | {tk.get('write_total', 0)} |")
+        lines.append("")
+
+    # --- Global Lock ---
+    gl = result.global_lock
+    if gl:
+        lines.append("## Global Lock")
+        lines.append("")
+        lines.append("| Metric | Readers | Writers |")
+        lines.append("|--------|---------|---------|")
+        lines.append(f"| Queue | {gl.get('queue_readers', 0)} | {gl.get('queue_writers', 0)} |")
+        lines.append(f"| Active | {gl.get('active_readers', 0)} | {gl.get('active_writers', 0)} |")
+        lines.append("")
+
+    # --- Network ---
+    if result.network:
+        lines.append("## Network")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Bytes In | {_fmt_bytes(result.network.get('bytesIn', 0))} |")
+        lines.append(f"| Bytes Out | {_fmt_bytes(result.network.get('bytesOut', 0))} |")
+        lines.append(f"| Requests | {_fmt_count(result.network.get('numRequests', 0))} |")
+        lines.append("")
+
+    # --- Document Metrics ---
+    dm = result.document_metrics
+    if dm:
+        lines.append("## Documents")
+        lines.append("")
+        lines.append("| Operation | Count |")
+        lines.append("|-----------|-------|")
+        for key in ("inserted", "updated", "deleted", "returned"):
+            lines.append(f"| {key} | {_fmt_count(dm.get(key, 0))} |")
+        lines.append("")
+
+    # --- Query Efficiency ---
+    qe = result.query_executor
+    if qe:
+        lines.append("## Query Efficiency")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Scanned Objects | {_fmt_count(qe.get('scannedObjects', 0))} |")
+        lines.append(f"| Scanned Keys | {_fmt_count(qe.get('scanned', 0))} |")
+        if dm:
+            returned = dm.get("returned", 0)
+            scanned = qe.get("scannedObjects", 0)
+            if returned > 0:
+                ratio = round(scanned / returned, 1)
+                status = "Warning" if ratio > 10 else "OK"
+                lines.append(f"| Scan-to-Return Ratio | {ratio}x | {status} |")
+        lines.append("")
+
+    # --- Plan Cache ---
+    pc = result.plan_cache
+    if pc:
+        lines.append("## Plan Cache (7.0+)")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Hits | {_fmt_count(pc.get('hits', 0))} |")
+        lines.append(f"| Misses | {_fmt_count(pc.get('misses', 0))} |")
+        lines.append("")
+
+    # --- Sort Metrics ---
+    sm = result.sort_metrics
+    if sm:
+        lines.append("## Sort (7.0+)")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Spill to Disk | {sm.get('spillToDisk', 0):,} |")
+        lines.append(f"| Total Bytes Sorted | {_fmt_bytes(sm.get('totalBytesSorted', 0))} |")
+        lines.append("")
+
+    # --- Cursors ---
+    cur = result.cursors
+    if cur:
+        lines.append("## Cursors")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Open Total | {cur.get('open_total', 0):,} |")
+        timed = cur.get("timed_out", 0)
+        status = "Warning" if timed > 0 else ""
+        lines.append(f"| Timed Out | {timed:,} | {status} |")
+        lines.append("")
+
+    # --- TTL ---
+    ttl = result.ttl_metrics
+    if ttl:
+        lines.append("## TTL")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Deleted Documents | {_fmt_count(ttl.get('deletedDocuments', 0))} |")
+        lines.append(f"| Passes | {ttl.get('passes', 0):,} |")
+        lines.append("")
+
+    # --- Asserts ---
+    asserts = result.asserts
+    if asserts:
+        any_assert = any(asserts.get(k, 0) > 0 for k in ("regular", "warning", "msg", "user"))
+        if any_assert:
+            lines.append("## Asserts")
+            lines.append("")
+            lines.append("| Type | Count |")
+            lines.append("|------|-------|")
+            for key in ("regular", "warning", "msg", "user", "rollovers"):
+                lines.append(f"| {key} | {asserts.get(key, 0):,} |")
+            lines.append("")
+
+    # --- Storage ---
+    st = result.storage
+    if st:
+        lines.append("## Storage")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Data Size | {_fmt_bytes(st.get('dataSize', 0))} |")
+        lines.append(f"| Storage Size | {_fmt_bytes(st.get('storageSize', 0))} |")
+        lines.append(f"| Index Size | {_fmt_bytes(st.get('indexSize', 0))} |")
+        lines.append(f"| Objects | {_fmt_count(st.get('objects', 0))} |")
+        lines.append(f"| Collections | {st.get('collections', 0)} |")
+        lines.append("")
+
+    # --- Collections ---
+    if result.collection_stats:
+        lines.append("## Collections")
+        lines.append("")
+        lines.append("| Collection | Documents | Data Size | Storage | Indexes |")
+        lines.append("|------------|-----------|-----------|---------|---------|")
+        # Sort by size descending
+        sorted_colls = sorted(result.collection_stats, key=lambda c: c.get("size", 0), reverse=True)
+        for c in sorted_colls:
+            name = c.get("name", "?")
+            count = _fmt_count(c.get("count", 0))
+            size = _fmt_bytes(c.get("size", 0))
+            storage = _fmt_bytes(c.get("storageSize", 0))
+            nidx = c.get("nindexes", 0)
+            lines.append(f"| {name} | {count} | {size} | {storage} | {nidx} |")
+        lines.append("")
+
+    # --- Top Collections by Activity ---
+    if result.top_collections:
+        lines.append("## Top Collections by Activity")
+        lines.append("")
+        lines.append("| Namespace | Reads | Read Time | Writes | Write Time |")
+        lines.append("|-----------|-------|-----------|--------|------------|")
+        # Sort by total activity
+        sorted_top = sorted(result.top_collections,
+                            key=lambda t: t.get("reads", 0) + t.get("writes", 0),
+                            reverse=True)
+        for t in sorted_top[:20]:
+            ns = t.get("ns", "?")
+            reads = _fmt_count(t.get("reads", 0))
+            read_time = _fmt_us(t.get("readTimeUs", 0))
+            writes = _fmt_count(t.get("writes", 0))
+            write_time = _fmt_us(t.get("writeTimeUs", 0))
+            lines.append(f"| {ns} | {reads} | {read_time} | {writes} | {write_time} |")
+        lines.append("")
+
+    # --- Replication ---
+    if result.replication:
+        lines.append("## Replication")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        r = result.replication
+        if r.get("setName"):
+            lines.append(f"| Replica Set | {r['setName']} |")
+        lines.append(f"| Is Writable Primary | {r.get('isWritablePrimary', 'N/A')} |")
+        if r.get("primary"):
+            lines.append(f"| Primary | {r['primary']} |")
+        if r.get("hosts"):
+            lines.append(f"| Hosts | {', '.join(r['hosts'])} |")
+        lines.append("")
+
+    # --- Oplog ---
+    if result.oplog:
+        lines.append("## Oplog")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        ol = result.oplog
+        log_size = ol.get("logSizeMB", 0)
+        used = ol.get("usedMB", 0)
+        lines.append(f"| Log Size | {log_size:.0f} MB |")
+        lines.append(f"| Used | {used:.0f} MB |")
+        if log_size > 0:
+            lines.append(f"| Usage | {round(100.0 * used / log_size, 1)}% |")
+        hours = ol.get("timeDiffHours", 0)
+        lines.append(f"| Time Window | {hours:.1f} hours |")
+        lines.append("")
+
+    # --- Slow Queries ---
+    if result.slow_queries:
+        lines.append("## Slow Queries")
+        lines.append("")
+        lines.append("| Op | Namespace | Duration | Plan |")
+        lines.append("|----|-----------|----------|------|")
+        for q in result.slow_queries:
+            op = q.get("op", "?")
+            ns = q.get("ns", "?")
+            millis = q.get("millis", 0)
+            plan = q.get("planSummary", "")
+            lines.append(f"| {op} | {ns} | {millis}ms | {plan} |")
+        lines.append("")
+
+    # --- Active Operations ---
+    if result.active_ops:
+        lines.append("## Active Operations")
+        lines.append("")
+        lines.append("| OpID | Type | Namespace | Duration |")
+        lines.append("|------|------|-----------|----------|")
+        sorted_ops = sorted(result.active_ops, key=lambda o: o.get("microsecs_running", 0), reverse=True)
+        for op in sorted_ops[:20]:
+            opid = op.get("opid", "?")
+            op_type = op.get("type", "?")
+            ns = op.get("ns", "")
+            us = op.get("microsecs_running", 0)
+            lines.append(f"| {opid} | {op_type} | {ns} | {_fmt_us(us)} |")
+        lines.append("")
+
+    # --- Infrastructure Trends ---
+    if result.metrics_history and result.metrics_history.get("windows"):
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Trends ({window_label})")
+            lines.append("")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend | Change |")
+            lines.append("|--------|---------|-----|-----|-----|-------|--------|")
+            display_order = [
+                ("cpu", "CPU"),
+                ("memory", "Memory"),
+                ("disk", "Disk"),
+                ("network_rx", "Network RX"),
+                ("network_tx", "Network TX"),
+            ]
+            for key, label in display_order:
+                if key in mh:
+                    m = mh[key]
+                    unit = m["unit"]
+                    trend = m.get("trend", {})
+                    direction = trend.get("direction", "?")
+                    change = trend.get("change_pct", 0)
+                    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "?")
+                    spike_note = ""
+                    if m.get("spikes"):
+                        spike_note = f" ({m['spikes']['count']} spikes)"
+                    lines.append(
+                        f"| {label} | {m['current']} {unit} | {m['min']} | {m['max']} | "
+                        f"{m['avg']} | {arrow} {direction} | {change:+.1f}%{spike_note} |"
+                    )
+            lines.append("")
+
+    # --- CPU / Memory summary ---
+    if result.cpu_memory:
+        lines.append("## Resource Usage")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        cm = result.cpu_memory
+        if "cpu_percent" in cm:
+            cpu = cm["cpu_percent"]
+            status = "Critical" if cpu > 85 else "Warning" if cpu > 70 else "Healthy"
+            trend_str = _trend_indicator(result.metrics_history, "cpu")
+            lines.append(f"| CPU Usage | {cpu} vCPU{trend_str} | {status} |")
+            if cm.get("cpu_limit"):
+                lines.append(f"| CPU Limit | {cm['cpu_limit']} vCPU | - |")
+        if "memory_gb" in cm:
+            mem_val = cm["memory_gb"]
+            trend_str = _trend_indicator(result.metrics_history, "memory")
+            utilization = ""
+            if cm.get("memory_limit_gb"):
+                pct = round((mem_val / cm["memory_limit_gb"]) * 100, 1)
+                status = "Critical" if pct > 90 else "Warning" if pct > 80 else "Healthy"
+                utilization = f" ({pct}% of {cm['memory_limit_gb']} GB)"
+            else:
+                status = "-"
+            lines.append(f"| Memory Usage | {mem_val} GB{utilization}{trend_str} | {status} |")
+        if result.disk_usage:
+            lines.append(f"| Disk Usage | {result.disk_usage.get('used', 'N/A')} | - |")
+        lines.append("")
+
+    # --- Recent Errors ---
+    if result.recent_errors:
+        lines.append("## Recent Errors")
+        lines.append("")
+        for error in result.recent_errors[:10]:
+            lines.append(f"- {error[:150]}...")
+        lines.append("")
+
+    # --- Recommendations ---
+    if result.recommendations:
+        lines.append("## Recommendations")
+        lines.append("")
+        for i, rec in enumerate(result.recommendations, 1):
+            priority = rec["priority"].upper()
+            lines.append(f"{i}. **[{priority}]** {rec['issue']}")
+            lines.append(f"   **Action:** {rec['action']}")
+            if rec.get("explanation"):
+                lines.append(f"   **Why:** {rec['explanation']}")
+            lines.append("")
+
+    # --- Errors ---
+    if result.errors:
+        lines.append("## Errors")
+        lines.append("")
+        for error in result.errors:
+            lines.append(f"- {error}")
+        lines.append("")
+
+    lines.append("=" * 60)
+    lines.append("END OF REPORT")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "server-status":
+        print(f"Running serverStatus on: {service}", file=sys.stderr)
+        code, stdout, stderr = run_mongosh_query(service, QUERY_SERVER_STATUS, timeout=30)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            data = _safe_json(stdout)
+            if data:
+                print(json.dumps(data, indent=2))
+            else:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "db-stats":
+        print(f"Running db.stats() on: {service}", file=sys.stderr)
+        code, stdout, stderr = run_mongosh_query(service, QUERY_DB_STATS, timeout=30)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            data = _safe_json(stdout)
+            if data:
+                print(json.dumps(data, indent=2))
+            else:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="MongoDB analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                        help="Timeout in seconds (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                        help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                        help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                        help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step",
+                        choices=["ssh-test", "server-status", "db-stats", "logs", "metrics"],
+                        help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    if args.step:
+        return run_single_step(args)
+
+    result = analyze_mongo(
+        args.service,
+        timeout=args.timeout,
+        quiet=args.quiet,
+        skip_logs=args.skip_logs,
+        metrics_hours=min(args.metrics_hours, 168),
+        project_id=args.project_id,
+        environment_id=args.environment_id,
+        service_id=args.service_id,
+    )
+
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-mysql.py
+++ b/.claude/skills/use-railway/scripts/analyze-mysql.py
@@ -1,0 +1,1195 @@
+#!/usr/bin/env python3
+"""
+MySQL analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status & resource metrics (CPU, memory, disk)
+- Connection overview
+- Query throughput & efficiency
+- InnoDB buffer pool & row operations
+- Lock contention
+- Top queries (from performance_schema)
+- Table sizes
+- Active processes
+- Recommendations
+
+Usage:
+    analyze-mysql.py --service <name>
+    analyze-mysql.py --service <name> --json
+    analyze-mysql.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _safe_int, _safe_float, _format_uptime, _trend_indicator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MySQLAnalysisResult:
+    """Container for MySQL analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Resource metrics from Railway API
+    disk_usage: Optional[Dict[str, Any]] = None
+    cpu_memory: Optional[Dict[str, Any]] = None
+    metrics_history: Optional[Dict[str, Any]] = None
+
+    # MySQL data
+    overview: Optional[Dict[str, Any]] = None
+    query_throughput: Optional[Dict[str, Any]] = None
+    innodb_row_ops: Optional[Dict[str, Any]] = None
+    query_efficiency: Optional[Dict[str, Any]] = None
+    innodb_buffer_pool: Optional[Dict[str, Any]] = None
+    innodb_io: Optional[Dict[str, Any]] = None
+    network: Optional[Dict[str, Any]] = None
+    locks: Optional[Dict[str, Any]] = None
+    table_cache: Optional[Dict[str, Any]] = None
+    top_queries: List[Dict[str, Any]] = field(default_factory=list)
+    top_queries_status: Optional[str] = None
+    tables: List[Dict[str, Any]] = field(default_factory=list)
+    active_processes: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Logs
+    recent_logs: List[str] = field(default_factory=list)
+    recent_errors: List[str] = field(default_factory=list)
+
+    # Metadata
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# MySQL-specific helpers
+# ---------------------------------------------------------------------------
+
+def run_mysql_query(service: str, query: str, timeout: int = 30) -> Tuple[int, str]:
+    """Run a MySQL query via SSH and return (returncode, output).
+
+    Uses -B (batch) mode which produces tab-separated output with headers.
+    Filters out the mysql CLI password warning.
+    """
+    import base64
+    query = " ".join(query.split())
+    # Base64-encode the query to avoid all shell quoting issues
+    # (single quotes in SQL IN clauses break bash -c '...' wrapping)
+    encoded = base64.b64encode(query.encode()).decode()
+    command = (
+        f'''bash +H -c 'echo {encoded} | base64 -d | MYSQL_PWD="$MYSQLPASSWORD" mysql -h localhost -P 3306 '''
+        f'''-u "$MYSQLUSER" -D "$MYSQLDATABASE" --default-character-set=utf8mb4 '''
+        f'''-B' '''
+    )
+    code, stdout, stderr = run_ssh_query(service, command, timeout)
+    # Filter out the password warning from stdout (mysql sometimes writes it there)
+    lines = []
+    for line in stdout.split("\n"):
+        if "Using a password on the command line" in line:
+            continue
+        lines.append(line)
+    stdout = "\n".join(lines)
+    if code != 0:
+        # Also filter warning from stderr
+        stderr_clean = "\n".join(
+            l for l in stderr.split("\n")
+            if "Using a password on the command line" not in l
+        )
+        return code, stderr_clean or stdout
+    return 0, stdout
+
+
+def parse_mysql_batch(output: str) -> List[Dict[str, str]]:
+    """Parse MySQL -B (batch/tab-separated) output into list of dicts.
+
+    First line is column headers, subsequent lines are values.
+    """
+    lines = [l for l in output.strip().split("\n") if l.strip()]
+    if len(lines) < 1:
+        return []
+    headers = lines[0].split("\t")
+    rows = []
+    for line in lines[1:]:
+        values = line.split("\t")
+        if len(values) == len(headers):
+            rows.append(dict(zip(headers, values)))
+    return rows
+
+
+def parse_mysql_kv(output: str) -> Dict[str, str]:
+    """Parse MySQL SHOW output (Variable_name / Value pairs) into a dict."""
+    rows = parse_mysql_batch(output)
+    result: Dict[str, str] = {}
+    for row in rows:
+        name = row.get("Variable_name", "")
+        value = row.get("Value", "")
+        if name:
+            result[name] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Railway context / status / metrics helpers
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# MySQL queries
+# ---------------------------------------------------------------------------
+
+QUERY_GLOBAL_STATUS = """SHOW GLOBAL STATUS WHERE Variable_name IN ('Threads_connected','Threads_running','Max_used_connections','Questions','Slow_queries','Com_select','Com_insert','Com_update','Com_delete','Innodb_buffer_pool_read_requests','Innodb_buffer_pool_reads','Innodb_buffer_pool_pages_data','Innodb_buffer_pool_pages_free','Innodb_buffer_pool_pages_dirty','Innodb_row_lock_waits','Innodb_row_lock_time','Uptime','Bytes_received','Bytes_sent','Connections','Aborted_clients','Aborted_connects','Innodb_rows_read','Innodb_rows_inserted','Innodb_rows_updated','Innodb_rows_deleted','Innodb_data_reads','Innodb_data_writes','Innodb_buffer_pool_bytes_data','Innodb_buffer_pool_bytes_dirty','Created_tmp_disk_tables','Created_tmp_tables','Handler_read_rnd_next','Handler_read_first','Handler_read_key','Select_full_join','Select_range','Sort_merge_passes','Table_locks_waited','Table_locks_immediate','Open_tables','Opened_tables')"""
+
+QUERY_VARIABLES = """SHOW VARIABLES WHERE Variable_name IN ('max_connections','innodb_buffer_pool_size','long_query_time','version','table_open_cache','performance_schema')"""
+
+QUERY_TABLE_SIZES = """SELECT TABLE_NAME, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH, DATA_LENGTH + INDEX_LENGTH AS TOTAL_SIZE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() ORDER BY TOTAL_SIZE DESC LIMIT 15"""
+
+QUERY_PROCESSLIST = """SHOW PROCESSLIST"""
+
+QUERY_TOP_QUERIES = """SELECT DIGEST, LEFT(DIGEST_TEXT, 200) AS DIGEST_TEXT, COUNT_STAR, ROUND(SUM_TIMER_WAIT/1000000000, 2) AS TOTAL_LATENCY_MS, ROUND(AVG_TIMER_WAIT/1000000000, 2) AS AVG_LATENCY_MS, SUM_ROWS_EXAMINED, SUM_ROWS_SENT, SUM_CREATED_TMP_DISK_TABLES, SUM_NO_INDEX_USED FROM performance_schema.events_statements_summary_by_digest WHERE DIGEST IS NOT NULL AND COUNT_STAR > 0 ORDER BY SUM_TIMER_WAIT DESC LIMIT 15"""
+
+
+# ---------------------------------------------------------------------------
+# MySQL data collection
+# ---------------------------------------------------------------------------
+
+def collect_mysql_data(service: str, timeout: int = 30) -> Dict[str, Any]:
+    """Collect all MySQL metrics via SSH.
+
+    Batches queries into two SSH calls for efficiency:
+      1. SHOW GLOBAL STATUS + SHOW VARIABLES
+      2. Table sizes + processlist + top queries (performance_schema)
+
+    Returns a dict with raw parsed data keyed by section.
+    """
+    data: Dict[str, Any] = {
+        "global_status": {},
+        "variables": {},
+        "tables": [],
+        "processlist": [],
+        "top_queries": [],
+        "errors": [],
+    }
+
+    # --- Batch 1: SHOW GLOBAL STATUS; SHOW VARIABLES ---
+    batch1_query = QUERY_GLOBAL_STATUS + "; " + QUERY_VARIABLES
+    code, output = run_mysql_query(service, batch1_query, timeout=timeout)
+    if code != 0:
+        data["errors"].append(f"Batch 1 (status/variables) failed: {output}")
+    else:
+        # MySQL concatenates the two result sets; split them by detecting
+        # a second header line starting with Variable_name
+        sections = _split_mysql_resultsets(output, "Variable_name")
+        if len(sections) >= 1:
+            data["global_status"] = parse_mysql_kv(sections[0])
+        if len(sections) >= 2:
+            data["variables"] = parse_mysql_kv(sections[1])
+
+    # --- Batch 2: tables + processlist + top queries ---
+    batch2_query = QUERY_TABLE_SIZES + "; " + QUERY_PROCESSLIST + "; " + QUERY_TOP_QUERIES
+    code, output = run_mysql_query(service, batch2_query, timeout=timeout)
+    if code != 0:
+        # Top queries may fail if performance_schema is off; try without
+        batch2_fallback = QUERY_TABLE_SIZES + "; " + QUERY_PROCESSLIST
+        code2, output2 = run_mysql_query(service, batch2_fallback, timeout=timeout)
+        if code2 != 0:
+            data["errors"].append(f"Batch 2 (tables/processlist) failed: {output}")
+        else:
+            sections = _split_mysql_resultsets_multi(output2, [
+                "TABLE_NAME",
+                "Id",
+            ])
+            if len(sections) >= 1:
+                data["tables"] = parse_mysql_batch(sections[0])
+            if len(sections) >= 2:
+                data["processlist"] = parse_mysql_batch(sections[1])
+    else:
+        sections = _split_mysql_resultsets_multi(output, [
+            "TABLE_NAME",
+            "Id",
+            "DIGEST",
+        ])
+        if len(sections) >= 1:
+            data["tables"] = parse_mysql_batch(sections[0])
+        if len(sections) >= 2:
+            data["processlist"] = parse_mysql_batch(sections[1])
+        if len(sections) >= 3:
+            data["top_queries"] = parse_mysql_batch(sections[2])
+
+    return data
+
+
+def _split_mysql_resultsets(output: str, header_key: str) -> List[str]:
+    """Split concatenated MySQL batch output into sections by header line."""
+    lines = output.strip().split("\n")
+    sections: List[List[str]] = []
+    current: List[str] = []
+
+    for line in lines:
+        if line.startswith(header_key + "\t") or line.strip() == header_key:
+            if current:
+                sections.append("\n".join(current))
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        sections.append("\n".join(current))
+
+    return sections
+
+
+def _split_mysql_resultsets_multi(output: str, header_keys: List[str]) -> List[str]:
+    """Split concatenated MySQL batch output into sections by multiple different header keys."""
+    lines = output.strip().split("\n")
+    sections: List[List[str]] = []
+    current: List[str] = []
+    expected_idx = 0
+
+    for line in lines:
+        # Check if this line starts a new result set
+        matched = False
+        if expected_idx < len(header_keys):
+            key = header_keys[expected_idx]
+            if line.startswith(key + "\t") or line.strip() == key:
+                if current:
+                    sections.append("\n".join(current))
+                current = [line]
+                expected_idx += 1
+                matched = True
+        # Also check remaining headers in case we skipped one
+        if not matched:
+            for idx in range(expected_idx, len(header_keys)):
+                key = header_keys[idx]
+                if line.startswith(key + "\t") or line.strip() == key:
+                    if current:
+                        sections.append("\n".join(current))
+                    current = [line]
+                    expected_idx = idx + 1
+                    matched = True
+                    break
+        if not matched:
+            current.append(line)
+
+    if current:
+        sections.append("\n".join(current))
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Parse collected data into result
+# ---------------------------------------------------------------------------
+
+def parse_mysql_data(data: Dict[str, Any], result: MySQLAnalysisResult) -> None:
+    """Transform raw MySQL data into structured result sections."""
+    gs = data.get("global_status", {})
+    vs = data.get("variables", {})
+
+    # --- Overview ---
+    version = vs.get("version", "unknown")
+    uptime_sec = _safe_int(gs.get("Uptime"))
+    threads_connected = _safe_int(gs.get("Threads_connected"))
+    threads_running = _safe_int(gs.get("Threads_running"))
+    max_used_connections = _safe_int(gs.get("Max_used_connections"))
+    max_connections = _safe_int(vs.get("max_connections"), 1)
+    aborted_clients = _safe_int(gs.get("Aborted_clients"))
+    aborted_connects = _safe_int(gs.get("Aborted_connects"))
+    connection_usage_pct = round(max_used_connections / max_connections * 100, 1) if max_connections > 0 else 0
+
+    result.overview = {
+        "version": version,
+        "uptime_seconds": uptime_sec,
+        "uptime_human": _format_uptime(uptime_sec),
+        "threads_connected": threads_connected,
+        "threads_running": threads_running,
+        "max_used_connections": max_used_connections,
+        "max_connections": max_connections,
+        "connection_usage_percent": connection_usage_pct,
+        "aborted_clients": aborted_clients,
+        "aborted_connects": aborted_connects,
+    }
+
+    # --- Query Throughput ---
+    questions = _safe_int(gs.get("Questions"))
+    slow_queries = _safe_int(gs.get("Slow_queries"))
+    long_query_time = vs.get("long_query_time", "10")
+    com_select = _safe_int(gs.get("Com_select"))
+    com_insert = _safe_int(gs.get("Com_insert"))
+    com_update = _safe_int(gs.get("Com_update"))
+    com_delete = _safe_int(gs.get("Com_delete"))
+
+    result.query_throughput = {
+        "questions": questions,
+        "slow_queries": slow_queries,
+        "long_query_time": long_query_time,
+        "com_select": com_select,
+        "com_insert": com_insert,
+        "com_update": com_update,
+        "com_delete": com_delete,
+    }
+
+    # --- InnoDB Row Operations ---
+    result.innodb_row_ops = {
+        "rows_read": _safe_int(gs.get("Innodb_rows_read")),
+        "rows_inserted": _safe_int(gs.get("Innodb_rows_inserted")),
+        "rows_updated": _safe_int(gs.get("Innodb_rows_updated")),
+        "rows_deleted": _safe_int(gs.get("Innodb_rows_deleted")),
+    }
+
+    # --- Query Efficiency ---
+    created_tmp_disk = _safe_int(gs.get("Created_tmp_disk_tables"))
+    created_tmp = _safe_int(gs.get("Created_tmp_tables"))
+    tmp_disk_pct = round(created_tmp_disk / created_tmp * 100, 1) if created_tmp > 0 else 0
+    handler_rnd_next = _safe_int(gs.get("Handler_read_rnd_next"))
+    handler_first = _safe_int(gs.get("Handler_read_first"))
+    handler_key = _safe_int(gs.get("Handler_read_key"))
+    scan_total = handler_rnd_next + handler_first + handler_key
+    table_scan_pct = round((handler_rnd_next + handler_first) / scan_total * 100, 1) if scan_total > 0 else 0
+    select_full_join = _safe_int(gs.get("Select_full_join"))
+    select_range = _safe_int(gs.get("Select_range"))
+    sort_merge_passes = _safe_int(gs.get("Sort_merge_passes"))
+
+    result.query_efficiency = {
+        "created_tmp_disk_tables": created_tmp_disk,
+        "created_tmp_tables": created_tmp,
+        "tmp_disk_table_percent": tmp_disk_pct,
+        "handler_read_rnd_next": handler_rnd_next,
+        "handler_read_first": handler_first,
+        "handler_read_key": handler_key,
+        "table_scan_percent": table_scan_pct,
+        "select_full_join": select_full_join,
+        "select_range": select_range,
+        "sort_merge_passes": sort_merge_passes,
+    }
+
+    # --- InnoDB Buffer Pool ---
+    read_requests = _safe_int(gs.get("Innodb_buffer_pool_read_requests"))
+    reads = _safe_int(gs.get("Innodb_buffer_pool_reads"))
+    hit_ratio = round((read_requests - reads) / read_requests * 100, 2) if read_requests > 0 else 0
+    pool_size = _safe_int(vs.get("innodb_buffer_pool_size"))
+    bytes_data = _safe_int(gs.get("Innodb_buffer_pool_bytes_data"))
+    bytes_dirty = _safe_int(gs.get("Innodb_buffer_pool_bytes_dirty"))
+    usage_pct = round(bytes_data / pool_size * 100, 1) if pool_size > 0 else 0
+    pages_free = _safe_int(gs.get("Innodb_buffer_pool_pages_free"))
+    pages_data = _safe_int(gs.get("Innodb_buffer_pool_pages_data"))
+    pages_dirty = _safe_int(gs.get("Innodb_buffer_pool_pages_dirty"))
+
+    result.innodb_buffer_pool = {
+        "hit_ratio": hit_ratio,
+        "read_requests": read_requests,
+        "reads": reads,
+        "buffer_pool_size": pool_size,
+        "bytes_data": bytes_data,
+        "bytes_dirty": bytes_dirty,
+        "usage_percent": usage_pct,
+        "pages_data": pages_data,
+        "pages_free": pages_free,
+        "pages_dirty": pages_dirty,
+    }
+
+    # --- InnoDB I/O ---
+    result.innodb_io = {
+        "data_reads": _safe_int(gs.get("Innodb_data_reads")),
+        "data_writes": _safe_int(gs.get("Innodb_data_writes")),
+    }
+
+    # --- Network ---
+    result.network = {
+        "bytes_received": _safe_int(gs.get("Bytes_received")),
+        "bytes_sent": _safe_int(gs.get("Bytes_sent")),
+    }
+
+    # --- Locks ---
+    row_lock_waits = _safe_int(gs.get("Innodb_row_lock_waits"))
+    row_lock_time = _safe_int(gs.get("Innodb_row_lock_time"))
+    table_locks_waited = _safe_int(gs.get("Table_locks_waited"))
+    table_locks_immediate = _safe_int(gs.get("Table_locks_immediate"))
+    lock_total = table_locks_waited + table_locks_immediate
+    table_lock_contention = round(table_locks_waited / lock_total * 100, 2) if lock_total > 0 else 0
+
+    result.locks = {
+        "row_lock_waits": row_lock_waits,
+        "row_lock_time": row_lock_time,
+        "table_locks_waited": table_locks_waited,
+        "table_locks_immediate": table_locks_immediate,
+        "table_lock_contention": table_lock_contention,
+    }
+
+    # --- Table Cache ---
+    open_tables = _safe_int(gs.get("Open_tables"))
+    opened_tables = _safe_int(gs.get("Opened_tables"))
+    table_open_cache = _safe_int(vs.get("table_open_cache"))
+    cache_utilization_pct = round(open_tables / table_open_cache * 100, 1) if table_open_cache > 0 else 0
+    opens_per_sec = round(opened_tables / uptime_sec, 2) if uptime_sec > 0 else 0
+
+    result.table_cache = {
+        "open_tables": open_tables,
+        "opened_tables": opened_tables,
+        "table_open_cache": table_open_cache,
+        "cache_utilization_percent": cache_utilization_pct,
+        "opens_per_second": opens_per_sec,
+    }
+
+    # --- Top Queries ---
+    for row in data.get("top_queries", []):
+        result.top_queries.append({
+            "digest": row.get("DIGEST", ""),
+            "digest_text": row.get("DIGEST_TEXT", ""),
+            "count_star": _safe_int(row.get("COUNT_STAR")),
+            "total_latency_ms": _safe_float(row.get("TOTAL_LATENCY_MS")),
+            "avg_latency_ms": _safe_float(row.get("AVG_LATENCY_MS")),
+            "rows_examined": _safe_int(row.get("SUM_ROWS_EXAMINED")),
+            "rows_sent": _safe_int(row.get("SUM_ROWS_SENT")),
+            "tmp_disk_tables": _safe_int(row.get("SUM_CREATED_TMP_DISK_TABLES")),
+            "no_index_used": _safe_int(row.get("SUM_NO_INDEX_USED")),
+        })
+
+    if result.top_queries:
+        result.top_queries_status = "ok"
+    else:
+        perf_schema = vs.get("performance_schema", "").upper()
+        if perf_schema == "OFF":
+            result.top_queries_status = "performance_schema_disabled"
+        elif perf_schema == "ON":
+            result.top_queries_status = "no_queries_recorded"
+        else:
+            result.top_queries_status = "unknown"
+
+    # --- Tables ---
+    for row in data.get("tables", []):
+        result.tables.append({
+            "name": row.get("TABLE_NAME", ""),
+            "rows": _safe_int(row.get("TABLE_ROWS")),
+            "data_length": _safe_int(row.get("DATA_LENGTH")),
+            "index_length": _safe_int(row.get("INDEX_LENGTH")),
+            "total_size": _safe_int(row.get("TOTAL_SIZE")),
+        })
+
+    # --- Active Processes ---
+    for row in data.get("processlist", []):
+        result.active_processes.append({
+            "id": row.get("Id", ""),
+            "user": row.get("User", ""),
+            "db": row.get("db", ""),
+            "command": row.get("Command", ""),
+            "time": _safe_int(row.get("Time")),
+            "state": row.get("State", ""),
+            "info": row.get("Info", ""),
+        })
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _format_count(n: int) -> str:
+    """Format large numbers with K/M/G suffix."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}G"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return str(n)
+
+
+def _format_bytes(b: int) -> str:
+    """Format bytes to human-readable."""
+    if b >= 1_073_741_824:
+        return f"{b / 1_073_741_824:.1f} GB"
+    if b >= 1_048_576:
+        return f"{b / 1_048_576:.1f} MB"
+    if b >= 1_024:
+        return f"{b / 1_024:.1f} KB"
+    return f"{b} B"
+
+
+def _status_ok_warn_crit(value: float, warn_threshold: float, crit_threshold: float) -> str:
+    if value >= crit_threshold:
+        return "CRITICAL"
+    if value >= warn_threshold:
+        return "WARN"
+    return "OK"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: MySQLAnalysisResult) -> List[Dict[str, str]]:
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"mysql_query"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: InnoDB buffer pool, query throughput, "
+                           f"locks, and tuning parameters could not be evaluated.",
+            })
+
+    def rec(severity: str, message: str):
+        recs.append({"severity": severity, "message": message})
+
+    ov = result.overview or {}
+    qt = result.query_throughput or {}
+    qe = result.query_efficiency or {}
+    bp = result.innodb_buffer_pool or {}
+    lk = result.locks or {}
+    tc = result.table_cache or {}
+
+    # Connection usage
+    conn_pct = ov.get("connection_usage_percent", 0)
+    max_conn = ov.get("max_connections", 0)
+    if conn_pct >= 90:
+        rec("critical", f"Connection usage critical at {conn_pct}%. Approaching max_connections ({max_conn}).")
+    elif conn_pct >= 70:
+        rec("warning", f"Connection usage at {conn_pct}%. Consider increasing max_connections.")
+
+    # Buffer pool hit ratio
+    hit_ratio = bp.get("hit_ratio", 100)
+    if hit_ratio < 95:
+        rec("critical", f"Buffer pool hit ratio at {hit_ratio}%. Increase innodb_buffer_pool_size.")
+    elif hit_ratio < 99:
+        rec("warning", f"Buffer pool hit ratio at {hit_ratio}% -- room for improvement with more RAM.")
+
+    # Buffer pool usage
+    bp_usage = bp.get("usage_percent", 0)
+    if bp_usage > 95:
+        rec("warning", f"Buffer pool {bp_usage}% full. Data pages may be evicted under load.")
+
+    # Temp tables to disk
+    tmp_pct = qe.get("tmp_disk_table_percent", 0)
+    created_disk = qe.get("created_tmp_disk_tables", 0)
+    created_total = qe.get("created_tmp_tables", 0)
+    if tmp_pct > 25:
+        rec("warning", f"{tmp_pct}% of temp tables going to disk. Increase tmp_table_size/max_heap_table_size or optimize queries.")
+    elif tmp_pct > 10:
+        rec("info", f"Temp tables to disk at {tmp_pct}%. Watch for queries creating large temporary results.")
+
+    # Table scan ratio
+    scan_pct = qe.get("table_scan_percent", 0)
+    if scan_pct > 75:
+        rec("critical", f"Table scan ratio at {scan_pct}%. Most reads are full scans -- add indexes.")
+    elif scan_pct > 50:
+        rec("warning", f"Table scan ratio at {scan_pct}%. Consider indexing frequently queried columns.")
+
+    # Full joins
+    full_joins = qe.get("select_full_join", 0)
+    if full_joins > 100:
+        rec("warning", f"{_format_count(full_joins)} full joins detected. These scan entire tables -- add indexes to join columns.")
+
+    # Sort merge passes
+    sort_passes = qe.get("sort_merge_passes", 0)
+    if sort_passes > 0:
+        rec("info", f"Sort merge passes ({_format_count(sort_passes)}). Increase sort_buffer_size or optimize queries.")
+
+    # Row lock waits
+    row_lock_waits = lk.get("row_lock_waits", 0)
+    if row_lock_waits > 1000:
+        rec("warning", f"InnoDB row lock waits ({_format_count(row_lock_waits)}). Check for lock contention in concurrent writes.")
+    elif row_lock_waits > 0:
+        rec("info", f"InnoDB row lock waits ({_format_count(row_lock_waits)}). Check for lock contention in concurrent writes.")
+
+    # Table lock contention
+    tl_contention = lk.get("table_lock_contention", 0)
+    if tl_contention > 5:
+        rec("warning", f"Table lock contention at {tl_contention}%. May indicate MyISAM tables -- convert to InnoDB.")
+
+    # Slow queries
+    slow = qt.get("slow_queries", 0)
+    threshold = qt.get("long_query_time", "10")
+    if slow > 0:
+        rec("info", f"{_format_count(slow)} slow queries (threshold: {threshold}s). Review with performance_schema or slow query log.")
+
+    # Aborted clients
+    aborted_clients = ov.get("aborted_clients", 0)
+    if aborted_clients > 0:
+        rec("info", f"{_format_count(aborted_clients)} aborted clients. Applications may not be closing connections properly.")
+
+    # Aborted connects
+    aborted_connects = ov.get("aborted_connects", 0)
+    if aborted_connects > 0:
+        rec("info", f"{_format_count(aborted_connects)} aborted connection attempts. Check authentication issues or connection limits.")
+
+    # No index used in top queries
+    if result.top_queries:
+        no_index_count = sum(1 for q in result.top_queries if q.get("no_index_used", 0) > 0)
+        if no_index_count > 0:
+            rec("warning", f"Top queries using no index ({no_index_count} of {len(result.top_queries)}). Missing indexes are likely impacting performance.")
+
+    # Table cache
+    tc = result.table_cache or {}
+    opens_per_sec = tc.get("opens_per_second", 0)
+    cache_util = tc.get("cache_utilization_percent", 0)
+    if cache_util >= 95:
+        rec("warning", f"Table cache {cache_util}% full ({tc.get('open_tables')}/{tc.get('table_open_cache')}). Increase table_open_cache.")
+    if opens_per_sec > 5:
+        rec("warning", f"Table opens at {opens_per_sec}/sec — cache may be undersized. Increase table_open_cache.")
+
+    # Top queries diagnostic
+    if not result.top_queries:
+        if result.top_queries_status == "performance_schema_disabled":
+            pass  # Off by default on Railway; overhead (~400MB+) is too high to recommend casually
+        elif result.top_queries_status == "no_queries_recorded":
+            rec("info", "performance_schema is ON but no queries recorded. Database may be idle or recently restarted.")
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatter
+# ---------------------------------------------------------------------------
+
+def format_report(result: MySQLAnalysisResult) -> str:
+    lines: List[str] = []
+
+    def heading(title: str, level: int = 2):
+        prefix = "#" * level
+        lines.append(f"\n{prefix} {title}")
+
+    def table_row(*cells: str):
+        lines.append("| " + " | ".join(cells) + " |")
+
+    def table_sep(ncols: int):
+        lines.append("| " + " | ".join(["---"] * ncols) + " |")
+
+    # Title
+    lines.append(f"# MySQL Analysis: {result.service}")
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Deployment: {result.deployment_status}")
+
+    # --- Resource Overview (from Railway API) ---
+    if result.cpu_memory or result.disk_usage:
+        heading("Resource Overview")
+        table_row("Metric", "Value")
+        table_sep(2)
+        if result.cpu_memory:
+            cm = result.cpu_memory
+            if "cpu_percent" in cm:
+                trend = _trend_indicator(result.metrics_history, "cpu")
+                lines.append(f"| CPU | {cm['cpu_percent']}% vCPU{trend} |")
+            if "memory_gb" in cm:
+                trend = _trend_indicator(result.metrics_history, "memory")
+                mem_str = f"{cm['memory_gb']} GB"
+                if "memory_limit_gb" in cm and cm["memory_limit_gb"] > 0:
+                    pct = round(cm["memory_gb"] / cm["memory_limit_gb"] * 100, 1)
+                    mem_str += f" / {cm['memory_limit_gb']} GB ({pct}%)"
+                lines.append(f"| Memory | {mem_str}{trend} |")
+        if result.disk_usage:
+            trend = _trend_indicator(result.metrics_history, "disk")
+            lines.append(f"| Disk | {result.disk_usage.get('used', 'N/A')}{trend} |")
+
+    # --- Overview ---
+    ov = result.overview
+    if ov:
+        heading("Overview")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Version", str(ov["version"]), "")
+        table_row("Uptime", ov["uptime_human"], "")
+        conn_status = _status_ok_warn_crit(ov["connection_usage_percent"], 70, 90)
+        table_row(
+            "Connections",
+            f"{ov['connection_usage_percent']}% ({ov['max_used_connections']}/{ov['max_connections']})",
+            conn_status,
+        )
+        table_row("Threads Running", str(ov["threads_running"]), "")
+        aborted_c_status = "WARN" if ov["aborted_clients"] > 0 else "OK"
+        table_row("Aborted Clients", _format_count(ov["aborted_clients"]), aborted_c_status)
+        aborted_conn_status = "WARN" if ov["aborted_connects"] > 0 else "OK"
+        table_row("Aborted Connects", _format_count(ov["aborted_connects"]), aborted_conn_status)
+
+    # --- Query Throughput ---
+    qt = result.query_throughput
+    if qt:
+        heading("Query Throughput")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Total Queries", _format_count(qt["questions"]), "")
+        slow_status = "WARN" if qt["slow_queries"] > 0 else "OK"
+        table_row("Slow Queries", f"{_format_count(qt['slow_queries'])} (> {qt['long_query_time']}s threshold)", slow_status)
+        table_row("SELECT", _format_count(qt["com_select"]), "")
+        table_row("INSERT", _format_count(qt["com_insert"]), "")
+        table_row("UPDATE", _format_count(qt["com_update"]), "")
+        table_row("DELETE", _format_count(qt["com_delete"]), "")
+
+    # --- InnoDB Row Operations ---
+    ro = result.innodb_row_ops
+    if ro:
+        heading("InnoDB Row Operations")
+        table_row("Operation", "Count")
+        table_sep(2)
+        table_row("Rows Read", _format_count(ro["rows_read"]))
+        table_row("Rows Inserted", _format_count(ro["rows_inserted"]))
+        table_row("Rows Updated", _format_count(ro["rows_updated"]))
+        table_row("Rows Deleted", _format_count(ro["rows_deleted"]))
+
+    # --- Query Efficiency ---
+    qe = result.query_efficiency
+    if qe:
+        heading("Query Efficiency")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        tmp_status = _status_ok_warn_crit(qe["tmp_disk_table_percent"], 10, 25)
+        table_row(
+            "Temp Tables to Disk",
+            f"{qe['tmp_disk_table_percent']}% ({_format_count(qe['created_tmp_disk_tables'])}/{_format_count(qe['created_tmp_tables'])})",
+            tmp_status,
+        )
+        scan_status = _status_ok_warn_crit(qe["table_scan_percent"], 50, 75)
+        table_row("Table Scan Ratio", f"{qe['table_scan_percent']}%", scan_status)
+        fj_status = "WARN" if qe["select_full_join"] > 100 else "OK"
+        table_row("Full Joins", _format_count(qe["select_full_join"]), fj_status)
+        table_row("Sort Merge Passes", _format_count(qe["sort_merge_passes"]), "")
+
+    # --- InnoDB Buffer Pool ---
+    bp = result.innodb_buffer_pool
+    if bp:
+        heading("InnoDB Buffer Pool")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        hr_status = _status_ok_warn_crit(100 - bp["hit_ratio"], 1, 5)  # inverted: lower hit = worse
+        table_row("Cache Hit Ratio", f"{bp['hit_ratio']}%", hr_status)
+        usage_status = _status_ok_warn_crit(bp["usage_percent"], 90, 95)
+        table_row(
+            "Pool Usage",
+            f"{bp['usage_percent']}% ({_format_bytes(bp['bytes_data'])}/{_format_bytes(bp['buffer_pool_size'])})",
+            usage_status,
+        )
+        table_row("Dirty Pages", _format_bytes(bp["bytes_dirty"]), "")
+        table_row("Free Pages", _format_count(bp["pages_free"]), "")
+
+    # --- Network ---
+    nw = result.network
+    if nw:
+        heading("Network")
+        table_row("Metric", "Value")
+        table_sep(2)
+        table_row("Bytes Received", _format_bytes(nw["bytes_received"]))
+        table_row("Bytes Sent", _format_bytes(nw["bytes_sent"]))
+
+    # --- Locks ---
+    lk = result.locks
+    if lk:
+        heading("Locks")
+        table_row("Metric", "Value", "Status")
+        table_sep(3)
+        table_row("Row Lock Waits", _format_count(lk["row_lock_waits"]), "")
+        table_row("Row Lock Time (ms)", _format_count(lk["row_lock_time"]), "")
+        tl_status = _status_ok_warn_crit(lk["table_lock_contention"], 1, 5)
+        table_row("Table Lock Contention", f"{lk['table_lock_contention']}%", tl_status)
+
+    # --- Table Cache ---
+    tc = result.table_cache
+    if tc:
+        heading("Table Cache")
+        table_row("Metric", "Value")
+        table_sep(2)
+        table_row("Open Tables", f"{_format_count(tc['open_tables'])} / {_format_count(tc.get('table_open_cache', 0))}")
+        table_row("Cache Utilization", f"{tc.get('cache_utilization_percent', 0)}%")
+        table_row("Table Opens/sec", f"{tc.get('opens_per_second', 0)}")
+
+    # --- Top Queries ---
+    if result.top_queries:
+        heading("Top Queries (by total latency)")
+        table_row("Query", "Calls", "Avg Latency", "Total Latency", "Rows Examined", "Rows Sent")
+        table_sep(6)
+        for q in result.top_queries[:15]:
+            digest = q["digest_text"][:60] + "..." if len(q["digest_text"]) > 60 else q["digest_text"]
+            # Escape pipe chars in query text
+            digest = digest.replace("|", "\\|")
+            table_row(
+                digest,
+                _format_count(q["count_star"]),
+                f"{q['avg_latency_ms']:.1f}ms",
+                f"{q['total_latency_ms']:.1f}ms",
+                _format_count(q["rows_examined"]),
+                _format_count(q["rows_sent"]),
+            )
+    else:
+        heading("Top Queries (by total latency)")
+        if result.top_queries_status == "performance_schema_disabled":
+            lines.append("performance_schema is disabled — no query-level data available.")
+            lines.append("Note: enabling it requires ~400MB+ additional memory; only advisable on larger instances.")
+        elif result.top_queries_status == "no_queries_recorded":
+            lines.append("No queries recorded. Database may be idle or recently restarted.")
+        else:
+            lines.append("No query data available.")
+        lines.append("")
+
+    # --- Tables ---
+    if result.tables:
+        heading("Tables (by size)")
+        table_row("Table", "Rows", "Data", "Indexes", "Total")
+        table_sep(5)
+        for t in result.tables[:15]:
+            table_row(
+                t["name"],
+                _format_count(t["rows"]),
+                _format_bytes(t["data_length"]),
+                _format_bytes(t["index_length"]),
+                _format_bytes(t["total_size"]),
+            )
+
+    # --- Active Queries ---
+    if result.active_processes:
+        heading("Active Queries")
+        # Filter out system processes
+        user_procs = [p for p in result.active_processes if p["command"] != "Daemon"]
+        if user_procs:
+            table_row("User", "Database", "Command", "Time (s)", "Query")
+            table_sep(5)
+            for p in user_procs[:20]:
+                info = (p["info"] or "")[:80]
+                info = info.replace("|", "\\|")
+                table_row(
+                    p["user"],
+                    p["db"] or "",
+                    p["command"],
+                    str(p["time"]),
+                    info,
+                )
+        else:
+            lines.append("\nNo active user queries.")
+
+    # --- Infrastructure Metrics ---
+    if result.metrics_history:
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Metrics ({window_label})")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend |")
+            lines.append("|--------|---------|-----|-----|-----|-------|")
+            for key in ["cpu", "memory", "disk", "network_rx", "network_tx"]:
+                if key in mh:
+                    entry = mh[key]
+                    trend = entry.get("trend", {})
+                    trend_str = trend.get("direction", "N/A")
+                    change = trend.get("change_pct", 0)
+                    if change != 0:
+                        trend_str += f" ({change:+.1f}%)"
+                    lines.append(
+                        f"| {key.replace('_', ' ').title()} "
+                        f"| {entry['current']}{entry['unit']} "
+                        f"| {entry['min']}{entry['unit']} "
+                        f"| {entry['max']}{entry['unit']} "
+                        f"| {entry['avg']}{entry['unit']} "
+                        f"| {trend_str} |"
+                    )
+            lines.append("")
+
+    # --- Collection Errors ---
+    if result.errors:
+        heading("Collection Errors")
+        for err in result.errors:
+            lines.append(f"- {err}")
+
+    # --- Recommendations ---
+    heading("Recommendations")
+    if result.recommendations:
+        for r in result.recommendations:
+            severity = r["severity"].upper()
+            lines.append(f"- **[{severity}]** {r['message']}")
+    else:
+        lines.append("No issues detected.")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+def analyze_mysql(service: str, timeout: int = 60, quiet: bool = False,
+                  skip_logs: bool = False, metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> MySQLAnalysisResult:
+    """Run complete MySQL analysis."""
+    if not quiet:
+        print(f"Analyzing mysql database: {service}", file=sys.stderr)
+
+    result = MySQLAnalysisResult(
+        service=service,
+        db_type="mysql",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === CONTEXT ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # === DEPLOYMENT STATUS ===
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION ===
+    progress(3, 5, "Running analysis (metrics, queries, logs in parallel)...", quiet)
+
+    def task_metrics():
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_mysql_queries():
+        if not ssh_available:
+            return {"errors": [f"SSH not available: {ssh_stderr or 'connection failed'}"]}
+        data = collect_mysql_data(service, timeout=timeout)
+        if data.get("errors") and not data.get("global_status"):
+            # Retry once
+            data = collect_mysql_data(service, timeout=timeout)
+        return data
+
+    def task_logs():
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_mysql = executor.submit(task_mysql_queries)
+        future_logs = executor.submit(task_logs)
+
+        metrics_result = future_metrics.result()
+        mysql_data = future_mysql.result()
+        logs_result = future_logs.result()
+
+    # Process metrics
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data",
+        }
+
+    # Process MySQL data
+    progress(4, 5, "Processing results...", quiet)
+    mysql_errors = mysql_data.get("errors", [])
+    if mysql_data.get("global_status"):
+        parse_mysql_data(mysql_data, result)
+        result.collection_status["mysql_query"] = {"status": "success"}
+        if mysql_errors:
+            result.collection_status["mysql_query"]["warnings"] = mysql_errors
+    else:
+        error_msg = "; ".join(mysql_errors) if mysql_errors else "No data returned"
+        if not ssh_available:
+            error_msg = f"SSH failed after {len(ssh_attempts)} attempts: {ssh_stderr or 'connection failed'}"
+        result.errors.append(f"MySQL data collection failed: {error_msg}")
+        result.collection_status["mysql_query"] = {
+            "status": "error",
+            "error": error_msg,
+        }
+
+    # Process logs
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {"status": "success", "lines": len(logs_result)}
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if "ERROR" in line.upper() or "FATAL" in line.upper()
+        ][:100]
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {
+            "status": "error",
+            "error": "Logs API returned no data",
+        }
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running MySQL queries on: {service}", file=sys.stderr)
+        data = collect_mysql_data(service, timeout=args.timeout)
+        print(json.dumps(data, indent=2, default=str))
+        return 0 if data.get("global_status") else 1
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="MySQL analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=60,
+                        help="Timeout in seconds for SSH queries (default: 60)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                        help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                        help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                        help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                        help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_mysql(
+        args.service,
+        timeout=args.timeout,
+        quiet=args.quiet,
+        skip_logs=args.skip_logs,
+        metrics_hours=min(args.metrics_hours, 168),
+        project_id=args.project_id,
+        environment_id=args.environment_id,
+        service_id=args.service_id,
+    )
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-postgres.py
+++ b/.claude/skills/use-railway/scripts/analyze-postgres.py
@@ -1,0 +1,3058 @@
+#!/usr/bin/env python3
+"""
+Complete database analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Deployment status
+- Resource overview (disk, connections)
+- Memory configuration
+- Cache efficiency (overall and per-table)
+- Vacuum health
+- Query performance (with --deep)
+- Index health
+- Recommendations
+
+Usage:
+    analyze-postgres.py --service <name>
+    analyze-postgres.py --service <name> --deep
+    analyze-postgres.py --service <name> --json
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query, run_psql_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _trend_indicator,
+)
+
+
+@dataclass
+class AnalysisResult:
+    """Container for analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+    disk_usage: Optional[Dict[str, Any]] = None
+    cpu_memory: Optional[Dict[str, Any]] = None
+    connections: Optional[Dict[str, Any]] = None
+    connection_states: List[Dict[str, Any]] = field(default_factory=list)
+    connections_by_app: List[Dict[str, Any]] = field(default_factory=list)
+    connections_by_age: List[Dict[str, Any]] = field(default_factory=list)
+    oldest_connection_sec: Optional[int] = None
+    oldest_connections: List[Dict[str, Any]] = field(default_factory=list)
+    memory_config: Optional[Dict[str, Any]] = None
+    cache_hit: Optional[Dict[str, Any]] = None
+    cache_per_table: List[Dict[str, Any]] = field(default_factory=list)
+    table_sizes: List[Dict[str, Any]] = field(default_factory=list)
+    database_stats: Optional[Dict[str, Any]] = None
+    size_breakdown: Optional[Dict[str, Any]] = None
+    vacuum_health: List[Dict[str, Any]] = field(default_factory=list)
+    xid_age: Optional[Dict[str, Any]] = None
+    pg_stat_statements_installed: bool = False
+    top_queries: List[Dict[str, Any]] = field(default_factory=list)
+    long_running_queries: List[Dict[str, Any]] = field(default_factory=list)
+    idle_in_transaction: List[Dict[str, Any]] = field(default_factory=list)
+    blocked_queries: List[Dict[str, Any]] = field(default_factory=list)
+    locks: List[Dict[str, Any]] = field(default_factory=list)
+    unused_indexes: List[Dict[str, Any]] = field(default_factory=list)
+    invalid_indexes: List[Dict[str, Any]] = field(default_factory=list)
+    seq_scan_tables: List[Dict[str, Any]] = field(default_factory=list)
+    replication: List[Dict[str, Any]] = field(default_factory=list)
+    bgwriter: Optional[Dict[str, Any]] = None
+    archiver: Optional[Dict[str, Any]] = None
+    progress_vacuum: List[Dict[str, Any]] = field(default_factory=list)
+    ssl_stats: Optional[Dict[str, Any]] = None
+    ha_cluster: Optional[Dict[str, Any]] = None
+    cluster_logs: List[Dict[str, Any]] = field(default_factory=list)
+    recent_logs: List[str] = field(default_factory=list)  # Raw unfiltered logs for LLM analysis
+    recent_errors: List[str] = field(default_factory=list)  # Legacy: filtered error logs
+    metrics_history: Optional[Dict[str, Any]] = None  # Multi-window time series + trend analysis for CPU, memory, disk, network
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)  # Status of each data source
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+
+def run_psql_query_safe(service: str, query: str, timeout: int = 60) -> Tuple[int, str, str]:
+    """Run a psql query using base64 encoding to avoid shell quoting issues."""
+    encoded = base64.b64encode(query.encode()).decode()
+    # 2>/dev/null suppresses psql warnings (e.g., collation version mismatch) that pollute stdout
+    command = f"echo '{encoded}' | base64 -d | psql $DATABASE_URL -P pager=off -t -A 2>/dev/null"
+    return run_ssh_query(service, command, timeout)
+
+
+def build_analysis_query() -> str:
+    """Build a single SQL query that returns all analysis data as JSON."""
+    return """
+SELECT json_build_object(
+    'connections', (
+        SELECT json_build_object(
+            'current', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()),
+            'max', (SELECT setting::int FROM pg_settings WHERE name = 'max_connections'),
+            'reserved', (SELECT setting::int FROM pg_settings WHERE name = 'superuser_reserved_connections'),
+            'active', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'active'),
+            'idle', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'idle'),
+            'idle_in_transaction', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'idle in transaction')
+        )
+    ),
+    'memory_config', (
+        SELECT json_agg(json_build_object(
+            'name', name,
+            'setting', setting,
+            'unit', unit
+        ))
+        FROM pg_settings
+        WHERE name IN (
+            'shared_buffers', 'effective_cache_size', 'work_mem', 'maintenance_work_mem',
+            'wal_buffers', 'checkpoint_completion_target', 'min_wal_size', 'max_wal_size',
+            'max_parallel_workers', 'max_parallel_workers_per_gather', 'random_page_cost',
+            'default_statistics_target', 'synchronous_commit', 'max_connections',
+            'autovacuum', 'autovacuum_vacuum_scale_factor', 'autovacuum_analyze_scale_factor',
+            'track_activity_query_size', 'log_min_duration_statement',
+            'idle_in_transaction_session_timeout', 'statement_timeout',
+            'track_io_timing'
+        )
+    ),
+    'cache_hit', (
+        SELECT json_build_object(
+            'table_hit_pct', ROUND(100.0 * sum(heap_blks_hit) / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0), 2),
+            'index_hit_pct', ROUND(100.0 * sum(idx_blks_hit) / NULLIF(sum(idx_blks_hit) + sum(idx_blks_read), 0), 2)
+        )
+        FROM pg_statio_user_tables
+    ),
+    'database_stats', (
+        SELECT json_build_object(
+            'deadlocks', deadlocks,
+            'temp_files', temp_files,
+            'temp_bytes', temp_bytes,
+            'stats_reset', COALESCE(stats_reset::text, 'never'),
+            'blks_read', blks_read,
+            'blks_hit', blks_hit,
+            'tup_returned', tup_returned,
+            'tup_fetched', tup_fetched,
+            'tup_inserted', tup_inserted,
+            'tup_updated', tup_updated,
+            'tup_deleted', tup_deleted,
+            'conflicts', conflicts,
+            'checksum_failures', COALESCE(checksum_failures, 0)
+        )
+        FROM pg_stat_database
+        WHERE datname = current_database()
+    ),
+    'cache_per_table', (
+        SELECT COALESCE(json_agg(t ORDER BY t.disk_reads DESC), '[]'::json)
+        FROM (
+            SELECT
+                relname as table_name,
+                heap_blks_read as disk_reads,
+                heap_blks_hit as cache_hits,
+                ROUND(100.0 * heap_blks_hit / NULLIF(heap_blks_hit + heap_blks_read, 0), 2) as hit_pct
+            FROM pg_statio_user_tables
+            WHERE heap_blks_read > 10000
+            ORDER BY heap_blks_read DESC LIMIT 1000
+        ) t
+    ),
+    'table_sizes', (
+        SELECT COALESCE(json_agg(t ORDER BY t.total_bytes DESC), '[]'::json)
+        FROM (
+            SELECT
+                schemaname as schema,
+                relname as table_name,
+                pg_size_pretty(pg_total_relation_size(relid)) as size,
+                pg_total_relation_size(relid) as total_bytes,
+                pg_table_size(relid) as data_bytes,
+                pg_indexes_size(relid) as index_bytes,
+                n_live_tup as row_count
+            FROM pg_stat_user_tables
+            ORDER BY pg_total_relation_size(relid) DESC LIMIT 1000
+        ) t
+    ),
+    'size_breakdown', (
+        SELECT json_build_object(
+            'database_bytes', pg_database_size(current_database()),
+            'wal_bytes', COALESCE((SELECT sum(size) FROM pg_ls_waldir()), 0),
+            'user_tables_bytes', COALESCE((SELECT sum(pg_table_size(relid)) FROM pg_stat_user_tables), 0),
+            'user_indexes_bytes', COALESCE((SELECT sum(pg_indexes_size(relid)) FROM pg_stat_user_tables), 0),
+            'system_bytes', COALESCE((
+                SELECT sum(pg_total_relation_size(c.oid))
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname IN ('pg_catalog', 'information_schema') AND NOT c.relisshared
+            ), 0)
+        )
+    ),
+    'vacuum_health', (
+        SELECT COALESCE(json_agg(t ORDER BY t.dead_rows DESC), '[]'::json)
+        FROM (
+            SELECT
+                s.schemaname as schema,
+                s.relname as table_name,
+                n_live_tup as live_rows,
+                n_dead_tup as dead_rows,
+                CASE WHEN n_live_tup > 0 THEN ROUND(100.0 * n_dead_tup / n_live_tup, 2) ELSE 0 END as dead_pct,
+                vacuum_count,
+                autovacuum_count,
+                COALESCE(last_vacuum::text, 'never') as last_vacuum,
+                COALESCE(last_autovacuum::text, 'never') as last_autovacuum,
+                COALESCE(last_analyze::text, 'never') as last_analyze,
+                age(c.relfrozenxid) as xid_age,
+                CASE WHEN n_dead_tup > 1000 AND (n_live_tup = 0 OR n_dead_tup::float / NULLIF(n_live_tup, 0) > 0.1) THEN true ELSE false END as needs_vacuum,
+                CASE WHEN age(c.relfrozenxid) > 150000000 THEN true ELSE false END as needs_freeze
+            FROM pg_stat_user_tables s
+            JOIN pg_class c ON c.oid = s.relid
+            WHERE n_dead_tup > 100
+            ORDER BY n_dead_tup DESC LIMIT 1000
+        ) t
+    ),
+    'xid_age', (
+        SELECT json_build_object(
+            'value', age(datfrozenxid)
+        )
+        FROM pg_database WHERE datname = current_database()
+    ),
+    'unused_indexes', (
+        SELECT COALESCE(json_agg(t ORDER BY t.size_bytes DESC), '[]'::json)
+        FROM (
+            SELECT
+                s.schemaname as schema,
+                s.relname as table_name,
+                s.indexrelname as index_name,
+                pg_size_pretty(pg_relation_size(s.indexrelid)) as size,
+                pg_relation_size(s.indexrelid) as size_bytes,
+                s.idx_scan as scans,
+                t.seq_scan as table_seq_scans,
+                t.idx_scan as table_idx_scans,
+                t.n_live_tup as table_rows,
+                i.indisprimary as is_primary,
+                i.indisunique as is_unique,
+                CASE WHEN t.seq_scan > 0 AND s.idx_scan = 0 AND t.n_live_tup > 1000
+                    THEN t.seq_scan ELSE 0 END as missing_index_score
+            FROM pg_stat_user_indexes s
+            JOIN pg_stat_user_tables t ON s.relid = t.relid
+            JOIN pg_index i ON s.indexrelid = i.indexrelid
+            WHERE s.idx_scan = 0 AND pg_relation_size(s.indexrelid) > 8192
+            ORDER BY pg_relation_size(s.indexrelid) DESC LIMIT 1000
+        ) t
+    ),
+    'connection_states', (
+        SELECT COALESCE(json_agg(t ORDER BY t.count DESC), '[]'::json)
+        FROM (
+            SELECT state, count(*) as count
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            GROUP BY state
+            ORDER BY count DESC
+        ) t
+    ),
+    'connections_by_app', (
+        SELECT COALESCE(json_agg(t ORDER BY t.count DESC), '[]'::json)
+        FROM (
+            SELECT COALESCE(application_name, '') as app, COUNT(*) as count
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            GROUP BY application_name
+            ORDER BY count DESC LIMIT 100
+        ) t
+    ),
+    'connections_by_age', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                CASE
+                    WHEN age_seconds < 60 THEN '< 1 min'
+                    WHEN age_seconds < 300 THEN '1-5 min'
+                    WHEN age_seconds < 3600 THEN '5-60 min'
+                    WHEN age_seconds < 86400 THEN '1-24 hr'
+                    ELSE '> 24 hr'
+                END as range,
+                count(*) as count
+            FROM (
+                SELECT EXTRACT(EPOCH FROM (now() - backend_start)) as age_seconds
+                FROM pg_stat_activity WHERE datname = current_database()
+            ) sub
+            GROUP BY 1
+            ORDER BY MIN(age_seconds)
+        ) t
+    ),
+    'oldest_connection_sec', (
+        SELECT COALESCE(MAX(EXTRACT(EPOCH FROM (now() - backend_start)))::int, 0)
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+    ),
+    'oldest_connections', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                COALESCE(application_name, '') as application_name,
+                state,
+                LEFT(query, 100) as query_preview,
+                ROUND(EXTRACT(EPOCH FROM (now() - backend_start)) / 3600)::int as age_hours,
+                ROUND(EXTRACT(EPOCH FROM (now() - backend_start)) / 86400, 1) as age_days,
+                client_addr::text,
+                wait_event_type,
+                wait_event
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND EXTRACT(EPOCH FROM (now() - backend_start)) > 86400
+            ORDER BY backend_start ASC
+            LIMIT 5
+        ) t
+    ),
+    'seq_scan_tables', (
+        SELECT COALESCE(json_agg(t ORDER BY t.seq_scans DESC), '[]'::json)
+        FROM (
+            SELECT
+                relname as table_name,
+                seq_scan as seq_scans,
+                idx_scan as idx_scans,
+                n_live_tup as rows
+            FROM pg_stat_user_tables
+            WHERE seq_scan > 100 AND n_live_tup > 1000
+            ORDER BY seq_scan DESC LIMIT 100
+        ) t
+    ),
+    'pg_stat_statements_installed', (
+        SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements')
+    ),
+    'top_queries', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                query,
+                calls,
+                ROUND(total_exec_time::numeric/1000/60, 1) as total_min,
+                ROUND(mean_exec_time::numeric, 1) as mean_ms,
+                ROUND(min_exec_time::numeric, 1) as min_ms,
+                ROUND(max_exec_time::numeric, 1) as max_ms,
+                ROUND(stddev_exec_time::numeric, 1) as stddev_ms,
+                rows,
+                CASE WHEN calls > 0 THEN ROUND(rows::numeric / calls, 2) ELSE 0 END as rows_per_call,
+                total_exec_time,
+                ROUND(total_plan_time::numeric, 1) as total_plan_ms,
+                ROUND(mean_plan_time::numeric, 1) as mean_plan_ms,
+                shared_blks_hit,
+                shared_blks_read,
+                shared_blks_dirtied,
+                shared_blks_written,
+                ROUND(100.0 * shared_blks_hit / NULLIF(shared_blks_hit + shared_blks_read, 0), 2) as cache_hit_pct,
+                local_blks_hit,
+                local_blks_read,
+                temp_blks_read,
+                temp_blks_written,
+                ROUND(blk_read_time::numeric, 1) as blk_read_time_ms,
+                ROUND(blk_write_time::numeric, 1) as blk_write_time_ms,
+                wal_records,
+                wal_bytes
+            FROM pg_stat_statements s
+            JOIN pg_database d ON s.dbid = d.oid
+            WHERE d.datname = current_database()
+            ORDER BY total_exec_time DESC LIMIT 100
+        ) t
+    ),
+    'long_running_queries', (
+        SELECT COALESCE(json_agg(t ORDER BY t.duration_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                pid,
+                EXTRACT(EPOCH FROM (now() - query_start))::int as duration_sec,
+                query
+            FROM pg_stat_activity
+            WHERE state = 'active'
+                AND now() - query_start > interval '5 seconds'
+            ORDER BY query_start LIMIT 100
+        ) t
+    ),
+    'idle_in_transaction', (
+        SELECT COALESCE(json_agg(t ORDER BY t.idle_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                pid,
+                EXTRACT(EPOCH FROM (now() - state_change))::int as idle_sec,
+                COALESCE(usename, '') as username,
+                COALESCE(application_name, '') as app,
+                query as last_query
+            FROM pg_stat_activity
+            WHERE state = 'idle in transaction'
+                AND now() - state_change > interval '30 seconds'
+            ORDER BY state_change LIMIT 100
+        ) t
+    ),
+    'blocked_queries', (
+        SELECT COALESCE(json_agg(t ORDER BY t.wait_sec DESC), '[]'::json)
+        FROM (
+            SELECT
+                blocked.pid,
+                EXTRACT(EPOCH FROM (now() - blocked.query_start))::int as wait_sec,
+                COALESCE(blocked.usename, '') as username,
+                COALESCE(blocking.pid::text, '') as blocking_pid,
+                left(blocked.query, 60) as query
+            FROM pg_stat_activity blocked
+            JOIN pg_locks blocked_locks ON blocked.pid = blocked_locks.pid
+            JOIN pg_locks blocking_locks ON blocked_locks.locktype = blocking_locks.locktype
+                AND blocked_locks.database IS NOT DISTINCT FROM blocking_locks.database
+                AND blocked_locks.relation IS NOT DISTINCT FROM blocking_locks.relation
+                AND blocked_locks.page IS NOT DISTINCT FROM blocking_locks.page
+                AND blocked_locks.tuple IS NOT DISTINCT FROM blocking_locks.tuple
+                AND blocked_locks.virtualxid IS NOT DISTINCT FROM blocking_locks.virtualxid
+                AND blocked_locks.transactionid IS NOT DISTINCT FROM blocking_locks.transactionid
+                AND blocked_locks.classid IS NOT DISTINCT FROM blocking_locks.classid
+                AND blocked_locks.objid IS NOT DISTINCT FROM blocking_locks.objid
+                AND blocked_locks.objsubid IS NOT DISTINCT FROM blocking_locks.objsubid
+                AND blocked_locks.pid != blocking_locks.pid
+            JOIN pg_stat_activity blocking ON blocking_locks.pid = blocking.pid
+            WHERE NOT blocked_locks.granted
+            ORDER BY blocked.query_start LIMIT 100
+        ) t
+    ),
+    'locks', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                l.locktype,
+                l.mode,
+                COALESCE(a.usename, '') as username,
+                COALESCE(a.application_name, '') as app,
+                left(COALESCE(a.query, ''), 50) as query
+            FROM pg_locks l
+            JOIN pg_stat_activity a ON l.pid = a.pid
+            WHERE a.datname = current_database() AND NOT l.granted
+            LIMIT 100
+        ) t
+    ),
+    'replication', (
+        SELECT COALESCE(json_agg(t), '[]'::json)
+        FROM (
+            SELECT
+                COALESCE(client_addr::text, 'local') as client,
+                state,
+                sent_lsn::text as sent_lsn,
+                replay_lsn::text as replay_lsn
+            FROM pg_stat_replication
+        ) t
+    ),
+    'bgwriter', (
+        SELECT json_build_object(
+            'checkpoints_timed', checkpoints_timed,
+            'checkpoints_req', checkpoints_req,
+            'buffers_checkpoint', buffers_checkpoint,
+            'buffers_clean', buffers_clean,
+            'buffers_backend', buffers_backend,
+            'buffers_backend_fsync', buffers_backend_fsync,
+            'maxwritten_clean', maxwritten_clean,
+            'stats_reset', COALESCE(stats_reset::text, 'never')
+        )
+        FROM pg_stat_bgwriter
+    ),
+    'invalid_indexes', (
+        SELECT COALESCE(json_agg(json_build_object(
+            'schema', n.nspname,
+            'table', c.relname,
+            'index', i.relname
+        )), '[]'::json)
+        FROM pg_index x
+        JOIN pg_class c ON c.oid = x.indrelid
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE NOT x.indisvalid
+    ),
+    'archiver', (
+        SELECT json_build_object(
+            'archived_count', archived_count,
+            'failed_count', failed_count,
+            'last_archived_wal', last_archived_wal,
+            'last_archived_time', COALESCE(last_archived_time::text, 'never'),
+            'last_failed_wal', last_failed_wal,
+            'last_failed_time', COALESCE(last_failed_time::text, 'never'),
+            'stats_reset', COALESCE(stats_reset::text, 'never')
+        )
+        FROM pg_stat_archiver
+    ),
+    'progress_vacuum', (
+        SELECT COALESCE(json_agg(json_build_object(
+            'pid', p.pid,
+            'datname', d.datname,
+            'relname', c.relname,
+            'phase', p.phase,
+            'heap_blks_total', p.heap_blks_total,
+            'heap_blks_scanned', p.heap_blks_scanned,
+            'heap_blks_vacuumed', p.heap_blks_vacuumed,
+            'index_vacuum_count', p.index_vacuum_count,
+            'max_dead_tuples', p.max_dead_tuples,
+            'num_dead_tuples', p.num_dead_tuples
+        )), '[]'::json)
+        FROM pg_stat_progress_vacuum p
+        JOIN pg_database d ON p.datid = d.oid
+        LEFT JOIN pg_class c ON p.relid = c.oid
+    ),
+    'ssl_stats', (
+        SELECT json_build_object(
+            'ssl_connections', (SELECT count(*) FROM pg_stat_ssl WHERE ssl = true),
+            'non_ssl_connections', (SELECT count(*) FROM pg_stat_ssl WHERE ssl = false),
+            'ssl_versions', (
+                SELECT COALESCE(json_agg(json_build_object('version', version, 'count', cnt)), '[]'::json)
+                FROM (SELECT version, count(*) as cnt FROM pg_stat_ssl WHERE ssl = true GROUP BY version) v
+            )
+        )
+    )
+)::text;
+"""
+
+
+def parse_batched_analysis(data: Dict[str, Any], result: AnalysisResult) -> None:
+    """Parse the batched JSON analysis data into the result object."""
+
+    # Connections
+    conn = data.get("connections")
+    if conn:
+        current = conn.get("current", 0)
+        max_conn = conn.get("max", 1)
+        reserved = conn.get("reserved", 3)
+        result.connections = {
+            "current": current,
+            "max": max_conn,
+            "reserved": reserved,
+            "available": max_conn - current - reserved,
+            "percent": round(current / max_conn * 100, 1) if max_conn > 0 else 0,
+            "active": conn.get("active", 0),
+            "idle": conn.get("idle", 0),
+            "idle_in_transaction": conn.get("idle_in_transaction", 0),
+        }
+
+    # Memory config (expanded for tuning analysis)
+    mem_config = data.get("memory_config")
+    if mem_config:
+        result.memory_config = {}
+        for row in mem_config:
+            name = row["name"]
+            setting = row["setting"]
+            unit = row["unit"]
+
+            # Handle different value types
+            if unit == "8kB":
+                # Convert 8kB pages to MB
+                mb = int(setting) * 8 / 1024 if str(setting).isdigit() else 0
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": round(mb, 1)}
+            elif unit == "kB":
+                mb = int(setting) / 1024 if str(setting).isdigit() else 0
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": round(mb, 1)}
+            elif unit == "MB":
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else 0, "unit": unit, "mb": int(setting) if str(setting).isdigit() else 0}
+            elif unit in ("ms", "s", "min"):
+                # Time-based settings
+                result.memory_config[name] = {"value": setting, "unit": unit}
+            elif name in ("random_page_cost", "checkpoint_completion_target", "autovacuum_vacuum_scale_factor", "autovacuum_analyze_scale_factor"):
+                # Float settings
+                result.memory_config[name] = {"value": float(setting) if setting else 0}
+            elif name in ("synchronous_commit", "autovacuum", "track_io_timing"):
+                # On/off settings
+                result.memory_config[name] = {"value": setting}
+            else:
+                # Integer settings (max_connections, max_parallel_workers, etc.)
+                result.memory_config[name] = {"value": int(setting) if str(setting).isdigit() else setting}
+
+    # Cache hit
+    cache = data.get("cache_hit")
+    if cache:
+        result.cache_hit = {
+            "table_hit_pct": cache.get("table_hit_pct"),
+            "index_hit_pct": cache.get("index_hit_pct"),
+        }
+
+    # Database stats
+    db_stats = data.get("database_stats")
+    if db_stats:
+        result.database_stats = {
+            "deadlocks": db_stats.get("deadlocks", 0),
+            "temp_files": db_stats.get("temp_files", 0),
+            "temp_bytes": db_stats.get("temp_bytes", 0),
+            "stats_reset": db_stats.get("stats_reset", "unknown"),
+            "blks_read": db_stats.get("blks_read", 0),
+            "blks_hit": db_stats.get("blks_hit", 0),
+            "tup_returned": db_stats.get("tup_returned", 0),
+            "tup_fetched": db_stats.get("tup_fetched", 0),
+            "tup_inserted": db_stats.get("tup_inserted", 0),
+            "tup_updated": db_stats.get("tup_updated", 0),
+            "tup_deleted": db_stats.get("tup_deleted", 0),
+            "conflicts": db_stats.get("conflicts", 0),
+            "checksum_failures": db_stats.get("checksum_failures", 0),
+        }
+
+    # Cache per table
+    cache_per_table = data.get("cache_per_table", [])
+    result.cache_per_table = [
+        {
+            "table": t.get("table_name"),
+            "disk_reads": str(t.get("disk_reads", 0)),
+            "cache_hits": str(t.get("cache_hits", 0)),
+            "hit_pct": str(t.get("hit_pct", 0)),
+        }
+        for t in cache_per_table
+    ]
+
+    # Table sizes
+    table_sizes = data.get("table_sizes", [])
+    result.table_sizes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "size": t.get("size"),
+            "total_bytes": str(t.get("total_bytes", 0)),
+            "data_bytes": str(t.get("data_bytes", 0)),
+            "index_bytes": str(t.get("index_bytes", 0)),
+            "row_count": str(t.get("row_count", 0)),
+        }
+        for t in table_sizes
+    ]
+
+    # Size breakdown
+    size = data.get("size_breakdown")
+    if size:
+        result.size_breakdown = {
+            "database_bytes": size.get("database_bytes", 0),
+            "wal_bytes": size.get("wal_bytes", 0),
+            "user_tables_bytes": size.get("user_tables_bytes", 0),
+            "user_indexes_bytes": size.get("user_indexes_bytes", 0),
+            "system_bytes": size.get("system_bytes", 0),
+        }
+
+    # Vacuum health
+    vacuum = data.get("vacuum_health", [])
+    result.vacuum_health = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "live_rows": str(t.get("live_rows", 0)),
+            "dead_rows": str(t.get("dead_rows", 0)),
+            "dead_pct": str(t.get("dead_pct", 0)),
+            "vacuum_count": str(t.get("vacuum_count", 0)),
+            "autovacuum_count": str(t.get("autovacuum_count", 0)),
+            "last_vacuum": t.get("last_vacuum", "never"),
+            "last_autovacuum": t.get("last_autovacuum", "never"),
+            "last_analyze": t.get("last_analyze", "never"),
+            "xid_age": str(t.get("xid_age", 0)),
+            "needs_vacuum": "true" if t.get("needs_vacuum") else "false",
+            "needs_freeze": "true" if t.get("needs_freeze") else "false",
+        }
+        for t in vacuum
+    ]
+
+    # XID age
+    xid = data.get("xid_age")
+    if xid and xid.get("value") is not None:
+        xid_val = xid["value"]
+        result.xid_age = {
+            "value": xid_val,
+            "millions": round(xid_val / 1_000_000, 1),
+            "pct_to_wraparound": round(xid_val / 2_147_483_647 * 100, 2)
+        }
+
+    # Unused indexes
+    unused = data.get("unused_indexes", [])
+    result.unused_indexes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table_name"),
+            "index": t.get("index_name"),
+            "size": t.get("size"),
+            "size_bytes": str(t.get("size_bytes", 0)),
+            "scans": str(t.get("scans", 0)),
+            "table_seq_scans": str(t.get("table_seq_scans", 0)),
+            "table_idx_scans": str(t.get("table_idx_scans", 0)),
+            "table_rows": str(t.get("table_rows", 0)),
+            "is_primary": t.get("is_primary", False),
+            "is_unique": t.get("is_unique", False),
+            "missing_index_score": str(t.get("missing_index_score", 0)),
+        }
+        for t in unused
+    ]
+
+    # Connection states
+    conn_states = data.get("connection_states", [])
+    result.connection_states = [
+        {"state": t.get("state"), "count": str(t.get("count", 0))}
+        for t in conn_states
+    ]
+
+    # Connections by app
+    conn_app = data.get("connections_by_app", [])
+    result.connections_by_app = [
+        {"app": t.get("app", ""), "count": str(t.get("count", 0))}
+        for t in conn_app
+    ]
+
+    # Connections by age
+    conn_age = data.get("connections_by_age", [])
+    result.connections_by_age = [
+        {"range": t.get("range"), "count": str(t.get("count", 0))}
+        for t in conn_age
+    ]
+
+    # Oldest connection
+    oldest = data.get("oldest_connection_sec")
+    if oldest is not None:
+        result.oldest_connection_sec = oldest
+
+    # Details of old connections (>24 hours)
+    oldest_conns = data.get("oldest_connections", [])
+    result.oldest_connections = [
+        {
+            "application_name": c.get("application_name", ""),
+            "state": c.get("state"),
+            "query_preview": c.get("query_preview"),
+            "age_hours": c.get("age_hours"),
+            "age_days": c.get("age_days"),
+            "client_addr": c.get("client_addr"),
+            "wait_event_type": c.get("wait_event_type"),
+            "wait_event": c.get("wait_event"),
+        }
+        for c in oldest_conns
+    ]
+
+    # Seq scan tables
+    seq_tables = data.get("seq_scan_tables", [])
+    result.seq_scan_tables = [
+        {
+            "table": t.get("table_name"),
+            "seq_scans": str(t.get("seq_scans", 0)),
+            "idx_scans": str(t.get("idx_scans", 0)),
+            "rows": str(t.get("rows", 0)),
+        }
+        for t in seq_tables
+    ]
+
+    # Top queries
+    top_q = data.get("top_queries", [])
+    result.top_queries = [
+        {
+            "query": t.get("query"),
+            "calls": str(t.get("calls", 0)),
+            "total_min": str(t.get("total_min", 0)),
+            "mean_ms": str(t.get("mean_ms", 0)),
+            "min_ms": str(t.get("min_ms", 0)),
+            "max_ms": str(t.get("max_ms", 0)),
+            "stddev_ms": str(t.get("stddev_ms", 0)),
+            "rows": str(t.get("rows", 0)),
+            "rows_per_call": str(t.get("rows_per_call", 0)),
+            "total_plan_ms": str(t.get("total_plan_ms", 0)),
+            "mean_plan_ms": str(t.get("mean_plan_ms", 0)),
+            "shared_blks_hit": t.get("shared_blks_hit", 0),
+            "shared_blks_read": t.get("shared_blks_read", 0),
+            "shared_blks_dirtied": t.get("shared_blks_dirtied", 0),
+            "shared_blks_written": t.get("shared_blks_written", 0),
+            "cache_hit_pct": t.get("cache_hit_pct"),
+            "local_blks_hit": t.get("local_blks_hit", 0),
+            "local_blks_read": t.get("local_blks_read", 0),
+            "temp_blks_read": t.get("temp_blks_read", 0),
+            "temp_blks_written": t.get("temp_blks_written", 0),
+            "blk_read_time_ms": str(t.get("blk_read_time_ms", 0)),
+            "blk_write_time_ms": str(t.get("blk_write_time_ms", 0)),
+            "wal_records": t.get("wal_records", 0),
+            "wal_bytes": t.get("wal_bytes", 0),
+        }
+        for t in top_q
+    ]
+
+    # Long running queries
+    long_q = data.get("long_running_queries", [])
+    result.long_running_queries = [
+        {
+            "pid": str(t.get("pid")),
+            "duration_sec": str(t.get("duration_sec", 0)),
+            "query": t.get("query"),
+        }
+        for t in long_q
+    ]
+
+    # Idle in transaction
+    idle_txn = data.get("idle_in_transaction", [])
+    result.idle_in_transaction = [
+        {
+            "pid": str(t.get("pid")),
+            "idle_sec": str(t.get("idle_sec", 0)),
+            "user": t.get("username", ""),
+            "app": t.get("app", ""),
+            "last_query": t.get("last_query"),
+        }
+        for t in idle_txn
+    ]
+
+    # Blocked queries
+    blocked = data.get("blocked_queries", [])
+    result.blocked_queries = [
+        {
+            "pid": str(t.get("pid")),
+            "wait_sec": str(t.get("wait_sec", 0)),
+            "user": t.get("username", ""),
+            "blocking_pid": t.get("blocking_pid", ""),
+            "query": t.get("query"),
+        }
+        for t in blocked
+    ]
+
+    # Locks
+    locks = data.get("locks", [])
+    result.locks = [
+        {
+            "locktype": t.get("locktype"),
+            "mode": t.get("mode"),
+            "user": t.get("username", ""),
+            "app": t.get("app", ""),
+            "query": t.get("query"),
+        }
+        for t in locks
+    ]
+
+    # Replication
+    repl = data.get("replication", [])
+    result.replication = [
+        {
+            "client": t.get("client"),
+            "state": t.get("state"),
+            "sent_lsn": t.get("sent_lsn"),
+            "replay_lsn": t.get("replay_lsn"),
+        }
+        for t in repl
+    ]
+
+    # pg_stat_statements installed flag
+    result.pg_stat_statements_installed = data.get("pg_stat_statements_installed", False)
+
+    # Background writer stats
+    bgwriter = data.get("bgwriter")
+    if bgwriter:
+        result.bgwriter = {
+            "checkpoints_timed": bgwriter.get("checkpoints_timed", 0),
+            "checkpoints_req": bgwriter.get("checkpoints_req", 0),
+            "buffers_checkpoint": bgwriter.get("buffers_checkpoint", 0),
+            "buffers_clean": bgwriter.get("buffers_clean", 0),
+            "buffers_backend": bgwriter.get("buffers_backend", 0),
+            "buffers_backend_fsync": bgwriter.get("buffers_backend_fsync", 0),
+            "maxwritten_clean": bgwriter.get("maxwritten_clean", 0),
+            "stats_reset": bgwriter.get("stats_reset", "never"),
+        }
+
+    # Invalid indexes
+    invalid_idx = data.get("invalid_indexes", [])
+    result.invalid_indexes = [
+        {
+            "schema": t.get("schema"),
+            "table": t.get("table"),
+            "index": t.get("index"),
+        }
+        for t in invalid_idx
+    ]
+
+    # WAL archiver stats
+    archiver = data.get("archiver")
+    if archiver:
+        result.archiver = {
+            "archived_count": archiver.get("archived_count", 0),
+            "failed_count": archiver.get("failed_count", 0),
+            "last_archived_wal": archiver.get("last_archived_wal"),
+            "last_archived_time": archiver.get("last_archived_time", "never"),
+            "last_failed_wal": archiver.get("last_failed_wal"),
+            "last_failed_time": archiver.get("last_failed_time", "never"),
+            "stats_reset": archiver.get("stats_reset", "never"),
+        }
+
+    # Vacuum progress
+    progress_vac = data.get("progress_vacuum", [])
+    result.progress_vacuum = [
+        {
+            "pid": t.get("pid"),
+            "datname": t.get("datname"),
+            "relname": t.get("relname"),
+            "phase": t.get("phase"),
+            "heap_blks_total": t.get("heap_blks_total", 0),
+            "heap_blks_scanned": t.get("heap_blks_scanned", 0),
+            "heap_blks_vacuumed": t.get("heap_blks_vacuumed", 0),
+            "index_vacuum_count": t.get("index_vacuum_count", 0),
+            "max_dead_tuples": t.get("max_dead_tuples", 0),
+            "num_dead_tuples": t.get("num_dead_tuples", 0),
+        }
+        for t in progress_vac
+    ]
+
+    # SSL connection stats
+    ssl = data.get("ssl_stats")
+    if ssl:
+        result.ssl_stats = {
+            "ssl_connections": ssl.get("ssl_connections", 0),
+            "non_ssl_connections": ssl.get("non_ssl_connections", 0),
+            "ssl_versions": ssl.get("ssl_versions", []),
+        }
+
+
+def parse_psql_output(output: str, columns: List[str]) -> List[Dict[str, str]]:
+    """Parse psql -t -A output (pipe-separated) into list of dicts."""
+    rows = []
+    for line in output.strip().split("\n"):
+        if not line or line.startswith("("):
+            continue
+        values = line.split("|")
+        if len(values) == len(columns):
+            rows.append(dict(zip(columns, [v.strip() for v in values])))
+    return rows
+
+
+def get_disk_usage_from_api(environment_id: str, service_id: str) -> Optional[Dict[str, Any]]:
+    """Get disk usage from Railway metrics API."""
+    from datetime import timedelta
+
+    # Build the API query
+    start_date = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+    # Use railway-api.sh script
+    import os
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return None
+
+    query = '''query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $measurements: [MetricMeasurement!]!) {
+        metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, measurements: $measurements) {
+            measurement values { ts value }
+        }
+    }'''
+
+    variables = json.dumps({
+        "environmentId": environment_id,
+        "serviceId": service_id,
+        "startDate": start_date,
+        "measurements": ["DISK_USAGE_GB"]
+    })
+
+    try:
+        result = subprocess.run(
+            [api_script, query, variables],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        metrics = data.get("data", {}).get("metrics", [])
+
+        for metric in metrics:
+            if metric.get("measurement") == "DISK_USAGE_GB":
+                values = metric.get("values", [])
+                if values:
+                    # Get latest value
+                    latest = values[-1].get("value", 0)
+                    return {
+                        "used_gb": round(latest, 2),
+                        "used": f"{latest:.1f} GB",
+                    }
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def get_disk_usage(service: str, environment_id: Optional[str] = None, service_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Get disk usage - try API first, fall back to SSH."""
+    # Try Railway API first
+    if environment_id and service_id:
+        api_result = get_disk_usage_from_api(environment_id, service_id)
+        if api_result:
+            return api_result
+
+    # Fall back to SSH
+    command = "df -h /var/lib/postgresql/data 2>/dev/null || df -h / | tail -1"
+    code, stdout, stderr = run_ssh_query(service, command)
+    if code != 0 or not stdout:
+        return None
+
+    # Parse df output: Filesystem Size Used Avail Use% Mounted
+    lines = stdout.strip().split("\n")
+    for line in lines:
+        if line and not line.startswith("Filesystem"):
+            parts = line.split()
+            if len(parts) >= 5:
+                return {
+                    "total": parts[1],
+                    "used": parts[2],
+                    "available": parts[3],
+                    "use_percent": parts[4].rstrip("%"),
+                }
+    return None
+
+
+def get_cpu_memory_from_api(environment_id: str, service_id: str) -> Optional[Dict[str, Any]]:
+    """Get CPU and memory usage from Railway metrics API.
+
+    DEPRECATED: Use get_all_metrics_from_api() instead for combined disk/cpu/memory.
+    """
+    result = get_all_metrics_from_api(environment_id, service_id)
+    if result:
+        return result.get("cpu_memory")
+    return None
+
+
+def get_recent_errors(service: str, limit: int = 10) -> List[str]:
+    """Get recent error logs (legacy - kept for backwards compat)."""
+    code, stdout, stderr = run_railway_command(
+        ["logs", "--service", service, "--lines", "100", "--filter", "@level:error"],
+        timeout=30
+    )
+    if code != 0:
+        return []
+
+    errors = []
+    for line in stdout.strip().split("\n")[:limit]:
+        if line.strip():
+            errors.append(line.strip())
+    return errors
+
+
+def get_cluster_logs(
+    ha_cluster: Optional[Dict[str, Any]],
+    environment_id: Optional[str],
+    limit: int = 100
+) -> List[Dict[str, Any]]:
+    """Get logs from all HA cluster members via Railway API.
+
+    For HA clusters, each member may be a separate deployment.
+    This function fetches recent logs from each cluster member.
+    """
+    if not ha_cluster or not environment_id:
+        return []
+
+    members = ha_cluster.get("members", [])
+    if not members:
+        return []
+
+    import os
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return []
+
+    cluster_logs = []
+
+    # Query to get deployments for the environment
+    deployment_query = '''query deployments($environmentId: String!) {
+        deployments(input: { environmentId: $environmentId }) {
+            edges { node { id status staticUrl service { id name } } }
+        }
+    }'''
+
+    try:
+        result = subprocess.run(
+            [api_script, deployment_query, json.dumps({"environmentId": environment_id})],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return []
+
+        data = json.loads(result.stdout)
+        deployments = data.get("data", {}).get("deployments", {}).get("edges", [])
+
+        # Find deployments that match cluster member names
+        member_names = {m.get("name", "").lower() for m in members}
+
+        for edge in deployments:
+            deployment = edge.get("node", {})
+            deployment_id = deployment.get("id")
+            service_name = deployment.get("service", {}).get("name", "").lower()
+            status = deployment.get("status")
+
+            # Check if this deployment corresponds to a cluster member
+            is_member = any(
+                member_name in service_name or service_name in member_name
+                for member_name in member_names
+            )
+
+            if not is_member and status != "SUCCESS":
+                continue
+
+            if not deployment_id:
+                continue
+
+            # Fetch logs for this deployment
+            log_query = '''query deploymentLogs($deploymentId: String!, $limit: Int) {
+                deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
+                    timestamp message severity
+                }
+            }'''
+
+            log_result = subprocess.run(
+                [api_script, log_query, json.dumps({
+                    "deploymentId": deployment_id,
+                    "limit": limit
+                })],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if log_result.returncode == 0:
+                log_data = json.loads(log_result.stdout)
+                logs = log_data.get("data", {}).get("deploymentLogs", [])
+                if logs:
+                    cluster_logs.append({
+                        "member": service_name,
+                        "deployment_id": deployment_id,
+                        "status": status,
+                        "logs": logs[-limit:],  # Last N logs
+                    })
+
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return cluster_logs
+
+
+def is_postgres_ha_service(service_id: Optional[str]) -> bool:
+    """Check if service is from postgres-ha template.
+
+    Returns True if the service source repo contains 'postgres-ha',
+    indicating this is part of an HA cluster that uses Patroni.
+    """
+    if not service_id:
+        return False
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return False
+
+    query = '''query service($id: String!) {
+        service(id: $id) {
+            source { repo }
+        }
+    }'''
+
+    try:
+        result = subprocess.run(
+            [api_script, query, json.dumps({"id": service_id})],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode != 0:
+            return False
+
+        data = json.loads(result.stdout)
+        repo = data.get("data", {}).get("service", {}).get("source", {}).get("repo", "")
+        return "postgres-ha" in repo.lower() if repo else False
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return False
+
+
+def analyze_postgres(service: str, timeout: int = 300, quiet: bool = False,
+                     skip_logs: bool = False,
+                     metrics_hours: int = 168,
+                     project_id: Optional[str] = None,
+                     environment_id: Optional[str] = None,
+                     service_id: Optional[str] = None) -> AnalysisResult:
+    """Run complete Postgres analysis with maximum data collection.
+
+    Uses a single batched SQL query to collect all database metrics,
+    minimizing SSH connections (~3 total instead of ~22).
+
+    Args:
+        skip_logs: Skip log fetching for faster analysis (~60s saved)
+        metrics_hours: Hours of metrics history to fetch (default: 168, max: 168)
+        project_id: Project ID (bypasses railway link config)
+        environment_id: Environment ID (bypasses railway link config)
+        service_id: Service ID (bypasses railway link config)
+    """
+    if not quiet:
+        print(f"Analyzing postgres database: {service}", file=sys.stderr)
+
+    result = AnalysisResult(
+        service=service,
+        db_type="postgres",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === FAST CONTEXT LOADING ===
+    # Use explicit IDs if provided, otherwise read from config file (instant)
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        # IDs passed directly — no need to read config or link
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        # Fall back to reading railway context from local config (instant, no API call)
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # Check if this is an HA service - only call API if name suggests HA
+    is_ha_service = False
+    if any(hint in service.lower() for hint in ["postgres-ha", "patroni", "-ha"]):
+        is_ha_service = is_postgres_ha_service(service_id)
+
+    # Get deployment status via API (~1s) instead of CLI (~15s)
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK WITH RETRY ===
+    # SSH can be flaky — retry with increasing timeouts before giving up
+    progress(2, 4, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION OF SLOW OPERATIONS ===
+    # Run metrics API, database query, and logs in parallel (~17-27s down to ~max of the three)
+    progress(3, 4, "Running analysis (metrics, query, logs in parallel)...", quiet)
+
+    analysis_query = build_analysis_query()
+
+    # Define parallel tasks
+    def task_metrics():
+        """Fetch all metrics (disk, CPU, memory) in one API call."""
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_database_query():
+        """Run the batched database analysis query with retry."""
+        if not ssh_available:
+            return (1, "", f"SSH not available: {ssh_stderr or 'connection failed'}")
+        code, stdout, stderr = run_psql_query_safe(service, analysis_query, timeout=timeout)
+        if code != 0:
+            # Retry once — SSH sessions can drop mid-query
+            if not quiet:
+                print(f"        Database query failed ({stderr or 'unknown'}), retrying...", file=sys.stderr, flush=True)
+            code, stdout, stderr = run_psql_query_safe(service, analysis_query, timeout=timeout)
+        return (code, stdout, stderr)
+
+    def task_logs():
+        """Fetch recent logs via API (~3s)."""
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    def task_ha_cluster():
+        """Check HA cluster status (Patroni)."""
+        if not is_ha_service:
+            return "skipped_not_ha"
+        if not ssh_available:
+            return "skipped_no_ssh"
+        code, stdout, stderr = run_ssh_query(service, "curl -s localhost:8008/cluster 2>/dev/null || echo '{}'")
+        if code == 0 and stdout and stdout.strip() != "{}":
+            try:
+                patroni_data = json.loads(stdout)
+                members = patroni_data.get("members", [])
+                if members:
+                    return {
+                        "members": [
+                            {
+                                "name": m.get("name"),
+                                "role": m.get("role"),
+                                "state": m.get("state"),
+                                "timeline": m.get("timeline"),
+                                "lag": m.get("lag"),
+                            }
+                            for m in members
+                        ]
+                    }
+            except json.JSONDecodeError:
+                pass
+        return None
+
+    # Run all tasks in parallel
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        future_metrics = executor.submit(task_metrics)
+        future_db = executor.submit(task_database_query)
+        future_logs = executor.submit(task_logs)
+        future_ha = executor.submit(task_ha_cluster)
+
+        # Collect results
+        metrics_result = future_metrics.result()
+        db_result = future_db.result()
+        logs_result = future_logs.result()
+        ha_result = future_ha.result()
+
+    # Process metrics result (combined disk + cpu/memory + 24h history)
+    if metrics_result:
+        result.disk_usage = metrics_result.get("disk_usage")
+        result.cpu_memory = metrics_result.get("cpu_memory")
+        result.metrics_history = metrics_result.get("metrics_history")
+        result.collection_status["metrics_api"] = {"status": "success"}
+    else:
+        result.collection_status["metrics_api"] = {
+            "status": "error",
+            "error": "Metrics API returned no data"
+        }
+
+    # Process database query result
+    code, stdout, stderr = db_result
+    if code == 0 and stdout:
+        try:
+            data = json.loads(stdout.strip())
+            parse_batched_analysis(data, result)
+            result.collection_status["database_query"] = {"status": "success"}
+        except json.JSONDecodeError as e:
+            result.errors.append(f"Failed to parse batched analysis JSON: {e}")
+            result.collection_status["database_query"] = {
+                "status": "error",
+                "error": f"JSON parse error: {e}"
+            }
+    else:
+        error_msg = stderr or stdout or "Unknown error"
+        if not ssh_available:
+            error_msg = f"SSH failed after {len(ssh_attempts)} attempts: {ssh_stderr or 'connection failed'}"
+        result.errors.append(f"Batched analysis query failed: {error_msg}")
+        result.collection_status["database_query"] = {
+            "status": "error",
+            "error": error_msg
+        }
+
+    # Process HA cluster result
+    if ha_result == "skipped_not_ha":
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {"status": "skipped", "reason": "not an HA service"}
+    elif ha_result == "skipped_no_ssh":
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {"status": "skipped", "reason": "SSH not available"}
+    elif ha_result is not None:
+        result.ha_cluster = ha_result
+        result.collection_status["ha_cluster"] = {"status": "success"}
+    else:
+        result.ha_cluster = None
+        result.collection_status["ha_cluster"] = {
+            "status": "error" if is_ha_service else "skipped",
+            "error": "Failed to retrieve Patroni cluster data" if is_ha_service else "not an HA service"
+        }
+
+    # Process logs result
+    if skip_logs:
+        result.collection_status["logs_api"] = {"status": "skipped", "reason": "skip_logs flag set"}
+    elif logs_result:
+        result.recent_logs = logs_result
+        result.collection_status["logs_api"] = {
+            "status": "success",
+            "lines": len(logs_result)
+        }
+
+        # Extract error logs locally
+        result.recent_errors = [
+            line for line in result.recent_logs
+            if 'ERROR' in line.upper() or 'FATAL' in line.upper() or 'PANIC' in line.upper()
+        ][:100]
+
+        # HA cluster logs (API call) - done after parallel since it depends on ha_cluster
+        if result.ha_cluster and environment_id:
+            progress(4, 5, "Fetching HA cluster logs...", quiet)
+            result.cluster_logs = get_cluster_logs(result.ha_cluster, environment_id, limit=5000)
+    else:
+        result.recent_logs = []
+        result.collection_status["logs_api"] = {
+            "status": "error",
+            "error": "Logs API returned no data"
+        }
+
+    # Generate recommendations
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        total = dal._progress_timer.total_elapsed()
+        print(f"Done.{total}", file=sys.stderr)
+
+    return result
+
+
+def generate_recommendations(result: AnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on analysis results."""
+    recommendations = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items()
+                  if v.get("status") in ("failed", "error")}
+        ssh_sources = {"database_query", "ha_cluster"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recommendations.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: connection stats, query performance, "
+                           f"table bloat, and tuning parameters could not be evaluated.",
+            })
+
+    # === POSTGRESQL TUNING RECOMMENDATIONS ===
+    # Based on best practices from PostgreSQL wiki and community
+    if result.memory_config:
+        mem = result.memory_config
+
+        # Get system memory from CPU/memory metrics if available
+        system_memory_gb = None
+        if result.cpu_memory and "memory_limit_gb" in result.cpu_memory:
+            # Use actual memory limit from Railway API
+            system_memory_gb = result.cpu_memory["memory_limit_gb"]
+        elif result.cpu_memory and "memory_gb" in result.cpu_memory:
+            # Fallback: estimate total as ~2x current usage
+            system_memory_gb = result.cpu_memory["memory_gb"] * 2  # rough estimate
+
+        # shared_buffers check (should be ~25% of RAM, max ~40%)
+        shared_buffers = mem.get("shared_buffers", {})
+        if shared_buffers and shared_buffers.get("mb"):
+            sb_mb = shared_buffers["mb"]
+            # Flag if shared_buffers is very low (< 128MB) - likely default
+            if sb_mb < 128:
+                # Calculate recommended value based on system memory or default to 1GB
+                rec_sb = "1GB"
+                if system_memory_gb:
+                    rec_sb_mb = int(system_memory_gb * 1024 * 0.25)
+                    rec_sb = f"{rec_sb_mb}MB" if rec_sb_mb < 1024 else f"{round(rec_sb_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "immediate",
+                    "issue": f"shared_buffers is only {sb_mb}MB (likely default)",
+                    "action": f"Increase shared_buffers to {rec_sb} (25% of RAM)",
+                    "explanation": "shared_buffers is PostgreSQL's main data cache - pages read from disk are stored here. "
+                                   f"At {sb_mb}MB, your entire working set cannot fit in memory, forcing repeated disk reads. "
+                                   "The rule of thumb is 25% of total RAM, up to 40% for read-heavy workloads.",
+                    "commands": [
+                        f"ALTER SYSTEM SET shared_buffers = '{rec_sb}';",
+                        "-- Requires database restart to take effect"
+                    ],
+                    "restart_required": True,
+                })
+            elif sb_mb < 256:
+                rec_sb = "512MB"
+                if system_memory_gb:
+                    rec_sb_mb = int(system_memory_gb * 1024 * 0.25)
+                    rec_sb = f"{rec_sb_mb}MB" if rec_sb_mb < 1024 else f"{round(rec_sb_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"shared_buffers is {sb_mb}MB - may be undersized",
+                    "action": f"Consider increasing shared_buffers to {rec_sb} (25% of RAM)",
+                    "explanation": "shared_buffers holds cached data pages. A larger buffer pool means more data stays in memory, "
+                                   "reducing disk I/O. Current size may be limiting cache hit ratio.",
+                    "commands": [
+                        f"ALTER SYSTEM SET shared_buffers = '{rec_sb}';",
+                        "-- Requires database restart to take effect"
+                    ],
+                    "restart_required": True,
+                })
+
+        # effective_cache_size check (should be 50-75% of RAM)
+        effective_cache = mem.get("effective_cache_size", {})
+        if effective_cache and effective_cache.get("mb"):
+            ec_mb = effective_cache["mb"]
+            # Flag if effective_cache_size seems low
+            if ec_mb < 512:
+                rec_ec = "3GB"
+                if system_memory_gb:
+                    rec_ec_mb = int(system_memory_gb * 1024 * 0.75)
+                    rec_ec = f"{rec_ec_mb}MB" if rec_ec_mb < 1024 else f"{round(rec_ec_mb/1024, 1)}GB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"effective_cache_size is {ec_mb}MB - may cause poor query plans",
+                    "action": f"Set effective_cache_size to {rec_ec} (75% of RAM)",
+                    "explanation": "effective_cache_size is a hint to the query planner about how much memory is available for caching "
+                                   "(shared_buffers + OS cache). It does NOT allocate memory - it just helps PostgreSQL estimate "
+                                   "whether data is likely to be cached. A low value makes the planner pessimistic, avoiding efficient "
+                                   "index scans in favor of sequential scans.",
+                    "commands": [
+                        f"ALTER SYSTEM SET effective_cache_size = '{rec_ec}';",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # work_mem check (per-operation memory for sorts/hashes)
+        work_mem = mem.get("work_mem", {})
+        if work_mem and work_mem.get("mb"):
+            wm_mb = work_mem["mb"]
+            # Calculate recommended work_mem based on connections and RAM
+            max_conns = result.connections.get("max", 100) if result.connections else 100
+            rec_wm = "32MB"
+            if system_memory_gb:
+                # Formula: (RAM / max_connections) / 4
+                rec_wm_mb = int((system_memory_gb * 1024 / max_conns) / 4)
+                rec_wm_mb = max(16, min(rec_wm_mb, 128))  # Clamp between 16-128MB
+                rec_wm = f"{rec_wm_mb}MB"
+
+            # Flag if work_mem is at default (4MB) with high temp file usage
+            if result.database_stats:
+                temp_files = result.database_stats.get("temp_files", 0)
+                temp_bytes = result.database_stats.get("temp_bytes", 0)
+                temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 1) if temp_bytes > 0 else 0
+                if wm_mb <= 4 and temp_files > 1000:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"work_mem is only {wm_mb}MB with {temp_files:,} temp files ({temp_gb} GB) spilled to disk",
+                        "action": f"Increase work_mem to {rec_wm}",
+                        "explanation": f"work_mem controls how much memory each sort, hash, or join operation can use BEFORE "
+                                       f"spilling to disk (temp files). At {wm_mb}MB, your queries are constantly spilling. "
+                                       f"The {temp_files:,} temp files mean disk I/O instead of fast memory operations. "
+                                       f"CAUTION: A query can use multiple work_mem allocations (one per sort node), "
+                                       f"so don't set this too high. Formula: (RAM / max_connections) / 4.",
+                        "commands": [
+                            f"ALTER SYSTEM SET work_mem = '{rec_wm}';",
+                            "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                        ],
+                        "restart_required": False,
+                    })
+                elif wm_mb <= 4:
+                    recommendations.append({
+                        "priority": "long-term",
+                        "issue": f"work_mem is at default ({wm_mb}MB)",
+                        "action": f"Consider increasing work_mem to {rec_wm} for complex queries",
+                        "explanation": "work_mem is memory per sort/hash operation. The default 4MB is conservative. "
+                                       "Increasing it can speed up complex queries but uses more memory per operation.",
+                        "commands": [
+                            f"ALTER SYSTEM SET work_mem = '{rec_wm}';",
+                            "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                        ],
+                        "restart_required": False,
+                    })
+
+        # maintenance_work_mem check
+        maint_mem = mem.get("maintenance_work_mem", {})
+        if maint_mem and maint_mem.get("mb"):
+            mm_mb = maint_mem["mb"]
+            if mm_mb < 64:
+                rec_mm = "256MB"
+                if system_memory_gb and system_memory_gb >= 8:
+                    rec_mm = "512MB"
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"maintenance_work_mem is {mm_mb}MB - VACUUM and CREATE INDEX will be slow",
+                    "action": f"Increase maintenance_work_mem to {rec_mm}",
+                    "explanation": "maintenance_work_mem is used by VACUUM, CREATE INDEX, and ALTER TABLE operations. "
+                                   f"At {mm_mb}MB, these maintenance operations process data in small batches, making them slow. "
+                                   "Unlike work_mem, only one maintenance operation runs per session, so this can safely be higher.",
+                    "commands": [
+                        f"ALTER SYSTEM SET maintenance_work_mem = '{rec_mm}';",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # random_page_cost check (default 4.0, should be 1.1-2.0 for SSD)
+        rpc = mem.get("random_page_cost", {})
+        if rpc and rpc.get("value"):
+            rpc_val = float(rpc["value"])
+            if rpc_val >= 4.0:
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"random_page_cost is {rpc_val} (HDD default) - Railway uses SSDs",
+                    "action": "Set random_page_cost to 1.5 for SSD storage",
+                    "explanation": "random_page_cost tells the query planner how expensive random disk access is compared to "
+                                   "sequential access. The default 4.0 assumes slow HDDs where random reads are 4x more expensive. "
+                                   "Railway uses fast SSDs where random reads are almost as fast as sequential. At 4.0, "
+                                   "the planner avoids index scans (random access) in favor of slower sequential scans.",
+                    "commands": [
+                        "ALTER SYSTEM SET random_page_cost = 1.5;",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # checkpoint_completion_target check (should be 0.9)
+        cct = mem.get("checkpoint_completion_target", {})
+        if cct and cct.get("value"):
+            cct_val = float(cct["value"])
+            if cct_val < 0.9:
+                recommendations.append({
+                    "priority": "long-term",
+                    "issue": f"checkpoint_completion_target is {cct_val} - I/O may be spiky",
+                    "action": "Set checkpoint_completion_target to 0.9",
+                    "explanation": f"PostgreSQL periodically writes dirty buffers to disk (checkpoints). At {cct_val}, "
+                                   f"it tries to complete this in {int(cct_val*100)}% of the checkpoint interval, causing I/O spikes. "
+                                   "At 0.9, writes spread over 90% of the interval, smoothing disk I/O. "
+                                   "WHY: Spiky I/O can cause query latency spikes during checkpoints. "
+                                   "SIDE EFFECT: Slightly more consistent (but spread out) disk writes. No downside in practice.",
+                    "commands": [
+                        "ALTER SYSTEM SET checkpoint_completion_target = 0.9;",
+                        "SELECT pg_reload_conf();  -- Takes effect immediately"
+                    ],
+                    "restart_required": False,
+                })
+
+        # max_parallel_workers check
+        mpw = mem.get("max_parallel_workers", {})
+        mpwpg = mem.get("max_parallel_workers_per_gather", {})
+        if mpw and mpw.get("value") == 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": "max_parallel_workers is 0 - parallel queries disabled",
+                "action": "Set max_parallel_workers to number of CPU cores",
+                "explanation": "PostgreSQL can use multiple CPU cores for large sequential scans, aggregates, and joins. "
+                               "With max_parallel_workers=0, all queries run single-threaded regardless of table size. "
+                               "WHY: Large analytical queries (COUNT, SUM, scans of big tables) could run 2-8x faster with parallelism. "
+                               "SIDE EFFECT: Parallel queries use more CPU and memory simultaneously. For OLTP workloads with many "
+                               "small queries, this rarely triggers. For analytical queries, it's a significant speedup. "
+                               "IF NOT CHANGED: Large table scans will always be slow, even with idle CPU cores.",
+                "commands": [
+                    "ALTER SYSTEM SET max_parallel_workers = 4;  -- Adjust to your CPU count",
+                    "ALTER SYSTEM SET max_parallel_workers_per_gather = 2;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+        elif mpwpg and mpwpg.get("value") == 0:
+            recommendations.append({
+                "priority": "long-term",
+                "issue": "max_parallel_workers_per_gather is 0 - parallel queries won't use workers",
+                "action": "Set max_parallel_workers_per_gather to 2-4",
+                "explanation": "Even though max_parallel_workers allows parallel execution, max_parallel_workers_per_gather=0 "
+                               "means each query can use 0 parallel workers (i.e., none). "
+                               "WHY: This effectively disables parallelism for all queries. "
+                               "SIDE EFFECT: Each parallel query can use up to this many additional workers. "
+                               "Setting to 2 means a query could use 3 total processes (1 leader + 2 workers). "
+                               "IF NOT CHANGED: You have parallel infrastructure configured but no queries will use it.",
+                "commands": [
+                    "ALTER SYSTEM SET max_parallel_workers_per_gather = 2;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+
+        # autovacuum check
+        autovac = mem.get("autovacuum", {})
+        if autovac and autovac.get("value") == "off":
+            recommendations.append({
+                "priority": "immediate",
+                "issue": "autovacuum is DISABLED - database will bloat and eventually fail",
+                "action": "Enable autovacuum immediately",
+                "explanation": "Autovacuum is PostgreSQL's background process that reclaims space from deleted/updated rows "
+                               "and prevents transaction ID wraparound. With autovacuum OFF: "
+                               "1) Tables bloat indefinitely - deleted rows waste space and slow queries. "
+                               "2) Transaction IDs (XIDs) are never frozen - the database WILL shut down when XIDs wrap (~2 billion transactions). "
+                               "3) Table statistics become stale - query planner makes bad decisions. "
+                               "WHY IT WAS DISABLED: Sometimes disabled for bulk loads, but must be re-enabled after. "
+                               "IF NOT CHANGED: Database will eventually refuse all writes to prevent corruption. This is not recoverable without maintenance.",
+                "commands": [
+                    "ALTER SYSTEM SET autovacuum = on;",
+                    "SELECT pg_reload_conf();"
+                ],
+                "restart_required": False,
+            })
+
+        # synchronous_commit info (not a warning, just info)
+        sync = mem.get("synchronous_commit", {})
+        if sync and sync.get("value") == "off":
+            recommendations.append({
+                "priority": "long-term",
+                "issue": "synchronous_commit is off - faster writes but risk of data loss on crash",
+                "action": "Evaluate if this is acceptable for your data",
+                "explanation": "With synchronous_commit=off, PostgreSQL returns 'success' to clients BEFORE data is flushed to disk. "
+                               "BENEFIT: Write transactions are 2-10x faster because they don't wait for disk. "
+                               "RISK: If the server crashes, the last ~100-800ms of committed transactions may be lost. "
+                               "The database will NOT be corrupted - it will be consistent, just missing recent commits. "
+                               "ACCEPTABLE FOR: Session data, analytics, caches, logs - anything you can afford to lose. "
+                               "NOT ACCEPTABLE FOR: Financial transactions, user data, anything where 'committed' must mean 'durable'. "
+                               "IF NOT CHANGED: You keep the performance benefit but accept the crash-loss risk.",
+            })
+
+    # pg_stat_statements not available
+    if not result.top_queries:
+        recommendations.append({
+            "priority": "short-term",
+            "issue": "pg_stat_statements extension not available - cannot analyze query performance",
+            "action": "Enable pg_stat_statements extension",
+            "explanation": "pg_stat_statements tracks execution statistics for all SQL queries: call count, total time, "
+                           "rows returned, cache hits, temp file usage. Without it, you cannot identify slow queries or optimization targets. "
+                           "WHY: This analysis found memory/vacuum issues but cannot pinpoint which QUERIES cause problems. "
+                           "SIDE EFFECT: Minor overhead (~1-5%) for tracking. Stores stats in shared memory. "
+                           "IF NOT ENABLED: You're flying blind - you can see symptoms (high I/O, temp files) but not the queries causing them. "
+                           "To enable, run: python3 scripts/enable-pg-stats.py --service <name> (may require brief restart).",
+        })
+
+    # Cache hit ratio
+    if result.cache_hit:
+        table_hit = result.cache_hit.get("table_hit_pct")
+        if table_hit is not None and table_hit < 95:
+            priority = "immediate" if table_hit < 90 else "short-term"
+            # Find the worst offending tables for context
+            worst_tables = []
+            for t in result.cache_per_table[:3]:
+                if float(t.get("hit_pct") or 100) < 90:
+                    worst_tables.append(f"{t['table']} ({t['hit_pct']}%)")
+            context = f" Worst tables: {', '.join(worst_tables)}." if worst_tables else ""
+            recommendations.append({
+                "priority": priority,
+                "issue": f"Table cache hit ratio is {table_hit}% (should be >95%)",
+                "action": "Increase shared_buffers - data is being read from disk instead of memory cache",
+                "explanation": f"Cache hit ratio measures how often PostgreSQL finds requested data in memory (shared_buffers) "
+                               f"vs reading from disk. At {table_hit}%, roughly {100-table_hit}% of data requests hit disk.{context}",
+            })
+
+    # Per-table cache - check for low hit rates with high disk reads
+    for table in result.cache_per_table:
+        try:
+            hit_pct = float(table.get("hit_pct") or 100)
+            disk_reads = int(table.get("disk_reads") or 0)
+            table_size = table.get("size", "unknown")
+        except (ValueError, TypeError):
+            continue
+
+        if hit_pct < 50 and disk_reads > 1_000_000:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' has {hit_pct}% cache hit with {disk_reads:,} disk reads",
+                "action": "Increase shared_buffers to fit this table in memory",
+                "explanation": f"The '{table['table']}' table ({table_size}) is almost never found in cache. "
+                               f"With {disk_reads:,} disk reads, every query touching this table causes disk I/O. "
+                               f"This is likely because the table is larger than shared_buffers.",
+            })
+        elif hit_pct < 80 and disk_reads > 10_000_000:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Table '{table['table']}' has {hit_pct}% cache hit with {disk_reads:,} disk reads",
+                "action": "Consider increasing shared_buffers for better caching",
+                "explanation": f"The '{table['table']}' table has a low cache hit rate, causing frequent disk reads. "
+                               f"Increasing shared_buffers would allow more of this table to stay in memory.",
+            })
+
+    # Memory config
+    if result.memory_config and result.table_sizes:
+        shared_buffers_mb = result.memory_config.get("shared_buffers", {}).get("mb", 0)
+        total_table_bytes = sum(int(t.get("bytes", 0)) for t in result.table_sizes)
+        total_table_mb = total_table_bytes / 1024 / 1024
+
+        if shared_buffers_mb > 0 and total_table_mb > shared_buffers_mb * 4:
+            largest_table = result.table_sizes[0] if result.table_sizes else None
+            context = ""
+            if largest_table:
+                lt_mb = int(largest_table.get("bytes", 0)) / 1024 / 1024
+                context = f" Your largest table ({largest_table['table']}) is {round(lt_mb)}MB alone."
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"shared_buffers ({shared_buffers_mb}MB) is much smaller than working set (~{round(total_table_mb)}MB)",
+                "action": f"Increase shared_buffers to at least {round(total_table_mb / 4)}MB",
+                "explanation": f"Your database has ~{round(total_table_mb)}MB of table data but only {shared_buffers_mb}MB of buffer cache.{context} "
+                               f"PostgreSQL cannot keep frequently-accessed data in memory, causing constant disk I/O.",
+            })
+
+    # Vacuum health (using enhanced flags)
+    for table in result.vacuum_health:
+        dead_pct = float(table.get("dead_pct", 0))
+        dead_rows = int(table.get("dead_rows", 0))
+        needs_vacuum = table.get("needs_vacuum") == "true"
+        needs_freeze = table.get("needs_freeze") == "true"
+        last_vacuum = table.get("last_vacuum", "never")
+        last_analyze = table.get("last_analyze", "never")
+
+        # Check needs_freeze flag first (more urgent)
+        if needs_freeze:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' needs FREEZE (XID age > 150M)",
+                "action": f"Run: VACUUM FREEZE \"{table['table']}\";",
+                "explanation": "PostgreSQL uses transaction IDs (XIDs) that can wrap around after ~2 billion transactions. "
+                               "VACUUM FREEZE marks old rows as 'frozen' so they don't need XID checking. "
+                               "If XIDs wrap around without freezing, the database will shut down to prevent data corruption.",
+                "commands": [f"VACUUM FREEZE \"{table['table']}\";"],
+            })
+        elif needs_vacuum:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' needs VACUUM ({dead_pct}% dead rows, {dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"This table has {dead_rows:,} dead rows ({dead_pct}% of table) from UPDATE/DELETE operations. "
+                               "Dead rows waste disk space and slow down queries by making them scan more pages. "
+                               f"Last vacuum: {last_vacuum}. Last analyze: {last_analyze}. "
+                               "ANALYZE also updates statistics for better query plans.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+        elif dead_pct > 20:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Table '{table['table']}' has {dead_pct}% dead rows ({dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"Over 20% of this table is dead rows from UPDATEs and DELETEs. "
+                               f"This bloat forces queries to scan many useless rows. Last vacuum: {last_vacuum}.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+        elif dead_pct > 10:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Table '{table['table']}' has {dead_pct}% dead rows ({dead_rows:,} rows)",
+                "action": f"Run: VACUUM ANALYZE \"{table['table']}\";",
+                "explanation": f"This table has accumulated {dead_rows:,} dead rows. While autovacuum should handle this, "
+                               f"it may be falling behind. Last vacuum: {last_vacuum}.",
+                "commands": [f"VACUUM ANALYZE \"{table['table']}\";"],
+            })
+
+    # XID age
+    if result.xid_age:
+        xid_millions = result.xid_age.get("millions", 0)
+        if xid_millions > 150:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"XID age is {xid_millions}M (wraparound risk at 2147M)",
+                "action": "Run VACUUM FREEZE on all high-XID tables",
+                "explanation": "PostgreSQL's transaction ID counter wraps around at ~2.1 billion. At 150M+, you're using ~7% of "
+                               "the available space. If this reaches 2 billion without VACUUM FREEZE, PostgreSQL will "
+                               "shut down to prevent data corruption. This is a critical issue requiring immediate action.",
+                "commands": ["VACUUM FREEZE;  -- Run on affected tables"],
+            })
+        elif xid_millions > 100:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"XID age is {xid_millions}M (approaching wraparound risk)",
+                "action": "Monitor autovacuum and consider manual VACUUM FREEZE",
+                "explanation": "XID age is elevated. Autovacuum should handle this, but verify it's running. "
+                               "If tables are being vacuumed but XID age stays high, long-running transactions may be blocking freezing.",
+            })
+
+    # Database stats (deadlocks, temp files)
+    if result.database_stats:
+        deadlocks = result.database_stats.get("deadlocks", 0)
+        if deadlocks > 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"{deadlocks} deadlock(s) detected since last stats reset",
+                "action": "Review application transaction logic and lock ordering",
+                "explanation": f"A deadlock occurs when two transactions each hold a lock the other needs, creating a cycle. "
+                               f"PostgreSQL detects this and kills one transaction (the 'victim') so the other can proceed. "
+                               f"WHY THIS MATTERS: {deadlocks} deadlocks means {deadlocks} transactions were aborted and had to retry. "
+                               f"COMMON CAUSES: 1) Transactions locking rows in different orders. 2) Long transactions holding locks. "
+                               f"3) Hot rows updated by many concurrent transactions. "
+                               f"FIX: Ensure all code paths lock tables/rows in the same order. Keep transactions short. "
+                               f"IF NOT FIXED: Deadlocks will continue, causing random transaction failures and retries.",
+            })
+
+        # Temp files - flag with description based on daily rate
+        temp_files = result.database_stats.get("temp_files", 0)
+        temp_bytes = result.database_stats.get("temp_bytes", 0)
+        temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 1) if temp_bytes > 0 else 0
+        stats_reset = result.database_stats.get("stats_reset", "unknown")
+        # Calculate days since reset for rate-based thresholds
+        days_since_reset = None
+        if stats_reset and stats_reset not in ("unknown", "never"):
+            try:
+                reset_date = datetime.fromisoformat(stats_reset.replace('Z', '+00:00'))
+                days_since_reset = (datetime.now(timezone.utc) - reset_date).days
+                days_since_reset = max(days_since_reset, 1)  # Avoid division by zero
+            except (ValueError, TypeError):
+                pass
+        # Use rate-based threshold if we have time period data
+        if days_since_reset and days_since_reset > 0:
+            gb_per_day = temp_gb / days_since_reset
+            files_per_day = round(temp_files / days_since_reset)
+            if gb_per_day > 5:  # More than 5GB/day is concerning
+                # Get current work_mem for context
+                wm_mb = result.memory_config.get("work_mem", {}).get("mb", 4) if result.memory_config else 4
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"High temp file usage: ~{files_per_day:,} files/day ({round(gb_per_day, 1)} GB/day)",
+                    "action": "Increase work_mem from {wm_mb}MB to 32-64MB",
+                    "explanation": f"When a query needs to sort or hash more data than work_mem allows ({wm_mb}MB), "
+                                   f"PostgreSQL spills to temp files on disk. Your queries are creating ~{files_per_day:,} temp files daily, "
+                                   f"writing {round(gb_per_day, 1)}GB to disk. This is slower than in-memory operations.",
+                    "commands": [
+                        "ALTER SYSTEM SET work_mem = '32MB';",
+                        "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                    ],
+                    "restart_required": False,
+                })
+        elif temp_files > 10000 or temp_gb > 10:  # Fallback if no date
+            wm_mb = result.memory_config.get("work_mem", {}).get("mb", 4) if result.memory_config else 4
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"High temp file usage: {temp_files:,} files, {temp_gb} GB written since stats reset",
+                "action": f"Increase work_mem from {wm_mb}MB to 32-64MB",
+                "explanation": f"Queries are spilling to disk because work_mem ({wm_mb}MB) is too small for sort/hash operations. "
+                               f"Each temp file represents a query that couldn't fit its working data in memory.",
+                "commands": [
+                    "ALTER SYSTEM SET work_mem = '32MB';",
+                    "SELECT pg_reload_conf();  -- Takes effect for new connections"
+                ],
+                "restart_required": False,
+            })
+
+    # Connection usage
+    if result.connections:
+        pct = result.connections.get("percent", 0)
+        current = result.connections.get("current", 0)
+        max_conn = result.connections.get("max", 100)
+        available = result.connections.get("available", max_conn - current)
+        if pct > 90:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Connection usage is {pct}% ({current}/{max_conn}, only {available} available)",
+                "action": "Use connection pooling (PgBouncer) or increase max_connections",
+                "explanation": f"You're using {current} of {max_conn} connections. Each PostgreSQL connection uses memory "
+                               f"(~10MB each). Rather than increasing max_connections, use connection pooling (PgBouncer) "
+                               f"to multiplex many app connections over fewer database connections.",
+            })
+        elif pct > 70:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Connection usage is {pct}% ({current}/{max_conn})",
+                "action": "Consider connection pooling for scalability",
+                "explanation": "Connection usage is elevated. Connection pooling (PgBouncer) helps applications share "
+                               "database connections efficiently, especially during traffic spikes.",
+            })
+
+    # Old connections
+    if result.oldest_connection_sec is not None:
+        age_hours = result.oldest_connection_sec / 3600
+        age_days = round(age_hours / 24, 1)
+        if age_hours > 48:
+            # Include details about what the old connections are
+            conn_details = ""
+            if result.oldest_connections:
+                details_list = []
+                for c in result.oldest_connections[:3]:
+                    app = c.get("application_name") or "(unnamed)"
+                    state = c.get("state", "unknown")
+                    days = c.get("age_days", "?")
+                    details_list.append(f"{app} ({state}, {days} days)")
+                conn_details = f" Old connections: {'; '.join(details_list)}."
+
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Oldest connection is ~{age_days} days old ({round(age_hours)} hours)",
+                "action": "Review connection pooling settings and application connection management",
+                "explanation": f"Long-lived connections can indicate connection pool misconfiguration or connection leaks. "
+                               f"They can also hold locks or prevent autovacuum from cleaning up. "
+                               f"If using connection pooling, ensure idle connections are recycled.{conn_details}",
+            })
+
+    # Disk usage
+    if result.disk_usage:
+        use_pct = int(result.disk_usage.get("use_percent", 0))
+        used = result.disk_usage.get("used", "unknown")
+        total = result.disk_usage.get("total", "unknown")
+        if use_pct > 85:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Disk usage is {use_pct}% ({used} / {total})",
+                "action": "Increase volume size or clean up data",
+                "explanation": "PostgreSQL needs free disk space for WAL files, temp files, and VACUUM operations. "
+                               "Running out of disk space can cause database crashes. Consider: "
+                               "1) Increasing volume size, 2) Dropping unused indexes, 3) VACUUM FULL on bloated tables, "
+                               "4) Archiving old data.",
+            })
+        elif use_pct > 70:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Disk usage is {use_pct}% ({used} / {total})",
+                "action": "Plan for volume expansion",
+                "explanation": f"Disk is at {use_pct}%, approaching the danger zone. PostgreSQL needs free space for: "
+                               f"1) WAL files - write-ahead logs that ensure durability. "
+                               f"2) Temp files - sorts and hashes spill here when work_mem is exceeded. "
+                               f"3) VACUUM operations - need space to rewrite tables during VACUUM FULL. "
+                               f"IF NOT ADDRESSED: At 85%+ you risk write failures. At 100%, database crashes and may not restart. "
+                               f"ACTIONS: Increase volume size in Railway, or identify large unused tables/indexes to drop.",
+            })
+
+    # Unused indexes - only flag non-PK, non-unique indexes >100MB
+    droppable_indexes = [
+        idx for idx in result.unused_indexes
+        if not idx.get("is_primary") and not idx.get("is_unique")
+        and int(idx.get("size_bytes", 0)) > 100 * 1024 * 1024
+    ]
+    if droppable_indexes:
+        total_size = sum_index_sizes(droppable_indexes)
+        index_names = [idx['index'] for idx in droppable_indexes[:3]]
+        recommendations.append({
+            "priority": "long-term",
+            "issue": f"{len(droppable_indexes)} unused non-constraint indexes >100MB ({total_size})",
+            "action": "Review and drop unused indexes to save space and improve write performance",
+            "explanation": f"These indexes have 0 scans since stats reset, meaning no queries are using them. "
+                           f"Each index costs disk space AND slows down writes (INSERT/UPDATE/DELETE must update all indexes). "
+                           f"Examples: {', '.join(index_names)}{'...' if len(droppable_indexes) > 3 else ''}",
+            "commands": [f"DROP INDEX IF EXISTS \"{idx['index']}\";  -- saves {idx['size']}" for idx in droppable_indexes[:3]],
+        })
+
+    # Tables with high missing index score (lots of seq scans, no index usage)
+    for idx in result.unused_indexes:
+        try:
+            missing_score = int(idx.get("missing_index_score", 0))
+            if missing_score > 1000:
+                table_rows = idx.get("table_rows", "unknown")
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"Table '{idx['table']}' has {missing_score:,} sequential scans with no index usage",
+                    "action": f"Consider adding an index on commonly filtered columns of '{idx['table']}'",
+                    "explanation": f"Sequential scans read the entire table ({table_rows} rows) for each query. "
+                                   f"With {missing_score:,} sequential scans, queries are repeatedly scanning all rows. "
+                                   f"An index on commonly filtered columns (WHERE clauses) would dramatically speed this up.",
+                })
+        except (ValueError, TypeError):
+            pass
+
+    # Long-running queries
+    if result.long_running_queries:
+        for q in result.long_running_queries[:3]:
+            try:
+                duration = int(q.get("duration_sec", 0))
+                query_preview = q.get("query", "")[:80]
+                if duration > 60:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Query running for {duration}s (PID {q.get('pid')})",
+                        "action": "Investigate and potentially cancel",
+                        "explanation": f"This query has been running for {duration} seconds. "
+                                       f"QUERY: {query_preview}... "
+                                       f"WHY THIS MATTERS: Long queries hold locks, consume memory, and may indicate missing indexes or inefficient queries. "
+                                       f"TO CANCEL (graceful): SELECT pg_cancel_backend({q.get('pid')}); "
+                                       f"TO TERMINATE (force): SELECT pg_terminate_backend({q.get('pid')}); "
+                                       f"SIDE EFFECT OF CANCEL: The query's transaction will be rolled back. The application will receive an error.",
+                        "commands": [f"SELECT pg_cancel_backend({q.get('pid')});  -- Graceful cancel"],
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Idle in transaction (stuck transactions)
+    if result.idle_in_transaction:
+        for txn in result.idle_in_transaction[:3]:
+            try:
+                idle_sec = int(txn.get("idle_sec", 0))
+                app_name = txn.get("application_name", "unknown app")
+                if idle_sec > 300:  # 5 minutes
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Transaction idle for {idle_sec}s (PID {txn.get('pid')}, user: {txn.get('user', 'unknown')}, app: {app_name})",
+                        "action": "Terminate the stuck transaction",
+                        "explanation": f"This connection started a transaction (BEGIN) but hasn't done anything for {idle_sec}s. "
+                                       f"WHY THIS IS BAD: 1) Holds row-level locks that block other queries. "
+                                       f"2) Prevents VACUUM from cleaning dead rows in any table it touched. "
+                                       f"3) Holds a transaction ID slot, contributing to XID bloat. "
+                                       f"COMMON CAUSES: Application bug, network timeout without cleanup, abandoned connection. "
+                                       f"TO FIX: SELECT pg_terminate_backend({txn.get('pid')}); (terminates connection). "
+                                       f"PREVENTION: Set idle_in_transaction_session_timeout to auto-kill stuck transactions.",
+                        "commands": [
+                            f"SELECT pg_terminate_backend({txn.get('pid')});  -- Kill this connection",
+                            "ALTER SYSTEM SET idle_in_transaction_session_timeout = '5min';  -- Auto-kill in future",
+                        ],
+                    })
+                elif idle_sec > 60:
+                    recommendations.append({
+                        "priority": "short-term",
+                        "issue": f"Transaction idle for {idle_sec}s (PID {txn.get('pid')}, app: {app_name})",
+                        "action": "Review application transaction handling",
+                        "explanation": f"This transaction has been idle for {idle_sec}s. While not critical yet, "
+                                       f"transactions should be short-lived. Long idle transactions hold locks and block VACUUM. "
+                                       f"COMMON CAUSES: Missing COMMIT/ROLLBACK, waiting for user input inside transaction, connection pool issues. "
+                                       f"PREVENTION: Use idle_in_transaction_session_timeout to auto-terminate stuck transactions.",
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Blocked queries
+    if result.blocked_queries:
+        for q in result.blocked_queries[:3]:
+            try:
+                wait_sec = int(q.get("wait_sec", 0))
+                if wait_sec > 30:
+                    recommendations.append({
+                        "priority": "immediate",
+                        "issue": f"Query waiting {wait_sec}s for lock (PID {q.get('pid')} blocked by {q.get('blocking_pid')})",
+                        "action": "Investigate the blocking query and terminate if appropriate",
+                        "explanation": f"PID {q.get('pid')} has been waiting {wait_sec}s for a lock held by PID {q.get('blocking_pid')}. "
+                                       f"WHY: The blocking query/transaction is holding a lock (row, table, or advisory) that this query needs. "
+                                       f"COMMON CAUSES: Long-running transaction, idle-in-transaction, DDL operations (ALTER TABLE). "
+                                       f"TO INVESTIGATE: SELECT query FROM pg_stat_activity WHERE pid = {q.get('blocking_pid')}; "
+                                       f"TO UNBLOCK: Cancel or terminate the blocking PID if it's stuck. "
+                                       f"SIDE EFFECT: Terminating the blocker will rollback its transaction, but unblock waiting queries.",
+                        "commands": [
+                            f"-- See what {q.get('blocking_pid')} is doing:",
+                            f"SELECT pid, state, query FROM pg_stat_activity WHERE pid = {q.get('blocking_pid')};",
+                            f"-- To terminate (if stuck): SELECT pg_terminate_backend({q.get('blocking_pid')});",
+                        ],
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    # Lock contention
+    if result.locks:
+        lock_types = set(lock.get("locktype", "unknown") for lock in result.locks)
+        recommendations.append({
+            "priority": "immediate",
+            "issue": f"{len(result.locks)} blocked lock(s) detected ({', '.join(lock_types)})",
+            "action": "Investigate lock contention - may indicate long transactions or deadlocks",
+            "explanation": "Queries are waiting for locks held by other transactions. Common causes: "
+                           "1) Long-running transactions holding locks, 2) Deadlocks (PostgreSQL will resolve these automatically), "
+                           "3) DDL operations (ALTER TABLE) blocking normal queries. "
+                           "Check blocked_queries and idle_in_transaction sections for details.",
+        })
+
+    # Sequential scans on large tables
+    for table in result.seq_scan_tables:
+        try:
+            seq_scans = int(table.get("seq_scans", 0))
+            idx_scans = int(table.get("idx_scans", 0))
+            rows = int(table.get("rows", 0))
+            if seq_scans > 1000 and idx_scans == 0 and rows > 10000:
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"Table '{table['table']}' has {seq_scans:,} sequential scans with 0 index scans ({rows:,} rows)",
+                    "action": "Add indexes on columns used in WHERE, JOIN, and ORDER BY clauses",
+                    "explanation": f"Every query on '{table['table']}' scans all {rows:,} rows instead of using an index. "
+                                   f"With {seq_scans:,} sequential scans, this table is a performance hotspot. "
+                                   f"To find which columns to index, run: EXPLAIN ANALYZE on slow queries touching this table, "
+                                   f"or check pg_stat_statements for common query patterns.",
+                })
+        except (ValueError, TypeError):
+            pass
+
+    # HA cluster issues
+    if result.ha_cluster:
+        members = result.ha_cluster.get("members", [])
+        for m in members:
+            state = m.get("state", "")
+            if state == "start failed":
+                recommendations.append({
+                    "priority": "immediate",
+                    "issue": f"HA replica '{m.get('name')}' is in 'start failed' state",
+                    "action": "Resync the replica",
+                    "explanation": f"The replica '{m.get('name')}' failed to start, typically due to timeline divergence. "
+                                   f"This happens when the replica's WAL history diverges from the primary (e.g., after failover). "
+                                   f"WHY THIS MATTERS: This replica cannot be used for failover or read scaling until fixed. "
+                                   f"FIX: The replica needs a fresh base backup (pg_basebackup) from the primary. "
+                                   f"IF NOT FIXED: You're running without redundancy - if the primary fails, no automatic failover is possible.",
+                })
+            elif state not in ("running", "streaming"):
+                recommendations.append({
+                    "priority": "short-term",
+                    "issue": f"HA replica '{m.get('name')}' is in '{state}' state",
+                    "action": "Investigate replica health",
+                    "explanation": f"Expected state is 'running' or 'streaming', but replica is '{state}'. "
+                                   f"POSSIBLE STATES: 'creating' (initializing), 'stopped' (manually stopped), 'start failed' (broken). "
+                                   f"WHY THIS MATTERS: Non-streaming replicas may have stale data and can't be used for failover. "
+                                   f"CHECK: Replica logs for specific errors. Network connectivity to primary. WAL lag.",
+                })
+
+    # Recent errors
+    if result.recent_errors and len(result.recent_errors) > 5:
+        # Summarize error types (recent_errors is a list of strings)
+        error_samples = [e[:60] if isinstance(e, str) else str(e)[:60] for e in result.recent_errors[:3]]
+        recommendations.append({
+            "priority": "short-term",
+            "issue": f"{len(result.recent_errors)} recent errors in logs",
+            "action": "Review error logs for patterns",
+            "explanation": f"Multiple errors detected in recent logs. Sample messages: {'; '.join(error_samples)}... "
+                           f"WHY THIS MATTERS: Frequent errors may indicate application bugs, configuration issues, or resource constraints. "
+                           f"CHECK: Look for patterns - are errors from one app? One query? Specific time periods? "
+                           f"COMMON TYPES: Connection errors (app/network issue), query errors (syntax/permissions), "
+                           f"out-of-memory errors (need more RAM or lower work_mem).",
+        })
+
+    # Invalid indexes
+    if result.invalid_indexes:
+        for idx in result.invalid_indexes:
+            recommendations.append({
+                "priority": "immediate",
+                "issue": f"Invalid index '{idx.get('index')}' on {idx.get('schema')}.{idx.get('table')}",
+                "action": "Drop and recreate the index",
+                "explanation": f"This index is marked as invalid - PostgreSQL will NOT use it for queries. "
+                               f"CAUSE: Usually a CREATE INDEX CONCURRENTLY that failed partway through (e.g., due to constraint violation, "
+                               f"out of disk space, or duplicate key). "
+                               f"WHY THIS MATTERS: The index takes up disk space and slows writes, but provides zero query benefit. "
+                               f"FIX: Drop it and recreate. Use CONCURRENTLY to avoid locking the table.",
+                "commands": [
+                    f"DROP INDEX CONCURRENTLY IF EXISTS \"{idx.get('index')}\";",
+                    f"-- Then recreate with: CREATE INDEX CONCURRENTLY ...",
+                ],
+            })
+
+    # WAL archiver failures
+    if result.archiver and result.archiver.get("failed_count", 0) > 0:
+        last_failed_wal = result.archiver.get("last_failed_wal", "unknown")
+        last_failed_time = result.archiver.get("last_failed_time", "unknown")
+        recommendations.append({
+            "priority": "immediate",
+            "issue": f"WAL archiver has {result.archiver['failed_count']} failed archival(s)",
+            "action": "Check archive_command configuration and destination storage",
+            "explanation": f"WAL (Write-Ahead Log) archiving is failing. Last failed WAL: {last_failed_wal} at {last_failed_time}. "
+                           f"This affects point-in-time recovery capability. Common causes: "
+                           f"1) Archive destination full or unreachable, 2) Permissions issues, 3) archive_command misconfiguration.",
+        })
+
+    # Background writer issues
+    if result.bgwriter:
+        bg = result.bgwriter
+        # High backend fsync indicates shared_buffers pressure
+        if bg.get("buffers_backend_fsync", 0) > 0:
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"Backend processes forced {bg['buffers_backend_fsync']:,} fsync operations",
+                "action": "Increase shared_buffers to reduce dirty buffer pressure",
+                "explanation": "Normally, the background writer or checkpointer flushes dirty buffers to disk. "
+                               f"When shared_buffers is too small, backends must flush dirty buffers themselves "
+                               f"(buffers_backend_fsync > 0). This forces query processes to do I/O, causing latency spikes.",
+            })
+
+        # Check if most checkpoints are requested (not timed)
+        timed = bg.get("checkpoints_timed", 0)
+        req = bg.get("checkpoints_req", 0)
+        total = timed + req
+        if total > 10 and req > timed:
+            req_pct = round(100.0 * req / total, 1)
+            recommendations.append({
+                "priority": "short-term",
+                "issue": f"{req_pct}% of checkpoints are requested (not timed) - WAL is filling up",
+                "action": "Increase max_wal_size to 2-4GB",
+                "explanation": f"Checkpoints should happen on a timer (checkpoint_timeout), not because WAL fills up. "
+                               f"With {req_pct}% requested checkpoints, WAL segments are filling faster than expected. "
+                               f"This causes I/O spikes. Increasing max_wal_size gives more headroom before forced checkpoints.",
+                "commands": [
+                    "ALTER SYSTEM SET max_wal_size = '2GB';",
+                    "SELECT pg_reload_conf();  -- Takes effect immediately"
+                ],
+                "restart_required": False,
+            })
+
+        # High maxwritten_clean indicates bgwriter can't keep up
+        if bg.get("maxwritten_clean", 0) > 100:
+            recommendations.append({
+                "priority": "long-term",
+                "issue": f"Background writer hit max write limit {bg['maxwritten_clean']:,} times",
+                "action": "Increase bgwriter_lru_maxpages to let bgwriter flush more buffers per round",
+                "explanation": "The background writer proactively flushes dirty buffers before they're needed. "
+                               f"It hit the per-round limit {bg['maxwritten_clean']:,} times, meaning it couldn't "
+                               f"keep up with the write rate. Increasing bgwriter_lru_maxpages allows more buffer "
+                               f"flushes per round.",
+            })
+
+    return recommendations
+
+
+def sum_index_sizes(indexes: List[Dict[str, Any]]) -> str:
+    """Sum up index sizes and return human-readable string."""
+    total_bytes = 0
+    for idx in indexes:
+        size_str = idx.get("size", "0")
+        # Parse sizes like "23 MB", "8448 kB", etc.
+        match = re.match(r"(\d+)\s*(MB|kB|GB|bytes?)?", size_str, re.IGNORECASE)
+        if match:
+            value = int(match.group(1))
+            unit = (match.group(2) or "bytes").upper()
+            if unit in ("KB", "KB"):
+                total_bytes += value * 1024
+            elif unit == "MB":
+                total_bytes += value * 1024 * 1024
+            elif unit == "GB":
+                total_bytes += value * 1024 * 1024 * 1024
+            else:
+                total_bytes += value
+
+    if total_bytes >= 1024 * 1024 * 1024:
+        return f"{total_bytes / 1024 / 1024 / 1024:.1f} GB"
+    elif total_bytes >= 1024 * 1024:
+        return f"{total_bytes / 1024 / 1024:.1f} MB"
+    elif total_bytes >= 1024:
+        return f"{total_bytes / 1024:.1f} KB"
+    return f"{total_bytes} bytes"
+
+
+def format_report(result: AnalysisResult) -> str:
+    """Format analysis result as human-readable report."""
+    lines = []
+    lines.append("=" * 60)
+    lines.append(f"Database Analysis: {result.service}")
+    lines.append("=" * 60)
+    lines.append(f"Type: {result.db_type}")
+    lines.append(f"Generated: {result.timestamp}")
+    lines.append(f"Status: {result.deployment_status}")
+    lines.append("")
+
+    # Collection status table
+    if result.collection_status:
+        lines.append("## Data Collection Status")
+        lines.append("")
+        lines.append("| Source | Status | Details |")
+        lines.append("|--------|--------|---------|")
+        source_labels = {
+            "database_query": "Database Query (SSH)",
+            "metrics_api": "Metrics API",
+            "logs_api": "Logs API",
+            "ha_cluster": "HA Cluster (Patroni)",
+        }
+        for source in ["database_query", "metrics_api", "logs_api", "ha_cluster"]:
+            if source in result.collection_status:
+                info = result.collection_status[source]
+                status = info["status"].upper()
+                details = ""
+                if info.get("error"):
+                    details = info["error"]
+                elif info.get("reason"):
+                    details = info["reason"]
+                elif info.get("lines"):
+                    details = f"{info['lines']} lines collected"
+                elif status == "SUCCESS":
+                    details = "OK"
+                label = source_labels.get(source, source)
+                lines.append(f"| {label} | {status} | {details} |")
+        lines.append("")
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value | Status |")
+    lines.append("|--------|-------|--------|")
+
+    # Deployment
+    status_icon = "Healthy" if result.deployment_status == "SUCCESS" else "Warning"
+    lines.append(f"| Deployment | {result.deployment_status} | {status_icon} |")
+
+    # Connections
+    if result.connections:
+        pct = result.connections["percent"]
+        current = result.connections["current"]
+        max_conn = result.connections["max"]
+        reserved = result.connections.get("reserved", 3)
+        available = result.connections.get("available", max_conn - current)
+        active = result.connections.get("active", 0)
+        idle = result.connections.get("idle", 0)
+        idle_in_txn = result.connections.get("idle_in_transaction", 0)
+        status = "Critical" if pct > 90 else "Warning" if pct > 70 else "Healthy"
+        lines.append(f"| Connections | {current} / {max_conn} ({pct}%) | {status} |")
+        lines.append(f"| - Active/Idle/IdleTxn | {active} / {idle} / {idle_in_txn} | {'Warning' if idle_in_txn > 5 else '-'} |")
+        lines.append(f"| - Available | {available} (reserved: {reserved}) | - |")
+
+    # Database size
+    if result.size_breakdown and result.size_breakdown.get("database_bytes"):
+        db_bytes = result.size_breakdown["database_bytes"]
+        db_gb = round(db_bytes / 1024 / 1024 / 1024, 2)
+        lines.append(f"| Database Size | {db_gb} GB | - |")
+
+    # Disk
+    if result.disk_usage:
+        pct = int(result.disk_usage["use_percent"])
+        status = "Critical" if pct > 85 else "Warning" if pct > 70 else "Healthy"
+        lines.append(f"| Disk | {result.disk_usage['used']} / {result.disk_usage['total']} ({pct}%) | {status} |")
+
+    # Cache hit
+    if result.cache_hit:
+        table_hit = result.cache_hit.get("table_hit_pct")
+        if table_hit is not None:
+            status = "Healthy" if table_hit >= 99 else "OK" if table_hit >= 95 else "Warning" if table_hit >= 90 else "Critical"
+            lines.append(f"| Table Cache Hit | {table_hit}% | {status} |")
+
+        index_hit = result.cache_hit.get("index_hit_pct")
+        if index_hit is not None:
+            status = "Healthy" if index_hit >= 99 else "OK" if index_hit >= 95 else "Warning"
+            lines.append(f"| Index Cache Hit | {index_hit}% | {status} |")
+
+    # Memory config summary
+    if result.memory_config:
+        if "shared_buffers" in result.memory_config:
+            sb = result.memory_config["shared_buffers"]
+            mb = sb.get("mb", 0)
+            status = "Warning" if mb < 128 else "OK" if mb < 256 else "Healthy"
+            lines.append(f"| shared_buffers | {mb} MB | {status} |")
+        if "work_mem" in result.memory_config:
+            wm = result.memory_config["work_mem"]
+            mb = wm.get("mb", 0)
+            status = "Default" if mb <= 4 else "OK"
+            lines.append(f"| work_mem | {mb} MB | {status} |")
+
+    # XID age
+    if result.xid_age:
+        millions = result.xid_age["millions"]
+        status = "Critical" if millions > 150 else "Warning" if millions > 100 else "Healthy"
+        lines.append(f"| XID Age | {millions}M | {status} |")
+
+    # CPU/Memory (with trend indicators from 24h history)
+    if result.cpu_memory:
+        if "cpu_percent" in result.cpu_memory:
+            cpu = result.cpu_memory["cpu_percent"]
+            status = "Critical" if cpu > 85 else "Warning" if cpu > 70 else "Healthy"
+            trend_str = _trend_indicator(result.metrics_history, "cpu")
+            lines.append(f"| CPU Usage | {cpu} vCPU{trend_str} | {status} |")
+            if result.cpu_memory.get("cpu_limit"):
+                lines.append(f"| CPU Limit | {result.cpu_memory['cpu_limit']} vCPU | - |")
+        if "memory_gb" in result.cpu_memory:
+            mem = result.cpu_memory["memory_gb"]
+            trend_str = _trend_indicator(result.metrics_history, "memory")
+            utilization = ""
+            if result.cpu_memory.get("memory_limit_gb"):
+                pct = round((mem / result.cpu_memory["memory_limit_gb"]) * 100, 1)
+                status = "Critical" if pct > 90 else "Warning" if pct > 80 else "Healthy"
+                utilization = f" ({pct}% of {result.cpu_memory['memory_limit_gb']} GB)"
+            else:
+                status = "-"
+            lines.append(f"| Memory Usage | {mem} GB{utilization}{trend_str} | {status} |")
+
+    # Database stats
+    if result.database_stats:
+        stats_reset = result.database_stats.get("stats_reset", "unknown")
+        # Calculate days since stats reset for rate calculations
+        days_since_reset = None
+        if stats_reset and stats_reset not in ("unknown", "never"):
+            try:
+                reset_date = datetime.fromisoformat(stats_reset.replace('Z', '+00:00'))
+                days_since_reset = (datetime.now(timezone.utc) - reset_date).days
+                days_since_reset = max(days_since_reset, 1)  # Avoid division by zero
+            except (ValueError, TypeError):
+                pass
+        # Shorten timestamp to just date if it's a full timestamp
+        stats_reset_display = stats_reset
+        if stats_reset and stats_reset != "unknown" and stats_reset != "never" and len(stats_reset) > 10:
+            stats_reset_display = stats_reset[:10]
+        lines.append(f"| Stats Reset | {stats_reset_display} | - |")
+        deadlocks = result.database_stats.get("deadlocks", 0)
+        temp_files = result.database_stats.get("temp_files", 0)
+        temp_bytes = result.database_stats.get("temp_bytes", 0)
+        temp_gb = round(temp_bytes / 1024 / 1024 / 1024, 2) if temp_bytes > 0 else 0
+        status = "Warning" if deadlocks > 0 else "Healthy"
+        lines.append(f"| Deadlocks | {deadlocks} (since reset) | {status} |")
+        # Show temp files with daily rate if we have time period data
+        if days_since_reset:
+            files_per_day = round(temp_files / days_since_reset)
+            gb_per_day = round(temp_gb / days_since_reset, 2)
+            # Status based on daily rate, not totals
+            if gb_per_day > 5:
+                temp_status = "High"
+            elif gb_per_day > 1:
+                temp_status = "Moderate"
+            else:
+                temp_status = "OK"
+            lines.append(f"| Temp Files | {temp_files:,} ({temp_gb} GB) over {days_since_reset}d (~{files_per_day}/day, {gb_per_day} GB/day) | {temp_status} |")
+        else:
+            lines.append(f"| Temp Files | {temp_files:,} ({temp_gb} GB since reset) | - |")
+
+    # Size breakdown
+    if result.size_breakdown:
+        wal_bytes = result.size_breakdown.get("wal_bytes", 0)
+        wal_mb = round(wal_bytes / 1024 / 1024, 1)
+        lines.append(f"| WAL Size | {wal_mb} MB | - |")
+
+    # Oldest connection
+    if result.oldest_connection_sec is not None:
+        age_hrs = round(result.oldest_connection_sec / 3600, 1)
+        status = "Warning" if age_hrs > 24 else "Healthy"
+        lines.append(f"| Oldest Connection | {age_hrs} hrs | {status} |")
+
+    # pg_stat_statements extension
+    pss_status = "Installed" if result.pg_stat_statements_installed else "Not installed"
+    pss_icon = "OK" if result.pg_stat_statements_installed else "Info"
+    lines.append(f"| pg_stat_statements | {pss_status} | {pss_icon} |")
+
+    lines.append("")
+
+    # Infrastructure Trends (multi-window)
+    if result.metrics_history and result.metrics_history.get("windows"):
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Trends ({window_label})")
+            lines.append("")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend | Change |")
+            lines.append("|--------|---------|-----|-----|-----|-------|--------|")
+            display_order = [
+                ("cpu", "CPU"),
+                ("memory", "Memory"),
+                ("disk", "Disk"),
+                ("network_rx", "Network RX"),
+                ("network_tx", "Network TX"),
+            ]
+            for key, label in display_order:
+                if key in mh:
+                    m = mh[key]
+                    unit = m["unit"]
+                    trend = m.get("trend", {})
+                    direction = trend.get("direction", "?")
+                    change = trend.get("change_pct", 0)
+                    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "?")
+                    spike_note = ""
+                    if m.get("spikes"):
+                        spike_note = f" ({m['spikes']['count']} spikes)"
+                    lines.append(
+                        f"| {label} | {m['current']} {unit} | {m['min']} | {m['max']} | {m['avg']} | "
+                        f"{arrow} {direction} | {change:+.1f}%{spike_note} |"
+                    )
+            lines.append("")
+
+    # PostgreSQL Configuration (tuning parameters)
+    if result.memory_config:
+        lines.append("## PostgreSQL Configuration")
+        lines.append("")
+        lines.append("| Parameter | Value | Recommended | Status |")
+        lines.append("|-----------|-------|-------------|--------|")
+
+        mem = result.memory_config
+
+        # Memory settings
+        if "shared_buffers" in mem:
+            sb = mem["shared_buffers"]
+            mb = sb.get("mb", 0)
+            status = "Low" if mb < 128 else "Default" if mb < 256 else "OK"
+            lines.append(f"| shared_buffers | {mb} MB | 25% of RAM | {status} |")
+
+        if "effective_cache_size" in mem:
+            ec = mem["effective_cache_size"]
+            mb = ec.get("mb", 0)
+            status = "Low" if mb < 512 else "OK"
+            lines.append(f"| effective_cache_size | {mb} MB | 50-75% of RAM | {status} |")
+
+        if "work_mem" in mem:
+            wm = mem["work_mem"]
+            mb = wm.get("mb", 0)
+            status = "Default" if mb <= 4 else "OK"
+            lines.append(f"| work_mem | {mb} MB | 16-64 MB | {status} |")
+
+        if "maintenance_work_mem" in mem:
+            mm = mem["maintenance_work_mem"]
+            mb = mm.get("mb", 0)
+            status = "Low" if mb < 64 else "OK"
+            lines.append(f"| maintenance_work_mem | {mb} MB | 256-1024 MB | {status} |")
+
+        # WAL settings
+        if "wal_buffers" in mem:
+            wb = mem["wal_buffers"]
+            mb = wb.get("mb", 0)
+            lines.append(f"| wal_buffers | {mb} MB | 16 MB | OK |")
+
+        if "checkpoint_completion_target" in mem:
+            cct = mem["checkpoint_completion_target"]
+            val = cct.get("value", 0)
+            status = "Low" if float(val) < 0.9 else "OK"
+            lines.append(f"| checkpoint_completion_target | {val} | 0.9 | {status} |")
+
+        # Parallelism
+        if "max_parallel_workers" in mem:
+            mpw = mem["max_parallel_workers"]
+            val = mpw.get("value", 0)
+            status = "Disabled" if val == 0 else "OK"
+            lines.append(f"| max_parallel_workers | {val} | CPU cores | {status} |")
+
+        if "max_parallel_workers_per_gather" in mem:
+            mpwpg = mem["max_parallel_workers_per_gather"]
+            val = mpwpg.get("value", 0)
+            status = "Disabled" if val == 0 else "OK"
+            lines.append(f"| max_parallel_workers_per_gather | {val} | 2-4 | {status} |")
+
+        # Planner
+        if "random_page_cost" in mem:
+            rpc = mem["random_page_cost"]
+            val = rpc.get("value", 4.0)
+            status = "HDD default" if float(val) >= 4.0 else "SSD optimized" if float(val) <= 2.0 else "OK"
+            lines.append(f"| random_page_cost | {val} | 1.1-2.0 (SSD) | {status} |")
+
+        if "default_statistics_target" in mem:
+            dst = mem["default_statistics_target"]
+            val = dst.get("value", 100)
+            lines.append(f"| default_statistics_target | {val} | 100-500 | OK |")
+
+        # Autovacuum
+        if "autovacuum" in mem:
+            av = mem["autovacuum"]
+            val = av.get("value", "on")
+            status = "CRITICAL" if val == "off" else "OK"
+            lines.append(f"| autovacuum | {val} | on | {status} |")
+
+        # Durability
+        if "synchronous_commit" in mem:
+            sc = mem["synchronous_commit"]
+            val = sc.get("value", "on")
+            status = "Faster (risk)" if val == "off" else "Safe"
+            lines.append(f"| synchronous_commit | {val} | on (safe) | {status} |")
+
+        lines.append("")
+
+    # Connection states
+    if result.connection_states:
+        lines.append("## Connection States")
+        lines.append("")
+        lines.append("| State | Count |")
+        lines.append("|-------|-------|")
+        for s in result.connection_states:
+            lines.append(f"| {s.get('state', 'unknown')} | {s.get('count', 0)} |")
+        lines.append("")
+
+    # Connections by application
+    if result.connections_by_app:
+        lines.append("## Connections by Application")
+        lines.append("")
+        lines.append("| Application | Count |")
+        lines.append("|-------------|-------|")
+        for c in result.connections_by_app[:10]:
+            app = c.get('app', '') or '(empty)'
+            lines.append(f"| {app} | {c.get('count', 0)} |")
+        lines.append("")
+
+    # Connections by age
+    if result.connections_by_age:
+        lines.append("## Connections by Age")
+        lines.append("")
+        lines.append("| Age Range | Count |")
+        lines.append("|-----------|-------|")
+        for c in result.connections_by_age:
+            lines.append(f"| {c.get('range', '')} | {c.get('count', 0)} |")
+        lines.append("")
+
+    # Per-table cache
+    if result.cache_per_table:
+        lines.append("## Per-Table Cache Hit Rates")
+        lines.append("")
+        lines.append("| Table | Hit % | Disk Reads | Status |")
+        lines.append("|-------|-------|------------|--------|")
+        for t in result.cache_per_table[:10]:
+            hit_pct = float(t.get("hit_pct", 0))
+            status = "OK" if hit_pct >= 95 else "Warning" if hit_pct >= 80 else "Critical"
+            lines.append(f"| {t['table']} | {t['hit_pct']}% | {int(t['disk_reads']):,} | {status} |")
+        lines.append("")
+
+    # Table sizes
+    if result.table_sizes:
+        lines.append("## Table Sizes")
+        lines.append("")
+        lines.append("| Schema.Table | Total | Data | Indexes | Rows |")
+        lines.append("|--------------|-------|------|---------|------|")
+        for t in result.table_sizes[:10]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            data_bytes = int(t.get('data_bytes', 0))
+            index_bytes = int(t.get('index_bytes', 0))
+            data_mb = round(data_bytes / 1024 / 1024, 1)
+            index_mb = round(index_bytes / 1024 / 1024, 1)
+            row_count = t.get('row_count', '0')
+            lines.append(f"| {full_name} | {t['size']} | {data_mb}MB | {index_mb}MB | {row_count} |")
+        lines.append("")
+
+    # Vacuum health
+    if result.vacuum_health:
+        lines.append("## Vacuum Health")
+        lines.append("")
+        lines.append("| Schema.Table | Dead Rows | Dead % | V/AV Count | Last Analyze | XID Age | Flags |")
+        lines.append("|--------------|-----------|--------|------------|--------------|---------|-------|")
+        for t in result.vacuum_health[:10]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            vacuum_count = t.get('vacuum_count', '0')
+            autovacuum_count = t.get('autovacuum_count', '0')
+            last_analyze = t.get('last_analyze', 'never')
+            # Shorten timestamp to just date
+            if last_analyze and last_analyze != 'never' and len(last_analyze) > 10:
+                last_analyze = last_analyze[:10]
+            xid_age = t.get('xid_age', '0')
+            xid_millions = round(int(xid_age) / 1_000_000, 1) if xid_age.isdigit() else 0
+            flags = []
+            if t.get('needs_vacuum') == 'true':
+                flags.append('VACUUM')
+            if t.get('needs_freeze') == 'true':
+                flags.append('FREEZE')
+            flags_str = ', '.join(flags) if flags else '-'
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            lines.append(f"| {full_name} | {int(t['dead_rows']):,} | {t['dead_pct']}% | {vacuum_count}/{autovacuum_count} | {last_analyze} | {xid_millions}M | {flags_str} |")
+        lines.append("")
+
+    # Unused indexes
+    if result.unused_indexes:
+        lines.append("## Unused Indexes (0 scans since stats reset)")
+        lines.append("")
+        lines.append("| Schema.Table | Index | Size | Type | Table Idx Scans |")
+        lines.append("|--------------|-------|------|------|-----------------|")
+        for t in result.unused_indexes[:20]:
+            schema = t.get('schema', 'public')
+            table = t.get('table', '')
+            full_name = f"{schema}.{table}" if schema != 'public' else table
+            table_idx_scans = t.get('table_idx_scans', '0')
+            # Show index type
+            idx_type = "PK" if t.get('is_primary') else "UNIQUE" if t.get('is_unique') else "idx"
+            lines.append(f"| {full_name} | {t['index']} | {t['size']} | {idx_type} | {table_idx_scans} |")
+        lines.append("")
+
+    # Invalid indexes (failed concurrent index builds)
+    if result.invalid_indexes:
+        lines.append("## Invalid Indexes (require rebuild)")
+        lines.append("")
+        lines.append("| Schema | Table | Index |")
+        lines.append("|--------|-------|-------|")
+        for t in result.invalid_indexes:
+            lines.append(f"| {t.get('schema', '')} | {t.get('table', '')} | {t.get('index', '')} |")
+        lines.append("")
+
+    # Top queries
+    if result.top_queries:
+        lines.append("## Top Queries by Execution Time")
+        lines.append("")
+        lines.append("| Query | Calls | Total (min) | Mean (ms) | Min/Max (ms) | Stddev | Rows/Call | Cache Hit % | Temp R/W | Plan (ms) | I/O Time (ms) |")
+        lines.append("|-------|-------|-------------|-----------|--------------|--------|-----------|-------------|----------|-----------|---------------|")
+        for t in result.top_queries[:15]:
+            query = t.get('query', '')[:50]
+            cache_pct = t.get('cache_hit_pct')
+            cache_str = f"{cache_pct}%" if cache_pct is not None else "-"
+            temp_r = t.get('temp_blks_read', 0)
+            temp_w = t.get('temp_blks_written', 0)
+            temp_str = f"{temp_r:,}/{temp_w:,}" if (temp_r or temp_w) else "-"
+            min_max = f"{t.get('min_ms', '-')}/{t.get('max_ms', '-')}"
+            stddev = t.get('stddev_ms', '-')
+            rows_per_call = t.get('rows_per_call', '-')
+            plan_ms = t.get('mean_plan_ms', '-')
+            blk_read = float(t.get('blk_read_time_ms', 0) or 0)
+            blk_write = float(t.get('blk_write_time_ms', 0) or 0)
+            io_time = f"{blk_read + blk_write:.0f}" if (blk_read + blk_write) > 0 else "-"
+            lines.append(f"| {query}... | {t.get('calls', '')} | {t.get('total_min', '')} | {t.get('mean_ms', '')} | {min_max} | {stddev} | {rows_per_call} | {cache_str} | {temp_str} | {plan_ms} | {io_time} |")
+        lines.append("")
+
+    # Long-running queries
+    if result.long_running_queries:
+        lines.append("## Long-Running Queries (>5s)")
+        lines.append("")
+        lines.append("| PID | Duration (s) | Query |")
+        lines.append("|-----|--------------|-------|")
+        for q in result.long_running_queries:
+            lines.append(f"| {q.get('pid', '')} | {q.get('duration_sec', '')} | {q.get('query', '')[:40]}... |")
+        lines.append("")
+
+    # Idle in transaction (stuck transactions)
+    if result.idle_in_transaction:
+        lines.append("## Idle In Transaction (>30s)")
+        lines.append("")
+        lines.append("| PID | Idle (s) | User | App | Last Query |")
+        lines.append("|-----|----------|------|-----|------------|")
+        for txn in result.idle_in_transaction:
+            lines.append(f"| {txn.get('pid', '')} | {txn.get('idle_sec', '')} | {txn.get('user', '')} | {txn.get('app', '')[:15]} | {txn.get('last_query', '')[:30]}... |")
+        lines.append("")
+
+    # Blocked queries
+    if result.blocked_queries:
+        lines.append("## Blocked Queries (waiting on locks)")
+        lines.append("")
+        lines.append("| PID | Wait (s) | User | Blocked By | Query |")
+        lines.append("|-----|----------|------|------------|-------|")
+        for q in result.blocked_queries:
+            lines.append(f"| {q.get('pid', '')} | {q.get('wait_sec', '')} | {q.get('user', '')} | PID {q.get('blocking_pid', '')} | {q.get('query', '')[:30]}... |")
+        lines.append("")
+
+    # Lock contention
+    if result.locks:
+        lines.append("## Lock Contention")
+        lines.append("")
+        lines.append("| Lock Type | Mode | User | App | Query |")
+        lines.append("|-----------|------|------|-----|-------|")
+        for lock in result.locks:
+            lines.append(f"| {lock.get('locktype', '')} | {lock.get('mode', '')} | {lock.get('user', '')} | {lock.get('app', '')[:15]} | {lock.get('query', '')[:25]}... |")
+        lines.append("")
+
+    # Sequential scan patterns
+    if result.seq_scan_tables:
+        lines.append("## Tables with High Sequential Scans")
+        lines.append("")
+        lines.append("| Table | Seq Scans | Index Scans | Rows |")
+        lines.append("|-------|-----------|-------------|------|")
+        for t in result.seq_scan_tables[:10]:
+            lines.append(f"| {t.get('table', '')} | {t.get('seq_scans', '')} | {t.get('idx_scans', '')} | {t.get('rows', '')} |")
+        lines.append("")
+
+    # Replication
+    if result.replication:
+        lines.append("## Replication Status")
+        lines.append("")
+        lines.append("| Client | State | Sent LSN | Replay LSN |")
+        lines.append("|--------|-------|----------|------------|")
+        for r in result.replication:
+            lines.append(f"| {r.get('client', '')} | {r.get('state', '')} | {r.get('sent_lsn', '')} | {r.get('replay_lsn', '')} |")
+        lines.append("")
+
+    # HA Cluster
+    if result.ha_cluster:
+        lines.append("## HA Cluster (Patroni)")
+        lines.append("")
+        members = result.ha_cluster.get("members", [])
+        if members:
+            lines.append("| Name | Role | State | Timeline | Lag |")
+            lines.append("|------|------|-------|----------|-----|")
+            for m in members:
+                lag = m.get('lag', 0) or 0
+                lines.append(f"| {m.get('name', '')} | {m.get('role', '')} | {m.get('state', '')} | {m.get('timeline', '')} | {lag} |")
+        lines.append("")
+
+    # Cluster logs (for HA clusters) - raw output for LLM analysis
+    if result.cluster_logs:
+        lines.append("## Cluster Member Logs")
+        lines.append("")
+        lines.append("(Use --json for full log data. LLM will analyze patterns.)")
+        lines.append("")
+        for member_log in result.cluster_logs:
+            member = member_log.get('member', 'unknown')
+            status = member_log.get('status', 'unknown')
+            logs = member_log.get('logs', [])
+            lines.append(f"### {member} ({status}) - {len(logs)} log entries collected")
+            lines.append("")
+
+    # Background writer stats
+    if result.bgwriter:
+        lines.append("## Background Writer Stats")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        bg = result.bgwriter
+        total_checkpoints = bg.get('checkpoints_timed', 0) + bg.get('checkpoints_req', 0)
+        timed_pct = round(100.0 * bg.get('checkpoints_timed', 0) / total_checkpoints, 1) if total_checkpoints > 0 else 0
+        lines.append(f"| Checkpoints (timed/requested) | {bg.get('checkpoints_timed', 0):,} / {bg.get('checkpoints_req', 0):,} ({timed_pct}% timed) |")
+        lines.append(f"| Buffers: checkpoint | {bg.get('buffers_checkpoint', 0):,} |")
+        lines.append(f"| Buffers: bgwriter clean | {bg.get('buffers_clean', 0):,} |")
+        lines.append(f"| Buffers: backend direct | {bg.get('buffers_backend', 0):,} |")
+        lines.append(f"| Buffers: backend fsync | {bg.get('buffers_backend_fsync', 0):,} |")
+        lines.append(f"| Max written clean | {bg.get('maxwritten_clean', 0):,} |")
+        stats_reset = bg.get('stats_reset', 'never')
+        if stats_reset and stats_reset != 'never' and len(stats_reset) > 10:
+            stats_reset = stats_reset[:10]
+        lines.append(f"| Stats reset | {stats_reset} |")
+        lines.append("")
+
+    # WAL archiver stats
+    if result.archiver:
+        arch = result.archiver
+        lines.append("## WAL Archiver Status")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Archived WAL count | {arch.get('archived_count', 0):,} |")
+        lines.append(f"| Failed archival count | {arch.get('failed_count', 0):,} |")
+        last_wal = arch.get('last_archived_wal') or 'none'
+        last_time = arch.get('last_archived_time', 'never')
+        if last_time and last_time != 'never' and len(last_time) > 19:
+            last_time = last_time[:19]
+        lines.append(f"| Last archived WAL | {last_wal} |")
+        lines.append(f"| Last archived time | {last_time} |")
+        if arch.get('failed_count', 0) > 0:
+            failed_wal = arch.get('last_failed_wal') or 'none'
+            failed_time = arch.get('last_failed_time', 'never')
+            if failed_time and failed_time != 'never' and len(failed_time) > 19:
+                failed_time = failed_time[:19]
+            lines.append(f"| Last failed WAL | {failed_wal} |")
+            lines.append(f"| Last failed time | {failed_time} |")
+        lines.append("")
+
+    # Vacuum progress (ongoing vacuums)
+    if result.progress_vacuum:
+        lines.append("## Ongoing Vacuum Operations")
+        lines.append("")
+        lines.append("| PID | Table | Phase | Progress |")
+        lines.append("|-----|-------|-------|----------|")
+        for vac in result.progress_vacuum:
+            total = vac.get('heap_blks_total', 0)
+            scanned = vac.get('heap_blks_scanned', 0)
+            pct = round(100.0 * scanned / total, 1) if total > 0 else 0
+            lines.append(f"| {vac.get('pid', '')} | {vac.get('relname', '')} | {vac.get('phase', '')} | {pct}% ({scanned:,}/{total:,} blks) |")
+        lines.append("")
+
+    # SSL connection stats
+    if result.ssl_stats:
+        ssl = result.ssl_stats
+        lines.append("## SSL Connection Stats")
+        lines.append("")
+        total = ssl.get('ssl_connections', 0) + ssl.get('non_ssl_connections', 0)
+        ssl_pct = round(100.0 * ssl.get('ssl_connections', 0) / total, 1) if total > 0 else 0
+        lines.append(f"- SSL connections: {ssl.get('ssl_connections', 0)} ({ssl_pct}%)")
+        lines.append(f"- Non-SSL connections: {ssl.get('non_ssl_connections', 0)}")
+        versions = ssl.get('ssl_versions', [])
+        if versions:
+            lines.append("- SSL versions in use:")
+            for v in versions:
+                lines.append(f"  - {v.get('version', 'unknown')}: {v.get('count', 0)} connections")
+        lines.append("")
+
+    # Recent errors
+    if result.recent_errors:
+        lines.append("## Recent Errors")
+        lines.append("")
+        for error in result.recent_errors[:5]:
+            lines.append(f"- {error[:100]}...")
+        lines.append("")
+
+    # Recommendations
+    if result.recommendations:
+        lines.append("## Recommendations")
+        lines.append("")
+        for i, rec in enumerate(result.recommendations, 1):
+            priority = rec["priority"].upper()
+            lines.append(f"{i}. **[{priority}]** {rec['issue']}")
+            lines.append(f"   **Action:** {rec['action']}")
+
+            # Show explanation if available
+            if rec.get("explanation"):
+                lines.append(f"   **Why:** {rec['explanation']}")
+
+            # Show commands if available
+            if rec.get("commands"):
+                lines.append("   **Commands:**")
+                for cmd in rec["commands"]:
+                    lines.append(f"   ```sql")
+                    lines.append(f"   {cmd}")
+                    lines.append(f"   ```")
+
+            # Note if restart is required
+            if rec.get("restart_required"):
+                lines.append("   ⚠️ *Requires database restart*")
+
+            lines.append("")
+
+    # Errors
+    if result.errors:
+        lines.append("## Errors")
+        lines.append("")
+        for error in result.errors:
+            lines.append(f"- {error}")
+        lines.append("")
+
+    lines.append("=" * 60)
+    lines.append("END OF REPORT")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Complete database analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                       help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                       help="Timeout in seconds for analysis query (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                       help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                       help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                       help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_postgres(args.service, timeout=args.timeout, quiet=args.quiet,
+                              skip_logs=args.skip_logs,
+                              metrics_hours=min(args.metrics_hours, 168),
+                              project_id=args.project_id,
+                              environment_id=args.environment_id,
+                              service_id=args.service_id)
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running analysis query on: {service}", file=sys.stderr)
+        query = build_analysis_query()
+        code, stdout, stderr = run_psql_query_safe(service, query, timeout=args.timeout)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            try:
+                data = json.loads(stdout.strip())
+                print(json.dumps(data, indent=2))
+            except json.JSONDecodeError:
+                print(f"Raw output:\n{stdout}")
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("Metrics API returned no data")
+                return 1
+        else:
+            print("Missing environment_id or service_id from railway config")
+            return 1
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/analyze-redis.py
+++ b/.claude/skills/use-railway/scripts/analyze-redis.py
@@ -1,0 +1,1090 @@
+#!/usr/bin/env python3
+"""
+Redis analysis for Railway deployments.
+
+Produces a comprehensive report covering:
+- Server overview (version, uptime, clients)
+- Memory usage and fragmentation
+- Throughput and command stats
+- Cache performance (hit/miss ratio)
+- Persistence status
+- Keyspace summary
+- Railway infrastructure metrics (CPU, memory, disk, network)
+- Recent logs
+- Recommendations
+
+Usage:
+    analyze-redis.py --service <name>
+    analyze-redis.py --service <name> --json
+    analyze-redis.py --service <name> --step ssh-test
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field, asdict
+
+import dal
+from dal import (
+    LOG_LINES_DEFAULT, ProgressTimer, RailwayContext,
+    _init_context, progress, run_railway_command, run_ssh_query,
+    get_railway_status, get_deployment_status,
+    get_all_metrics_from_api, _analyze_window, _build_metrics_history,
+    get_recent_logs,
+    _safe_int, _safe_float, _format_uptime,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RedisAnalysisResult:
+    """Container for Redis analysis results."""
+    service: str
+    db_type: str
+    timestamp: str
+    deployment_status: str = "UNKNOWN"
+
+    # Redis INFO sections
+    overview: Optional[Dict[str, Any]] = None
+    memory: Optional[Dict[str, Any]] = None
+    throughput: Optional[Dict[str, Any]] = None
+    cache: Optional[Dict[str, Any]] = None
+    persistence: Optional[Dict[str, Any]] = None
+    keyspace: List[Dict[str, Any]] = field(default_factory=list)
+    total_keys: int = 0
+    command_stats: List[Dict[str, Any]] = field(default_factory=list)
+    slowlog_len: Optional[int] = None
+    slowlog_entries: List[Dict[str, Any]] = field(default_factory=list)
+    big_keys: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Railway infrastructure
+    metrics_history: Optional[Dict[str, Any]] = None
+    recent_logs: List[str] = field(default_factory=list)
+
+    # Status tracking
+    collection_status: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    recommendations: List[Dict[str, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Redis data collection
+# ---------------------------------------------------------------------------
+
+def parse_redis_info(raw: str) -> Dict[str, str]:
+    """Parse Redis INFO output into a flat key:value dict.
+
+    Lines starting with # are section headers and are skipped.
+    """
+    info: Dict[str, str] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" in line:
+            key, _, value = line.partition(":")
+            info[key.strip()] = value.strip()
+    return info
+
+
+def extract_overview(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract overview metrics from INFO dict."""
+    return {
+        "redis_version": info.get("redis_version", "unknown"),
+        "uptime_in_seconds": _safe_int(info.get("uptime_in_seconds")),
+        "connected_clients": _safe_int(info.get("connected_clients")),
+        "blocked_clients": _safe_int(info.get("blocked_clients")),
+        "rejected_connections": _safe_int(info.get("rejected_connections")),
+    }
+
+
+def extract_memory(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract memory metrics from INFO dict."""
+    return {
+        "used_memory_human": info.get("used_memory_human", "N/A"),
+        "used_memory_rss_human": info.get("used_memory_rss_human", "N/A"),
+        "used_memory_peak_human": info.get("used_memory_peak_human", "N/A"),
+        "mem_fragmentation_ratio": _safe_float(info.get("mem_fragmentation_ratio")),
+        "maxmemory": _safe_int(info.get("maxmemory")),
+        "maxmemory_human": info.get("maxmemory_human", "N/A"),
+        "maxmemory_policy": info.get("maxmemory_policy", "unknown"),
+    }
+
+
+def extract_throughput(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract throughput metrics from INFO dict."""
+    return {
+        "instantaneous_ops_per_sec": _safe_int(info.get("instantaneous_ops_per_sec")),
+        "total_commands_processed": _safe_int(info.get("total_commands_processed")),
+        "total_connections_received": _safe_int(info.get("total_connections_received")),
+    }
+
+
+def extract_cache(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract cache performance metrics from INFO dict."""
+    hits = _safe_int(info.get("keyspace_hits"))
+    misses = _safe_int(info.get("keyspace_misses"))
+    total = hits + misses
+    hit_rate = round(hits / total * 100, 2) if total > 0 else 0.0
+    return {
+        "keyspace_hits": hits,
+        "keyspace_misses": misses,
+        "hit_rate": hit_rate,
+        "expired_keys": _safe_int(info.get("expired_keys")),
+        "evicted_keys": _safe_int(info.get("evicted_keys")),
+    }
+
+
+def extract_persistence(info: Dict[str, str]) -> Dict[str, Any]:
+    """Extract persistence metrics from INFO dict."""
+    return {
+        "rdb_last_save_time": _safe_int(info.get("rdb_last_save_time")),
+        "rdb_last_bgsave_status": info.get("rdb_last_bgsave_status", "unknown"),
+        "rdb_current_bgsave_time_sec": _safe_int(info.get("rdb_current_bgsave_time_sec")),
+        "aof_enabled": info.get("aof_enabled", "0") == "1",
+        "aof_last_rewrite_status": info.get("aof_last_rewrite_status", "unknown"),
+    }
+
+
+def extract_keyspace(info: Dict[str, str]) -> Tuple[List[Dict[str, Any]], int]:
+    """Extract keyspace metrics from INFO dict.
+
+    Keyspace entries look like: db0:keys=1234,expires=567,avg_ttl=12345
+    Returns (list of db dicts, total_keys).
+    """
+    databases: List[Dict[str, Any]] = []
+    total_keys = 0
+    for key, value in info.items():
+        if not re.match(r'^db\d+$', key):
+            continue
+        # Parse keys=X,expires=Y,avg_ttl=Z
+        parts = {}
+        for item in value.split(","):
+            k, _, v = item.partition("=")
+            parts[k] = v
+        keys = _safe_int(parts.get("keys"))
+        total_keys += keys
+        databases.append({
+            "db": key,
+            "keys": keys,
+            "expires": _safe_int(parts.get("expires")),
+            "avg_ttl": _safe_int(parts.get("avg_ttl")),
+        })
+    return databases, total_keys
+
+
+def extract_command_stats(info: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Extract command statistics from INFO dict.
+
+    Command stat entries look like: cmdstat_GET:calls=123,usec=456,usec_per_call=3.71
+    Returns list sorted by calls descending.
+    """
+    stats: List[Dict[str, Any]] = []
+    for key, value in info.items():
+        if not key.startswith("cmdstat_"):
+            continue
+        cmd_name = key[len("cmdstat_"):]
+        parts = {}
+        for item in value.split(","):
+            k, _, v = item.partition("=")
+            parts[k] = v
+        stats.append({
+            "command": cmd_name,
+            "calls": _safe_int(parts.get("calls")),
+            "usec": _safe_int(parts.get("usec")),
+            "usec_per_call": _safe_float(parts.get("usec_per_call")),
+        })
+    stats.sort(key=lambda x: x["calls"], reverse=True)
+    return stats
+
+
+_CLIENT_IP_RE = re.compile(r'^(\[.+\]|(?:\d{1,3}\.){3}\d{1,3}):\d+$')
+
+
+def parse_slowlog_get(raw: str) -> List[Dict[str, Any]]:
+    """Parse SLOWLOG GET output into structured entries.
+
+    redis-cli --raw SLOWLOG GET format (Redis 4.0+):
+      <id>
+      <timestamp_unix>
+      <duration_us>
+      <cmd>
+      <arg1>
+      ...
+      <argN>
+      <client_ip:port>
+      [<client_name>]   (optional, may be absent)
+
+    There is no num_args field in the raw output. The client IP line
+    (IPv4 or IPv6 with port) marks the end of each entry's arguments.
+    """
+    entries: List[Dict[str, Any]] = []
+    lines = [l.strip() for l in raw.strip().splitlines() if l.strip()]
+    if not lines:
+        return entries
+
+    i = 0
+    while i < len(lines):
+        try:
+            entry_id = int(lines[i])
+        except (ValueError, IndexError):
+            i += 1
+            continue
+
+        if i + 3 >= len(lines):
+            break
+
+        try:
+            timestamp = int(lines[i + 1])
+            duration_us = int(lines[i + 2])
+        except (ValueError, IndexError):
+            i += 1
+            continue
+
+        # lines[i+3] is the command name; scan forward for client IP
+        cmd_start = i + 3
+        client_ip_pos = None
+        for k in range(cmd_start, min(cmd_start + 30, len(lines))):
+            if _CLIENT_IP_RE.match(lines[k]):
+                client_ip_pos = k
+                break
+
+        if client_ip_pos is not None:
+            cmd_parts = lines[cmd_start:client_ip_pos]
+            # Advance past client IP and optional client name
+            next_i = client_ip_pos + 1
+            if next_i < len(lines):
+                try:
+                    int(lines[next_i])
+                except ValueError:
+                    next_i += 1  # skip client name
+        else:
+            # No client IP found — take command + first arg only and advance
+            cmd_parts = lines[cmd_start:cmd_start + 2]
+            next_i = cmd_start + 2
+
+        command = " ".join(cmd_parts) if cmd_parts else "unknown"
+        if len(command) > 120:
+            command = command[:117] + "..."
+
+        entries.append({
+            "id": entry_id,
+            "timestamp_unix": timestamp,
+            "duration_us": duration_us,
+            "command": command,
+        })
+
+        i = next_i
+
+    return entries
+
+
+def parse_bigkeys(raw: str) -> List[Dict[str, Any]]:
+    """Parse redis-cli --bigkeys output into structured entries.
+
+    Looks for lines like:
+      Biggest string found "cache:render:page/dashboard" has 2145832 bytes
+      Biggest hash found "user:sessions" has 14291 fields
+      Biggest list found "queue:notifications" has 8402 items
+      Biggest set found "tags:all" has 291 members
+      Biggest zset found "leaderboard:global" has 10042 members
+      Biggest stream found "events:main" has 5012 entries
+    """
+    entries: List[Dict[str, Any]] = []
+    # Match: Biggest <type> found "<key>" has <count> <unit>
+    # Redis 8+ uses double quotes; older versions used single quotes
+    pattern = re.compile(
+        r'Biggest\s+(\w+)\s+found\s+["\']([^"\']+)["\']\s+has\s+([\d,]+)\s+(\w+)',
+        re.IGNORECASE,
+    )
+    for line in raw.splitlines():
+        m = pattern.search(line)
+        if m:
+            key_type = m.group(1).lower()
+            key_name = m.group(2)
+            size_str = m.group(3).replace(",", "")
+            unit = m.group(4).lower()
+            size = _safe_int(size_str)
+
+            # Format size for display
+            if unit == "bytes":
+                detail = _format_bytes_human(size)
+            else:
+                detail = f"{size:,} {unit}"
+
+            entries.append({
+                "type": key_type,
+                "key": key_name,
+                "size_or_count": size,
+                "detail": detail,
+            })
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _format_number(n: int) -> str:
+    """Format a large number with K/M/B suffixes."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}K"
+    return f"{n:,}"
+
+
+def _format_duration(seconds: int) -> str:
+    """Format a duration in seconds to a human-readable relative string."""
+    if seconds <= 0:
+        return "N/A"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86400:
+        return f"{seconds // 3600}h ago"
+    return f"{seconds // 86400}d ago"
+
+
+def _format_ttl(ms: int) -> str:
+    """Format average TTL in milliseconds to a human-readable string."""
+    if ms <= 0:
+        return "none"
+    seconds = ms // 1000
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _format_usec(usec: float) -> str:
+    """Format microseconds to a human-readable string."""
+    if usec < 1000:
+        return f"{usec:.1f}us"
+    if usec < 1_000_000:
+        return f"{usec / 1000:.1f}ms"
+    return f"{usec / 1_000_000:.2f}s"
+
+
+def _format_total_time(usec: int) -> str:
+    """Format total microseconds to a readable time string."""
+    seconds = usec / 1_000_000
+    if seconds < 1:
+        return f"{usec / 1000:.1f}ms"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds / 3600:.1f}h"
+
+
+def _format_bytes_human(nbytes: int) -> str:
+    """Format bytes into human-readable string."""
+    if nbytes <= 0:
+        return "0"
+    for unit in ["B", "K", "M", "G", "T"]:
+        if nbytes < 1024:
+            return f"{nbytes:.1f}{unit}" if nbytes != int(nbytes) else f"{int(nbytes)}{unit}"
+        nbytes /= 1024
+    return f"{nbytes:.1f}P"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations engine
+# ---------------------------------------------------------------------------
+
+def generate_recommendations(result: RedisAnalysisResult) -> List[Dict[str, str]]:
+    """Generate recommendations based on collected metrics."""
+    recs: List[Dict[str, str]] = []
+
+    # Collection failures — surface critical issues when SSH/introspection failed
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items() if v.get("status") == "failed"}
+        ssh_sources = {"redis_info", "slowlog", "slowlog_entries", "big_keys"}
+        ssh_failed = {k: v for k, v in failed.items() if k in ssh_sources}
+        if ssh_failed:
+            sources = ", ".join(ssh_failed.keys())
+            errors = "; ".join(v.get("error", "unknown") for v in ssh_failed.values())
+            recs.append({
+                "severity": "critical",
+                "category": "collection",
+                "message": f"SSH introspection failed — unable to collect {sources}. "
+                           f"Error: {errors}. "
+                           f"Analysis is incomplete: memory fragmentation, cache hit rate, "
+                           f"keyspace stats, and persistence health could not be evaluated.",
+            })
+
+    # Memory fragmentation
+    if result.memory:
+        frag = result.memory.get("mem_fragmentation_ratio", 0)
+        if frag > 1.5:
+            recs.append({
+                "severity": "warning",
+                "category": "memory",
+                "message": f"High memory fragmentation ({frag:.2f}). Consider restarting Redis to defragment, or enable activedefrag.",
+            })
+
+    # Cache hit rate
+    if result.cache:
+        hit_rate = result.cache.get("hit_rate", 0)
+        if hit_rate < 80 and (result.cache.get("keyspace_hits", 0) + result.cache.get("keyspace_misses", 0)) > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "cache",
+                "message": f"Low cache hit rate ({hit_rate:.1f}%). Review key access patterns - many keys may be expired or evicted before use.",
+            })
+        elif hit_rate < 95 and hit_rate >= 80:
+            recs.append({
+                "severity": "info",
+                "category": "cache",
+                "message": f"Cache hit rate at {hit_rate:.1f}% — could be improved. Check if working set fits in memory.",
+            })
+
+    # Evicted keys
+    if result.cache:
+        evicted = result.cache.get("evicted_keys", 0)
+        if evicted > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "memory",
+                "message": f"Redis is evicting keys ({_format_number(evicted)} evicted). Increase maxmemory or reduce dataset size.",
+            })
+
+    # Rejected connections
+    if result.overview:
+        rejected = result.overview.get("rejected_connections", 0)
+        if rejected > 0:
+            recs.append({
+                "severity": "warning",
+                "category": "connections",
+                "message": f"Connections being rejected ({_format_number(rejected)}). Check maxclients setting.",
+            })
+
+    # Blocked clients
+    if result.overview:
+        blocked = result.overview.get("blocked_clients", 0)
+        if blocked > 0:
+            recs.append({
+                "severity": "info",
+                "category": "connections",
+                "message": f"Blocked clients detected ({blocked}). Check for blocking operations (BLPOP, BRPOP, etc.).",
+            })
+
+    # maxmemory not set — on Railway this is expected; autoscaling handles growth
+
+    # RDB save failure
+    if result.persistence:
+        rdb_status = result.persistence.get("rdb_last_bgsave_status", "")
+        if rdb_status and rdb_status != "ok":
+            recs.append({
+                "severity": "critical",
+                "category": "persistence",
+                "message": "Last RDB save failed. Check disk space and permissions.",
+            })
+
+    # Slow log — data-driven when entries are available
+    if result.slowlog_entries:
+        # Analyze the actual slow commands
+        total_entries = len(result.slowlog_entries)
+        cmd_counts: Dict[str, int] = {}
+        total_duration = 0
+        for entry in result.slowlog_entries:
+            cmd = entry["command"].split()[0] if entry["command"] else "unknown"
+            cmd_counts[cmd] = cmd_counts.get(cmd, 0) + 1
+            total_duration += entry["duration_us"]
+        top_cmd = max(cmd_counts, key=cmd_counts.get) if cmd_counts else "unknown"
+        top_count = cmd_counts.get(top_cmd, 0)
+        avg_duration = total_duration / total_entries if total_entries > 0 else 0
+
+        msg = (f"Slow log contains {result.slowlog_len or total_entries} entries. "
+               f"Of the {total_entries} most recent: {top_count} are {top_cmd} commands "
+               f"averaging {_format_usec(avg_duration)}.")
+        if result.big_keys:
+            big_key_types = ", ".join(f"{bk['type']} ({bk['detail']})" for bk in result.big_keys[:3])
+            msg += f" Largest keys: {big_key_types} — check if these correlate with slow commands."
+        severity = "warning" if (result.slowlog_len or 0) > 100 else "info"
+        recs.append({"severity": severity, "category": "performance", "message": msg})
+    elif result.slowlog_len is not None and result.slowlog_len > 100:
+        recs.append({
+            "severity": "warning",
+            "category": "performance",
+            "message": f"High number of slow log entries ({result.slowlog_len}). Slow log details could not be collected.",
+        })
+
+    # Big keys — standalone recommendation when no slowlog correlation
+    if result.big_keys and not result.slowlog_entries:
+        big_key_summary = "; ".join(f"{bk['key']} ({bk['type']}: {bk['detail']})" for bk in result.big_keys[:5])
+        recs.append({
+            "severity": "info",
+            "category": "performance",
+            "message": f"Largest keys by type: {big_key_summary}. Large keys can cause latency spikes on read/delete operations.",
+        })
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_report(result: RedisAnalysisResult) -> str:
+    """Format the analysis result as a markdown report."""
+    lines: List[str] = []
+
+    lines.append(f"# Redis Analysis: {result.service}")
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append(f"Deployment Status: {result.deployment_status}")
+    lines.append("")
+
+    # --- Overview ---
+    if result.overview:
+        o = result.overview
+        lines.append("## Overview")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Version | {o.get('redis_version', 'N/A')} |")
+        lines.append(f"| Uptime | {_format_uptime(o.get('uptime_in_seconds', 0))} |")
+        lines.append(f"| Connected Clients | {o.get('connected_clients', 0):,} |")
+        lines.append(f"| Blocked Clients | {o.get('blocked_clients', 0):,} |")
+        lines.append(f"| Rejected Connections | {o.get('rejected_connections', 0):,} |")
+        lines.append(f"| Total Keys | {result.total_keys:,} |")
+        lines.append("")
+
+    # --- Memory ---
+    if result.memory:
+        m = result.memory
+        lines.append("## Memory")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+
+        frag = m.get("mem_fragmentation_ratio", 0)
+        frag_status = "OK" if 1.0 <= frag <= 1.5 else ("HIGH" if frag > 1.5 else "LOW")
+
+        lines.append(f"| Used Memory | {m.get('used_memory_human', 'N/A')} | |")
+        lines.append(f"| RSS Memory | {m.get('used_memory_rss_human', 'N/A')} | |")
+        lines.append(f"| Peak Memory | {m.get('used_memory_peak_human', 'N/A')} | |")
+        lines.append(f"| Fragmentation Ratio | {frag:.2f} | {frag_status} |")
+
+        maxmem = m.get("maxmemory", 0)
+        if maxmem > 0:
+            lines.append(f"| Max Memory | {m.get('maxmemory_human', _format_bytes_human(maxmem))} | |")
+        else:
+            lines.append("| Max Memory | Unlimited | |")
+
+        lines.append(f"| Eviction Policy | {m.get('maxmemory_policy', 'N/A')} | |")
+        lines.append("")
+
+    # --- Throughput ---
+    if result.throughput:
+        t = result.throughput
+        lines.append("## Throughput")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Ops/sec | {t.get('instantaneous_ops_per_sec', 0):,} |")
+        lines.append(f"| Total Commands | {_format_number(t.get('total_commands_processed', 0))} |")
+        lines.append(f"| Total Connections | {_format_number(t.get('total_connections_received', 0))} |")
+        if result.slowlog_len is not None:
+            lines.append(f"| Slow Log Entries | {result.slowlog_len:,} |")
+        lines.append("")
+
+    # --- Cache Performance ---
+    if result.cache:
+        c = result.cache
+        hit_rate = c.get("hit_rate", 0)
+        hit_status = "OK" if hit_rate >= 95 else ("WARN" if hit_rate >= 80 else "LOW")
+        evicted = c.get("evicted_keys", 0)
+        evict_status = "OK" if evicted == 0 else "WARN"
+
+        lines.append("## Cache Performance")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        lines.append(f"| Hit Rate | {hit_rate:.1f}% | {hit_status} |")
+        lines.append(f"| Hits | {_format_number(c.get('keyspace_hits', 0))} | |")
+        lines.append(f"| Misses | {_format_number(c.get('keyspace_misses', 0))} | |")
+        lines.append(f"| Expired Keys | {_format_number(c.get('expired_keys', 0))} | |")
+        lines.append(f"| Evicted Keys | {_format_number(evicted)} | {evict_status} |")
+        lines.append("")
+
+    # --- Persistence ---
+    if result.persistence:
+        p = result.persistence
+        rdb_status = p.get("rdb_last_bgsave_status", "unknown")
+        rdb_status_display = "OK" if rdb_status == "ok" else "FAIL"
+
+        lines.append("## Persistence")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+
+        rdb_last_save = p.get("rdb_last_save_time", 0)
+        if rdb_last_save > 0:
+            now_epoch = int(datetime.now(timezone.utc).timestamp())
+            save_ago = now_epoch - rdb_last_save
+            lines.append(f"| RDB Last Save | {_format_duration(save_ago)} | |")
+        else:
+            lines.append("| RDB Last Save | never | |")
+
+        lines.append(f"| RDB Status | {rdb_status} | {rdb_status_display} |")
+        lines.append(f"| AOF Enabled | {'Yes' if p.get('aof_enabled') else 'No'} | |")
+
+        if p.get("aof_enabled"):
+            aof_status = p.get("aof_last_rewrite_status", "unknown")
+            aof_display = "OK" if aof_status == "ok" else aof_status
+            lines.append(f"| AOF Rewrite Status | {aof_status} | {aof_display} |")
+
+        lines.append("")
+
+    # --- Command Stats ---
+    if result.command_stats:
+        top_n = result.command_stats[:20]
+        lines.append("## Command Stats (top 20)")
+        lines.append("| Command | Calls | Avg Latency | Total Time |")
+        lines.append("|---------|-------|-------------|------------|")
+        for cs in top_n:
+            lines.append(
+                f"| {cs['command']} "
+                f"| {_format_number(cs['calls'])} "
+                f"| {_format_usec(cs['usec_per_call'])} "
+                f"| {_format_total_time(cs['usec'])} |"
+            )
+        lines.append("")
+
+    # --- Slow Log Entries ---
+    if result.slowlog_entries:
+        lines.append("## Slow Log Entries (recent)")
+        lines.append("| # | Timestamp | Duration | Command |")
+        lines.append("|---|-----------|----------|---------|")
+        now_epoch = int(datetime.now(timezone.utc).timestamp())
+        for entry in result.slowlog_entries:
+            age = now_epoch - entry["timestamp_unix"]
+            lines.append(
+                f"| {entry['id']} "
+                f"| {_format_duration(age)} "
+                f"| {_format_usec(entry['duration_us'])} "
+                f"| {entry['command']} |"
+            )
+        lines.append("")
+
+    # --- Biggest Keys ---
+    if result.big_keys:
+        lines.append("## Biggest Keys")
+        lines.append("| Type | Key | Size/Count |")
+        lines.append("|------|-----|------------|")
+        for bk in result.big_keys:
+            lines.append(
+                f"| {bk['type']} "
+                f"| {bk['key']} "
+                f"| {bk['detail']} |"
+            )
+        lines.append("")
+
+    # --- Keyspace ---
+    if result.keyspace:
+        lines.append("## Keyspace")
+        lines.append("| Database | Keys | Expires | Avg TTL |")
+        lines.append("|----------|------|---------|---------|")
+        for db in result.keyspace:
+            lines.append(
+                f"| {db['db']} "
+                f"| {db['keys']:,} "
+                f"| {db['expires']:,} "
+                f"| {_format_ttl(db['avg_ttl'])} |"
+            )
+        lines.append("")
+
+    # --- Infrastructure Metrics ---
+    if result.metrics_history:
+        windows = result.metrics_history.get("windows", {})
+        for window_label, window_data in windows.items():
+            mh = window_data.get("metrics", {})
+            if not mh:
+                continue
+            lines.append(f"## Infrastructure Metrics ({window_label})")
+            lines.append("| Metric | Current | Min | Max | Avg | Trend |")
+            lines.append("|--------|---------|-----|-----|-----|-------|")
+            for key in ["cpu", "memory", "disk", "network_rx", "network_tx"]:
+                if key in mh:
+                    entry = mh[key]
+                    trend = entry.get("trend", {})
+                    trend_str = trend.get("direction", "N/A")
+                    change = trend.get("change_pct", 0)
+                    if change != 0:
+                        trend_str += f" ({change:+.1f}%)"
+                    lines.append(
+                        f"| {key.replace('_', ' ').title()} "
+                        f"| {entry['current']}{entry['unit']} "
+                        f"| {entry['min']}{entry['unit']} "
+                        f"| {entry['max']}{entry['unit']} "
+                        f"| {entry['avg']}{entry['unit']} "
+                        f"| {trend_str} |"
+                    )
+            lines.append("")
+
+    # --- Collection Status ---
+    if result.collection_status:
+        failed = {k: v for k, v in result.collection_status.items() if v.get("status") == "failed"}
+        if failed:
+            lines.append("## Collection Issues")
+            for source, status in failed.items():
+                lines.append(f"- **{source}**: {status.get('error', 'unknown error')}")
+            lines.append("")
+
+    # --- Recommendations ---
+    if result.recommendations:
+        lines.append("## Recommendations")
+        for rec in result.recommendations:
+            severity = rec.get("severity", "info").upper()
+            lines.append(f"- [{severity}] {rec['message']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+def analyze_redis(service: str, timeout: int = 300, quiet: bool = False,
+                  skip_logs: bool = False,
+                  metrics_hours: int = 168,
+                  project_id: Optional[str] = None,
+                  environment_id: Optional[str] = None,
+                  service_id: Optional[str] = None) -> RedisAnalysisResult:
+    """Run complete Redis analysis with maximum data collection.
+
+    Collects Redis INFO ALL, SLOWLOG LEN, SLOWLOG GET 20, --bigkeys,
+    Railway metrics, and logs in parallel where possible.
+
+    Args:
+        skip_logs: Skip log fetching for faster analysis
+        metrics_hours: Hours of metrics history to fetch (default: 168, max: 168)
+        project_id: Project ID (bypasses railway link config)
+        environment_id: Environment ID (bypasses railway link config)
+        service_id: Service ID (bypasses railway link config)
+    """
+    if not quiet:
+        print(f"Analyzing redis database: {service}", file=sys.stderr)
+
+    result = RedisAnalysisResult(
+        service=service,
+        db_type="redis",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+    # === FAST CONTEXT LOADING ===
+    if not quiet:
+        print("  [0/5] Getting Railway context...", file=sys.stderr, flush=True)
+    dal._progress_timer.start()
+
+    if environment_id and service_id:
+        dal._ctx = RailwayContext(project_id=project_id, environment_id=environment_id, service_id=service_id)
+        if not quiet:
+            print(f"        using explicit IDs (env={environment_id[:8]}..., svc={service_id[:8]}...)", file=sys.stderr, flush=True)
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            dal._ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+        environment_id = dal._ctx.environment_id
+        service_id = dal._ctx.service_id
+
+    # Get deployment status via API (~1s)
+    progress(1, 5, "Fetching deployment status...", quiet)
+    result.deployment_status = get_deployment_status(service, service_id=service_id)
+
+    # === SSH PRE-CHECK WITH RETRY ===
+    progress(2, 5, "Testing SSH connectivity...", quiet)
+    ssh_available = False
+    ssh_stderr = ""
+    ssh_attempts = [30, 60, 90]
+    for attempt, attempt_timeout in enumerate(ssh_attempts, 1):
+        ssh_code, ssh_stdout, ssh_stderr = run_ssh_query(service, "echo ok", timeout=attempt_timeout)
+        if ssh_code == 0 and "ok" in ssh_stdout:
+            ssh_available = True
+            if not quiet:
+                for line in ssh_stderr.splitlines():
+                    if line.startswith("Using SSH key:"):
+                        print(f"        {line}", file=sys.stderr, flush=True)
+                        break
+            break
+        if not quiet:
+            remaining = len(ssh_attempts) - attempt
+            if remaining > 0:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), retrying with {ssh_attempts[attempt]}s timeout...", file=sys.stderr, flush=True)
+            else:
+                print(f"        SSH attempt {attempt}/{len(ssh_attempts)} failed ({ssh_stderr or 'no response'}), giving up", file=sys.stderr, flush=True)
+
+    # === PARALLEL EXECUTION ===
+    progress(3, 5, "Running analysis (Redis INFO, slowlog, bigkeys, metrics, logs in parallel)...", quiet)
+
+    def task_redis_info():
+        """Fetch Redis INFO ALL via SSH."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw INFO ALL'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout)
+        return ("failed", stderr or "empty response", stdout)
+
+    def task_slowlog():
+        """Fetch Redis SLOWLOG LEN via SSH."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw SLOWLOG LEN'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_slowlog_get():
+        """Fetch Redis SLOWLOG GET 20 via SSH for actual slow query details."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw SLOWLOG GET 20'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_bigkeys():
+        """Fetch redis-cli --bigkeys via SSH (SCAN-based, may take longer)."""
+        if not ssh_available:
+            return ("failed", f"SSH not available: {ssh_stderr or 'connection failed'}", "")
+        command = 'timeout 60s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --bigkeys'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=75)
+        if code == 0 and stdout.strip():
+            return ("ok", "", stdout.strip())
+        return ("failed", stderr or "empty response", "")
+
+    def task_metrics():
+        """Fetch all metrics (disk, CPU, memory) in one API call."""
+        if environment_id and service_id:
+            return get_all_metrics_from_api(environment_id, service_id, hours=metrics_hours)
+        return None
+
+    def task_logs():
+        """Fetch recent logs via API (~3s)."""
+        if skip_logs:
+            return []
+        return get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        future_info = executor.submit(task_redis_info)
+        future_slowlog = executor.submit(task_slowlog)
+        future_slowlog_get = executor.submit(task_slowlog_get)
+        future_bigkeys = executor.submit(task_bigkeys)
+        future_metrics = executor.submit(task_metrics)
+        future_logs = executor.submit(task_logs)
+
+        # Collect results
+        info_result = future_info.result()
+        slowlog_result = future_slowlog.result()
+        slowlog_get_result = future_slowlog_get.result()
+        bigkeys_result = future_bigkeys.result()
+        metrics_result = future_metrics.result()
+        logs_result = future_logs.result()
+
+    # === PROCESS RESULTS ===
+    progress(4, 5, "Processing results...", quiet)
+
+    # Redis INFO ALL
+    info_status, info_error, info_raw = info_result
+    if info_status == "ok" and info_raw:
+        result.collection_status["redis_info"] = {"status": "ok"}
+        info = parse_redis_info(info_raw)
+
+        result.overview = extract_overview(info)
+        result.memory = extract_memory(info)
+        result.throughput = extract_throughput(info)
+        result.cache = extract_cache(info)
+        result.persistence = extract_persistence(info)
+        result.keyspace, result.total_keys = extract_keyspace(info)
+        result.command_stats = extract_command_stats(info)
+    else:
+        result.collection_status["redis_info"] = {"status": "failed", "error": info_error}
+        result.errors.append(f"Redis INFO failed: {info_error}")
+
+    # SLOWLOG LEN
+    sl_status, sl_error, sl_raw = slowlog_result
+    if sl_status == "ok" and sl_raw:
+        result.collection_status["slowlog"] = {"status": "ok"}
+        result.slowlog_len = _safe_int(sl_raw)
+    else:
+        result.collection_status["slowlog"] = {"status": "failed", "error": sl_error}
+
+    # SLOWLOG GET 20
+    slg_status, slg_error, slg_raw = slowlog_get_result
+    if slg_status == "ok" and slg_raw:
+        result.collection_status["slowlog_entries"] = {"status": "ok"}
+        result.slowlog_entries = parse_slowlog_get(slg_raw)
+    else:
+        result.collection_status["slowlog_entries"] = {"status": "failed", "error": slg_error}
+
+    # Big keys
+    bk_status, bk_error, bk_raw = bigkeys_result
+    if bk_status == "ok" and bk_raw:
+        result.collection_status["big_keys"] = {"status": "ok"}
+        result.big_keys = parse_bigkeys(bk_raw)
+    else:
+        result.collection_status["big_keys"] = {"status": "failed", "error": bk_error}
+
+    # Metrics
+    if metrics_result:
+        result.collection_status["metrics"] = {"status": "ok"}
+        result.metrics_history = metrics_result.get("metrics_history")
+    else:
+        result.collection_status["metrics"] = {"status": "failed", "error": "no metrics returned"}
+
+    # Logs
+    if logs_result:
+        result.collection_status["logs"] = {"status": "ok", "lines": len(logs_result)}
+        result.recent_logs = logs_result
+    else:
+        result.collection_status["logs"] = {"status": "failed", "error": "no logs returned"}
+
+    # === RECOMMENDATIONS ===
+    progress(5, 5, "Generating recommendations...", quiet)
+    result.recommendations = generate_recommendations(result)
+
+    if not quiet:
+        elapsed = dal._progress_timer.step_elapsed()
+        if elapsed:
+            print(f"        done{elapsed}", file=sys.stderr, flush=True)
+        print(f"  Analysis complete{dal._progress_timer.total_elapsed()}", file=sys.stderr, flush=True)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Single-step debugging
+# ---------------------------------------------------------------------------
+
+def run_single_step(args) -> int:
+    """Run a single collection step for debugging."""
+    service = args.service
+    _init_context(args)
+    environment_id = dal._ctx.environment_id
+    service_id = dal._ctx.service_id
+
+    if args.step == "ssh-test":
+        print(f"Testing SSH to service: {service}", file=sys.stderr)
+        code, stdout, stderr = run_ssh_query(service, "echo ok", timeout=45)
+        print(f"Exit code: {code}")
+        print(f"Stdout: {stdout.strip()}")
+        if stderr:
+            print(f"Stderr: {stderr.strip()}")
+        return 0 if (code == 0 and "ok" in stdout) else 1
+
+    elif args.step == "query":
+        print(f"Running Redis INFO ALL on: {service}", file=sys.stderr)
+        command = 'timeout 30s redis-cli -h localhost -p 6379 -a "$REDISPASSWORD" --no-auth-warning --raw INFO ALL'
+        code, stdout, stderr = run_ssh_query(service, command, timeout=45)
+        print(f"Exit code: {code}")
+        if code == 0 and stdout:
+            info = parse_redis_info(stdout)
+            print(json.dumps(info, indent=2))
+        else:
+            print(f"Error: {stderr or stdout}")
+        return code
+
+    elif args.step == "logs":
+        print(f"Fetching logs for: {service}", file=sys.stderr)
+        logs = get_recent_logs(service, lines=LOG_LINES_DEFAULT,
+                               environment_id=environment_id,
+                               service_id=service_id)
+        print(f"Lines fetched: {len(logs)}")
+        for line in logs:
+            print(line)
+        return 0
+
+    elif args.step == "metrics":
+        print(f"Fetching metrics for: {service}", file=sys.stderr)
+        if environment_id and service_id:
+            metrics = get_all_metrics_from_api(environment_id, service_id)
+            if metrics:
+                print(json.dumps(metrics, indent=2))
+            else:
+                print("No metrics returned", file=sys.stderr)
+                return 1
+        else:
+            print("No environment_id or service_id available", file=sys.stderr)
+            return 1
+        return 0
+
+    else:
+        print(f"Unknown step: {args.step}", file=sys.stderr)
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Redis analysis for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument("--service", required=True, help="Service name")
+    parser.add_argument("--json", action="store_true",
+                       help="Output as JSON")
+    parser.add_argument("--timeout", type=int, default=300,
+                       help="Timeout in seconds for analysis (default: 300)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Suppress progress messages")
+    parser.add_argument("--skip-logs", action="store_true",
+                       help="Skip log fetching for faster analysis")
+    parser.add_argument("--metrics-hours", type=int, default=168,
+                       help="Hours of metrics history to fetch (default: 168, max: 168)")
+    parser.add_argument("--step", choices=["ssh-test", "query", "logs", "metrics"],
+                       help="Run a single collection step for debugging")
+    parser.add_argument("--project-id", help="Project ID (bypasses railway link)")
+    parser.add_argument("--environment-id", help="Environment ID (bypasses railway link)")
+    parser.add_argument("--service-id", help="Service ID (bypasses railway link)")
+
+    args = parser.parse_args()
+
+    # Single-step debugging mode
+    if args.step:
+        return run_single_step(args)
+
+    # Run analysis
+    result = analyze_redis(args.service, timeout=args.timeout, quiet=args.quiet,
+                           skip_logs=args.skip_logs,
+                           metrics_hours=min(args.metrics_hours, 168),
+                           project_id=args.project_id,
+                           environment_id=args.environment_id,
+                           service_id=args.service_id)
+
+    # Output
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(format_report(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/dal.py
+++ b/.claude/skills/use-railway/scripts/dal.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Shared Railway infrastructure helpers for database analysis scripts."""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass
+
+LOG_LINES_DEFAULT = 1000  # Number of log lines to fetch via API
+
+
+class ProgressTimer:
+    """Track elapsed time for progress messages."""
+    def __init__(self):
+        self.start_time = None
+        self.step_start_time = None
+
+    def start(self):
+        """Start the overall timer."""
+        self.start_time = datetime.now()
+        self.step_start_time = self.start_time
+
+    def step_elapsed(self) -> str:
+        """Get elapsed time since last step, then reset step timer."""
+        if self.step_start_time is None:
+            return ""
+        now = datetime.now()
+        elapsed = (now - self.step_start_time).total_seconds()
+        self.step_start_time = now
+        if elapsed < 0.1:
+            return ""
+        return f" ({elapsed:.1f}s)"
+
+    def total_elapsed(self) -> str:
+        """Get total elapsed time."""
+        if self.start_time is None:
+            return ""
+        elapsed = (datetime.now() - self.start_time).total_seconds()
+        return f" (total: {elapsed:.1f}s)"
+
+
+# Global timer instance
+_progress_timer = ProgressTimer()
+
+
+@dataclass
+class RailwayContext:
+    """Explicit Railway IDs that bypass railway link."""
+    project_id: Optional[str] = None
+    environment_id: Optional[str] = None
+    service_id: Optional[str] = None
+
+    def ssh_flags(self) -> List[str]:
+        """Return CLI flags for railway ssh."""
+        flags = ["--native"]
+        if self.project_id:
+            flags.extend(["--project", self.project_id])
+        if self.environment_id:
+            flags.extend(["--environment", self.environment_id])
+        if self.service_id:
+            flags.extend(["--service", self.service_id])
+        return flags
+
+    def logs_flags(self) -> List[str]:
+        """Return CLI flags for railway logs."""
+        flags = []
+        if self.environment_id:
+            flags.extend(["--environment", self.environment_id])
+        return flags
+
+
+# Global context — set once at startup, used by all CLI calls
+_ctx = RailwayContext()
+
+
+def _init_context(args) -> None:
+    """Initialize global context from CLI args or railway config."""
+    global _ctx
+    if args.environment_id and args.service_id:
+        _ctx = RailwayContext(
+            project_id=getattr(args, 'project_id', None),
+            environment_id=args.environment_id,
+            service_id=args.service_id,
+        )
+    else:
+        railway_status = get_railway_status()
+        if railway_status:
+            _ctx = RailwayContext(
+                project_id=railway_status.get("projectId"),
+                environment_id=railway_status.get("environmentId"),
+                service_id=railway_status.get("serviceId"),
+            )
+
+
+def progress(step: int, total: int, message: str, quiet: bool = False):
+    """Print progress message to stderr with elapsed time."""
+    if not quiet:
+        # Show elapsed time from previous step (before current step message)
+        elapsed = _progress_timer.step_elapsed()
+        if elapsed:
+            print(f"        done{elapsed}", file=sys.stderr, flush=True)
+        print(f"  [{step}/{total}] {message}", file=sys.stderr, flush=True)
+
+
+def run_railway_command(args: List[str], timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a railway CLI command and return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            ["railway"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", "Command timed out"
+    except FileNotFoundError:
+        return 127, "", "railway CLI not found"
+
+
+def _cli_fatal_error(returncode: int, stderr: str) -> Optional[str]:
+    """Return a friendly error string if the CLI itself is broken, else None.
+
+    These errors are unrecoverable — retrying won't help.
+    """
+    if returncode == 127 or "railway CLI not found" in stderr:
+        return (
+            "Railway CLI not found. "
+            "Install it with: npm i -g @railway/cli  "
+            "or  brew install railway"
+        )
+    lower = stderr.lower()
+    if "unknown flag" in lower or "flag provided but not defined" in lower:
+        return (
+            "Railway CLI is outdated — the --native SSH flag is not supported. "
+            "Update it with: npm i -g @railway/cli@latest  "
+            "or  brew upgrade railway"
+        )
+    return None
+
+
+def run_ssh_query(service: str, command: str, timeout: int = 60,
+                  max_attempts: int = 3) -> Tuple[int, str, str]:
+    """Run a command via railway ssh, retrying up to max_attempts times.
+
+    Passes the command as a single argument after '--'. Railway ssh
+    interprets it through a shell on the remote end, so pipes, env vars,
+    and redirects all work without an explicit sh -c wrapper.
+
+    Retries on non-zero exit code or empty stdout (covers transient errors
+    like 'exec request failed on channel 0').  Never retries when the CLI
+    itself is missing or outdated — those errors are unrecoverable.
+    """
+    flags = _ctx.ssh_flags()
+    # Only pass --service <name> if context didn't already provide --service <id>
+    if not _ctx.service_id:
+        flags += ["--service", service]
+    args = ["ssh"] + flags + ["--", command]
+    last_code, last_stdout, last_stderr = 1, "", ""
+    for attempt in range(1, max_attempts + 1):
+        last_code, last_stdout, last_stderr = run_railway_command(args, timeout)
+        if last_code == 0 and last_stdout.strip():
+            return last_code, last_stdout, last_stderr
+        fatal = _cli_fatal_error(last_code, last_stderr)
+        if fatal:
+            return last_code, last_stdout, fatal
+        if attempt < max_attempts:
+            print(
+                f"        SSH attempt {attempt}/{max_attempts} failed "
+                f"({last_stderr.strip() or 'empty response'}), retrying...",
+                file=sys.stderr, flush=True,
+            )
+    return last_code, last_stdout, last_stderr
+
+
+def run_psql_query(service: str, query: str, timeout: int = 60) -> Tuple[int, str]:
+    """Run a psql query via railway ssh and return (returncode, output).
+
+    Normalizes query whitespace and suppresses psql warnings (e.g. collation
+    version mismatch) that would otherwise pollute stdout.
+    """
+    query = " ".join(query.split())
+    command = f'''PAGER='' psql $DATABASE_URL -P pager=off -t -A -c "{query}" 2>/dev/null'''
+    code, stdout, stderr = run_ssh_query(service, command, timeout)
+    if code != 0:
+        return code, stderr or stdout
+    return 0, stdout
+
+
+def get_railway_status() -> Optional[Dict[str, Any]]:
+    """Get environment and service IDs from Railway config file.
+
+    Reads directly from ~/.railway/config.json instead of calling CLI (~15s saved).
+    """
+    config_path = os.path.expanduser("~/.railway/config.json")
+    if not os.path.exists(config_path):
+        return None
+
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+        # Get linked project for current directory
+        cwd = os.getcwd()
+        projects = config.get("projects", {})
+
+        # Find project config for current directory or parent
+        project_config = None
+        check_path = cwd
+        while check_path != "/":
+            if check_path in projects:
+                project_config = projects[check_path]
+                break
+            check_path = os.path.dirname(check_path)
+
+        if not project_config:
+            return None
+
+        return {
+            "projectId": project_config.get("project"),
+            "environmentId": project_config.get("environment"),
+            "serviceId": project_config.get("service"),
+            "serviceName": project_config.get("name", ""),
+        }
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def get_deployment_status(service: str, service_id: Optional[str] = None) -> str:
+    """Get deployment status for service.
+
+    Uses direct API call if service_id provided (~1s), falls back to CLI (~15s).
+    """
+    # Fast path: use API directly if we have service_id
+    if service_id:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        api_script = os.path.join(script_dir, "railway-api.sh")
+
+        if os.path.exists(api_script):
+            query = '''query svc($id: String!) {
+                service(id: $id) {
+                    deployments(first: 1) {
+                        edges { node { status } }
+                    }
+                }
+            }'''
+            try:
+                result = subprocess.run(
+                    [api_script, query, json.dumps({"id": service_id})],
+                    capture_output=True,
+                    text=True,
+                    timeout=10
+                )
+                if result.returncode == 0:
+                    data = json.loads(result.stdout)
+                    edges = data.get("data", {}).get("service", {}).get("deployments", {}).get("edges", [])
+                    if edges:
+                        return edges[0].get("node", {}).get("status", "UNKNOWN")
+            except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                pass
+
+    # Fallback: use CLI (slow, ~15s)
+    code, stdout, stderr = run_railway_command(
+        ["service", "status", "--service", service, "--json"]
+    )
+    if code != 0:
+        return "UNKNOWN"
+    try:
+        data = json.loads(stdout)
+        status = data.get("status", "UNKNOWN")
+        if data.get("stopped"):
+            return f"{status} (stopped)"
+        return status
+    except json.JSONDecodeError:
+        return "UNKNOWN"
+
+
+def get_all_metrics_from_api(environment_id: str, service_id: str, hours: int = 24) -> Optional[Dict[str, Any]]:
+    """Get disk, CPU, memory, and network usage from Railway metrics API.
+
+    Fetches time-series data and computes trend analysis including
+    min/max/avg, spike detection, and directional trends.
+
+    Args:
+        hours: Hours of history to fetch (default: 24, max: 168)
+    """
+    from datetime import timedelta
+
+    start_date = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    api_script = os.path.join(script_dir, "railway-api.sh")
+
+    if not os.path.exists(api_script):
+        return None
+
+    query = '''query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $measurements: [MetricMeasurement!]!) {
+        metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, measurements: $measurements) {
+            measurement values { ts value }
+        }
+    }'''
+
+    variables = json.dumps({
+        "environmentId": environment_id,
+        "serviceId": service_id,
+        "startDate": start_date,
+        "measurements": [
+            "DISK_USAGE_GB", "CPU_USAGE", "MEMORY_USAGE_GB",
+            "MEMORY_LIMIT_GB", "CPU_LIMIT",
+            "NETWORK_RX_GB", "NETWORK_TX_GB",
+        ]
+    })
+
+    try:
+        result = subprocess.run(
+            [api_script, query, variables],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        metrics = data.get("data", {}).get("metrics", [])
+
+        combined = {"disk_usage": None, "cpu_memory": {}, "metrics_history": None}
+
+        # Raw time series keyed by measurement name
+        raw_series: Dict[str, List[Dict[str, Any]]] = {}
+
+        for metric in metrics:
+            measurement = metric.get("measurement")
+            values = metric.get("values", [])
+            if values:
+                raw_series[measurement] = values
+                latest = values[-1].get("value", 0)
+                if measurement == "DISK_USAGE_GB":
+                    combined["disk_usage"] = {
+                        "used_gb": round(latest, 2),
+                        "used": f"{round(latest, 1)} GB"
+                    }
+                elif measurement == "CPU_USAGE":
+                    combined["cpu_memory"]["cpu_percent"] = round(latest, 1)
+                elif measurement == "MEMORY_USAGE_GB":
+                    combined["cpu_memory"]["memory_gb"] = round(latest, 2)
+                elif measurement == "MEMORY_LIMIT_GB":
+                    combined["cpu_memory"]["memory_limit_gb"] = round(latest, 2)
+                elif measurement == "CPU_LIMIT":
+                    combined["cpu_memory"]["cpu_limit"] = round(latest, 1)
+
+        if not combined["cpu_memory"]:
+            combined["cpu_memory"] = None
+
+        # Build time-series history with trend analysis
+        if raw_series:
+            combined["metrics_history"] = _build_metrics_history(raw_series, hours=hours)
+
+        return combined
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def _analyze_window(values: List[Dict[str, Any]], nums: List[float], d: int,
+                    unit: str) -> Dict[str, Any]:
+    """Analyze a single time window of metric data.
+
+    Returns summary stats, trend, spike detection, and downsampled series.
+    """
+    if not nums:
+        return {}
+
+    avg_val = sum(nums) / len(nums)
+    min_val = min(nums)
+    max_val = max(nums)
+
+    entry: Dict[str, Any] = {
+        "unit": unit,
+        "current": round(nums[-1], d),
+        "min": round(min_val, d),
+        "max": round(max_val, d),
+        "avg": round(avg_val, d),
+        "samples": len(nums),
+    }
+
+    # Trend: compare first quarter avg to last quarter avg
+    q_size = max(len(nums) // 4, 1)
+    first_q = nums[:q_size]
+    last_q = nums[-q_size:]
+    first_avg = sum(first_q) / len(first_q)
+    last_avg = sum(last_q) / len(last_q)
+
+    if first_avg > 0:
+        change_pct = round(((last_avg - first_avg) / first_avg) * 100, 1)
+    elif last_avg > 0:
+        change_pct = 100.0
+    else:
+        change_pct = 0.0
+
+    if change_pct > 10:
+        trend_dir = "increasing"
+    elif change_pct < -10:
+        trend_dir = "decreasing"
+    else:
+        trend_dir = "stable"
+
+    entry["trend"] = {
+        "direction": trend_dir,
+        "change_pct": change_pct,
+        "first_quarter_avg": round(first_avg, d),
+        "last_quarter_avg": round(last_avg, d),
+    }
+
+    # Spike detection
+    if len(nums) >= 10:
+        variance = sum((x - avg_val) ** 2 for x in nums) / len(nums)
+        stddev = variance ** 0.5
+        threshold = avg_val + 2 * stddev
+        if stddev > 0 and threshold > 0:
+            spikes = []
+            for v in values:
+                val = v.get("value")
+                if val is not None and val > threshold:
+                    spikes.append({"ts": v["ts"], "value": round(val, d)})
+            if spikes:
+                entry["spikes"] = {
+                    "count": len(spikes),
+                    "threshold": round(threshold, d),
+                    "peaks": spikes[:10],
+                }
+
+    # Compact time series: downsample to ~48 points
+    series_points = []
+    for v in values:
+        ts = v.get("ts")
+        val = v.get("value")
+        if ts is not None and val is not None:
+            series_points.append({"ts": ts, "value": round(val, d)})
+
+    if len(series_points) > 48:
+        step = len(series_points) / 48
+        downsampled = []
+        for i in range(48):
+            idx = int(i * step)
+            downsampled.append(series_points[idx])
+        downsampled.append(series_points[-1])
+        entry["series"] = downsampled
+    else:
+        entry["series"] = series_points
+
+    return entry
+
+
+def _build_metrics_history(raw_series: Dict[str, List[Dict[str, Any]]], hours: int = 168) -> Dict[str, Any]:
+    """Build multi-window time-series history with trend analysis.
+
+    Always produces a full-window analysis. If the window is > 24h, also
+    produces a 24h short-window analysis from the tail of the data so the
+    LLM can compare long-term vs short-term trends.
+    """
+    from datetime import timedelta
+
+    metric_info = {
+        "CPU_USAGE": {"name": "cpu", "unit": "vCPU", "decimals": 2},
+        "MEMORY_USAGE_GB": {"name": "memory", "unit": "GB", "decimals": 2},
+        "MEMORY_LIMIT_GB": {"name": "memory_limit", "unit": "GB", "decimals": 2},
+        "CPU_LIMIT": {"name": "cpu_limit", "unit": "vCPU", "decimals": 2},
+        "DISK_USAGE_GB": {"name": "disk", "unit": "GB", "decimals": 2},
+        "NETWORK_RX_GB": {"name": "network_rx", "unit": "GB", "decimals": 3},
+        "NETWORK_TX_GB": {"name": "network_tx", "unit": "GB", "decimals": 3},
+    }
+
+    # Determine the 24h cutoff timestamp
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    cutoff_24h = now_ts - (24 * 3600)
+
+    produce_short_window = hours > 24
+
+    full_window: Dict[str, Any] = {}
+    short_window: Dict[str, Any] = {}
+
+    for measurement, values in raw_series.items():
+        info = metric_info.get(measurement)
+        if not info or len(values) < 2:
+            continue
+
+        nums = [v["value"] for v in values if v.get("value") is not None]
+        if not nums:
+            continue
+
+        d = info["decimals"]
+        name = info["name"]
+
+        # Full window analysis
+        full_window[name] = _analyze_window(values, nums, d, info["unit"])
+
+        # Short window (last 24h) analysis
+        if produce_short_window:
+            recent_values = [v for v in values if v.get("ts", 0) >= cutoff_24h]
+            recent_nums = [v["value"] for v in recent_values if v.get("value") is not None]
+            if len(recent_nums) >= 2:
+                short_window[name] = _analyze_window(recent_values, recent_nums, d, info["unit"])
+
+    # Build the result with named windows
+    windows: Dict[str, Any] = {}
+
+    # Label the full window
+    if hours >= 168:
+        full_label = "7d"
+    elif hours >= 72:
+        full_label = f"{hours // 24}d"
+    else:
+        full_label = f"{hours}h"
+
+    windows[full_label] = {
+        "window_hours": hours,
+        "metrics": full_window,
+    }
+
+    if produce_short_window and short_window:
+        windows["24h"] = {
+            "window_hours": 24,
+            "metrics": short_window,
+        }
+
+    return {"windows": windows}
+
+
+def info(msg: str) -> None:
+    """Print an [INFO] message to stdout."""
+    print(f"[INFO] {msg}")
+
+
+def error(msg: str) -> None:
+    """Print an [ERROR] message to stderr and exit."""
+    print(f"[ERROR] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def confirm_with_user(prompt: str) -> bool:
+    """Get confirmation directly from the terminal.
+
+    Reads from /dev/tty to ensure it's an actual user at a terminal,
+    not piped input. This prevents automated scripts from bypassing confirmation.
+    """
+    try:
+        with open('/dev/tty', 'r') as tty:
+            print(prompt, end=' ', flush=True)
+            response = tty.readline().strip().lower()
+            return response in ('y', 'yes')
+    except (OSError, IOError):
+        print("\n[ERROR] This command requires interactive terminal confirmation.")
+        print("It cannot be run with piped input or in non-interactive mode.")
+        print("Please run this command directly in a terminal.")
+        return False
+
+
+def _safe_int(val: Any, default: int = 0) -> int:
+    """Safely convert a value to int, returning default on failure."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_float(val: Any, default: float = 0.0) -> float:
+    """Safely convert a value to float, returning default on failure."""
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _format_uptime(seconds: int) -> str:
+    """Format uptime seconds into a human-readable string."""
+    if seconds <= 0:
+        return "N/A"
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
+    minutes = (seconds % 3600) // 60
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0 and days == 0:
+        parts.append(f"{minutes}m")
+    return " ".join(parts) if parts else "< 1m"
+
+
+def _trend_indicator(metrics_history: Optional[Dict[str, Any]], metric_name: str) -> str:
+    """Return a compact trend string like ' (^ +15.2% 24h)' for use in summary rows."""
+    if not metrics_history:
+        return ""
+    windows = metrics_history.get("windows", {})
+    window_data = windows.get("24h") or next(iter(windows.values()), None) if windows else None
+    if not window_data or not window_data.get("metrics"):
+        return ""
+    m = window_data["metrics"].get(metric_name)
+    if not m or "trend" not in m:
+        return ""
+    t = m["trend"]
+    direction = t.get("direction", "stable")
+    change = t.get("change_pct", 0)
+    window_label = "24h" if "24h" in windows else next(iter(windows), "")
+    arrow = {"increasing": "^", "decreasing": "v", "stable": "~"}.get(direction, "")
+    if direction == "stable":
+        return f" ({arrow} stable {window_label})"
+    return f" ({arrow} {change:+.1f}% {window_label})"
+
+
+def get_recent_logs(service: str, lines: int = LOG_LINES_DEFAULT,
+                    environment_id: Optional[str] = None,
+                    service_id: Optional[str] = None) -> List[str]:
+    """Get recent logs for LLM analysis.
+
+    Uses API if environment_id and service_id provided (~3s),
+    retries once with longer timeout on failure,
+    falls back to CLI (~27s for 100 lines).
+    """
+    # Fast path: use API directly
+    if environment_id and service_id:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        api_script = os.path.join(script_dir, "railway-api.sh")
+
+        if os.path.exists(api_script):
+            # Use environmentLogs API with service filter
+            query = f'''query {{
+                environmentLogs(
+                    environmentId: "{environment_id}",
+                    beforeLimit: {lines},
+                    filter: "@service:{service_id}"
+                ) {{
+                    timestamp
+                    message
+                }}
+            }}'''
+            # Try API twice: first with 15s timeout, retry with 30s
+            for attempt_timeout in [15, 30]:
+                try:
+                    result = subprocess.run(
+                        [api_script, query],
+                        capture_output=True,
+                        text=True,
+                        timeout=attempt_timeout
+                    )
+                    if result.returncode == 0:
+                        data = json.loads(result.stdout)
+                        logs_data = data.get("data", {}).get("environmentLogs", [])
+                        if logs_data:
+                            return [f"{log['timestamp']} {log['message']}" for log in logs_data]
+                except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                    pass
+
+    # Fallback: use CLI (slow, ~27s)
+    code, stdout, stderr = run_railway_command(
+        ["logs"] + _ctx.logs_flags() + ["--service", service, "--lines", str(lines)],
+        timeout=30
+    )
+    if code != 0:
+        return []
+
+    logs = []
+    for line in stdout.strip().split("\n"):
+        if line.strip():
+            logs.append(line.strip())
+    return logs

--- a/.claude/skills/use-railway/scripts/enable-pg-stats.py
+++ b/.claude/skills/use-railway/scripts/enable-pg-stats.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Enable pg_stat_statements for query statistics tracking.
+
+This script replicates the frontend's Metrics.tsx enable logic:
+1. Check if pg_stat_statements is already in shared_preload_libraries
+2. If yes, just install the extension
+3. If no, install extension + ALTER SYSTEM + restart
+
+Usage:
+    enable-pg-stats.py --service <name>
+
+Requires: railway CLI linked to the correct project/environment
+
+IMPORTANT: This script requires interactive terminal confirmation.
+It cannot be run with piped input - the user must confirm directly.
+"""
+
+import argparse
+import sys
+import re
+from typing import List
+
+from dal import run_psql_query, info, error, confirm_with_user
+
+
+def parse_preload_libraries(value: str) -> List[str]:
+    """Parse shared_preload_libraries value into clean library names."""
+    if not value or not value.strip():
+        return []
+
+    # Split by comma and clean up quotes
+    libs = []
+    for lib in value.split(","):
+        clean = lib.strip().replace('"', '').replace("'", '')
+        # Validate as PostgreSQL identifier
+        if clean and re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', clean):
+            libs.append(clean)
+    return libs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Enable pg_stat_statements for query performance tracking.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+What this does:
+  1. Checks if pg_stat_statements is already in shared_preload_libraries
+  2. Installs the extension: CREATE EXTENSION IF NOT EXISTS pg_stat_statements
+  3. If library wasn't preloaded: configures shared_preload_libraries and restarts
+
+Note: If restart is needed, the database will have brief downtime.
+
+IMPORTANT: This script requires interactive terminal confirmation and cannot
+be automated. The user must confirm the action directly.
+        """
+    )
+
+    parser.add_argument("--service", required=True, help="Service name (requires linked project)")
+
+    args = parser.parse_args()
+    service = args.service
+
+    # Step 1: Check current shared_preload_libraries
+    info("Checking current shared_preload_libraries...")
+    code, output = run_psql_query(service, "SHOW shared_preload_libraries")
+    if code != 0:
+        error(f"Failed to query shared_preload_libraries: {output}")
+
+    current_libs = output
+    info(f"Current shared_preload_libraries: {current_libs or '<empty>'}")
+
+    # Check if pg_stat_statements is already loaded
+    existing_libs = parse_preload_libraries(current_libs)
+    library_already_loaded = "pg_stat_statements" in existing_libs
+
+    if library_already_loaded:
+        info("pg_stat_statements is already in shared_preload_libraries")
+        needs_restart = False
+    else:
+        info("pg_stat_statements is NOT in shared_preload_libraries (will need restart)")
+        needs_restart = True
+
+    # Step 2: Check if extension is already installed
+    info("Checking if pg_stat_statements extension is installed...")
+    code, output = run_psql_query(service, "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'")
+
+    extension_exists = code == 0 and output.strip() == "1"
+
+    if extension_exists:
+        info("pg_stat_statements extension is already installed")
+        needs_install = False
+    else:
+        info("pg_stat_statements extension needs to be installed")
+        needs_install = True
+
+    # If everything is already configured, exit early
+    if not needs_restart and not needs_install:
+        info("pg_stat_statements is fully configured and ready!")
+        print("")
+        print("Query statistics are available. Run:")
+        print("  SELECT * FROM pg_stat_statements LIMIT 10;")
+        return 0
+
+    # Confirm before making changes - REQUIRES interactive terminal
+    print("")
+    print(f"About to make the following changes to '{service}':")
+    if needs_install:
+        print("  - Install pg_stat_statements extension")
+    if needs_restart:
+        print("  - Configure shared_preload_libraries")
+        print("  - Restart the database (brief downtime)")
+    print("")
+
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return 1
+
+    # Step 3: Install extension
+    if needs_install:
+        info("Installing pg_stat_statements extension...")
+        code, output = run_psql_query(service, "CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        if code != 0:
+            error(f"Failed to install extension: {output}")
+        info("Extension installed")
+
+    # Step 4: Configure shared_preload_libraries and restart if needed
+    if needs_restart:
+        info("Configuring shared_preload_libraries...")
+
+        # Add pg_stat_statements to existing libraries
+        if "pg_stat_statements" not in existing_libs:
+            existing_libs.append("pg_stat_statements")
+
+        # Build ALTER SYSTEM with individual quoted values
+        # PostgreSQL syntax: ALTER SYSTEM SET shared_preload_libraries TO 'lib1', 'lib2'
+        quoted_libs = ", ".join(f"'{lib}'" for lib in existing_libs)
+        alter_query = f"ALTER SYSTEM SET shared_preload_libraries TO {quoted_libs}"
+
+        info(f"Setting shared_preload_libraries to: {', '.join(existing_libs)}")
+
+        code, output = run_psql_query(service, alter_query)
+        if code != 0:
+            error(f"Failed to configure shared_preload_libraries: {output}")
+        info("shared_preload_libraries configured")
+
+        # Step 5: Restart the service
+        info("Restarting database service...")
+        code, stdout, stderr = run_railway_command(["restart", "--service", service, "--yes"])
+        if code != 0:
+            error(f"Failed to restart service: {stderr or stdout}")
+
+        print("")
+        info("Database is restarting. Query statistics will be available shortly.")
+        print("")
+        print("After restart completes, verify with:")
+        print("  SHOW shared_preload_libraries;")
+        print("  SELECT * FROM pg_stat_statements LIMIT 5;")
+    else:
+        print("")
+        info("pg_stat_statements is now ready!")
+        print("")
+        print("Query statistics are available. Run:")
+        print("  SELECT * FROM pg_stat_statements LIMIT 10;")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/pg-extensions.py
+++ b/.claude/skills/use-railway/scripts/pg-extensions.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+Manage PostgreSQL extensions for Railway database services.
+
+This script replicates the frontend's Extensions.tsx logic:
+- List available and installed extensions
+- Install extensions with automatic dependency handling
+- Uninstall extensions with dependency checking
+
+Usage:
+    pg-extensions.py --service <name> list
+    pg-extensions.py --service <name> install <extension> [--version <ver>]
+    pg-extensions.py --service <name> uninstall <extension>
+    pg-extensions.py --service <name> info <extension>
+
+Requires: railway CLI linked to the correct project/environment
+
+IMPORTANT: Install and uninstall require interactive terminal confirmation.
+They cannot be run with piped input - the user must confirm directly.
+"""
+
+import argparse
+import sys
+import json
+from typing import Tuple, List, Optional, Dict, Any
+from dataclasses import dataclass
+
+from dal import run_psql_query, info, error, confirm_with_user
+
+
+@dataclass
+class Extension:
+    """PostgreSQL extension info."""
+    name: str
+    default_version: str
+    installed_version: Optional[str]
+    comment: str
+
+
+def list_extensions(service: str, json_output: bool = False) -> List[Extension]:
+    """List all available and installed extensions."""
+    # Query available extensions
+    available_query = "SELECT name, default_version, comment FROM pg_available_extensions ORDER BY name"
+    code, output = run_psql_query(service, available_query)
+    if code != 0:
+        error(f"Failed to query available extensions: {output}")
+
+    # Parse available extensions
+    available = {}
+    for line in output.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:
+            name = parts[0].strip()
+            version = parts[1].strip()
+            comment = parts[2].strip() if len(parts) > 2 else ""
+            available[name] = {"version": version, "comment": comment}
+
+    # Query installed extensions
+    installed_query = "SELECT extname, extversion FROM pg_extension"
+    code, output = run_psql_query(service, installed_query)
+    if code != 0:
+        error(f"Failed to query installed extensions: {output}")
+
+    # Parse installed extensions
+    installed = {}
+    for line in output.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:
+            name = parts[0].strip()
+            version = parts[1].strip()
+            installed[name] = version
+
+    # Build extension list
+    extensions = []
+    for name, info in available.items():
+        ext = Extension(
+            name=name,
+            default_version=info["version"],
+            installed_version=installed.get(name),
+            comment=info["comment"]
+        )
+        extensions.append(ext)
+
+    if json_output:
+        print(json.dumps([{
+            "name": e.name,
+            "defaultVersion": e.default_version,
+            "installedVersion": e.installed_version,
+            "comment": e.comment
+        } for e in extensions], indent=2))
+    else:
+        # Print formatted output
+        installed_exts = [e for e in extensions if e.installed_version]
+        available_exts = [e for e in extensions if not e.installed_version]
+
+        print(f"\n{len(installed_exts)} Extension(s) installed:")
+        print("-" * 60)
+        if installed_exts:
+            for e in sorted(installed_exts, key=lambda x: x.name):
+                print(f"  {e.name} (v{e.installed_version})")
+        else:
+            print("  (none)")
+
+        print(f"\n{len(available_exts)} Extension(s) available:")
+        print("-" * 60)
+        for e in sorted(available_exts, key=lambda x: x.name)[:30]:
+            desc = f" - {e.comment[:50]}..." if e.comment and len(e.comment) > 50 else f" - {e.comment}" if e.comment else ""
+            print(f"  {e.name} (v{e.default_version}){desc}")
+        if len(available_exts) > 30:
+            print(f"  ... and {len(available_exts) - 30} more")
+
+    return extensions
+
+
+def get_extension_dependencies(service: str, extension: str) -> List[str]:
+    """Get dependencies for an extension."""
+    query = f"""
+        SELECT DISTINCT unnest(pev.requires) as dependency
+        FROM pg_available_extension_versions pev
+        WHERE pev.name = '{extension}' AND pev.requires IS NOT NULL
+        ORDER BY dependency
+    """
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        return []
+
+    deps = []
+    for line in output.strip().split("\n"):
+        if line.strip():
+            deps.append(line.strip())
+    return deps
+
+
+def get_extension_dependents(service: str, extension: str) -> List[str]:
+    """Get extensions that depend on this extension."""
+    query = f"""
+        SELECT e.extname AS dependent_extension
+        FROM pg_depend d
+        JOIN pg_extension e ON d.objid = e.oid
+        JOIN pg_extension ref_e ON d.refobjid = ref_e.oid
+        WHERE d.classid = 'pg_extension'::regclass
+            AND d.refclassid = 'pg_extension'::regclass
+            AND ref_e.extname = '{extension}'
+        ORDER BY dependent_extension
+    """
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        return []
+
+    dependents = []
+    for line in output.strip().split("\n"):
+        if line.strip():
+            dependents.append(line.strip())
+    return dependents
+
+
+def is_extension_installed(service: str, extension: str) -> Tuple[bool, Optional[str]]:
+    """Check if extension is installed, return (installed, version)."""
+    query = f"SELECT extversion FROM pg_extension WHERE extname = '{extension}'"
+    code, output = run_psql_query(service, query)
+    if code == 0 and output.strip():
+        return True, output.strip()
+    return False, None
+
+
+def is_extension_available(service: str, extension: str) -> bool:
+    """Check if extension is available in the image."""
+    query = f"SELECT 1 FROM pg_available_extensions WHERE name = '{extension}'"
+    code, output = run_psql_query(service, query)
+    return code == 0 and output.strip() == "1"
+
+
+def install_extension(service: str, extension: str, version: Optional[str] = None) -> bool:
+    """Install an extension with CASCADE (auto-install dependencies)."""
+    # Check if available
+    if not is_extension_available(service, extension):
+        error(f"Extension '{extension}' is not available in this database image")
+
+    # Check if already installed
+    installed, curr_ver = is_extension_installed(service, extension)
+    if installed:
+        info(f"Extension '{extension}' is already installed (v{curr_ver})")
+        return True
+
+    # Check dependencies and confirm - REQUIRES interactive terminal
+    deps = get_extension_dependencies(service, extension)
+    if deps:
+        print(f"\nInstalling '{extension}' will also install these dependencies: {', '.join(deps)}")
+    else:
+        print(f"\nAbout to install extension '{extension}'")
+
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return False
+
+    # Build install query
+    query = f'CREATE EXTENSION IF NOT EXISTS "{extension}"'
+    if version:
+        query += f" VERSION '{version}'"
+    query += " CASCADE"  # Auto-install dependencies
+
+    info(f"Installing extension '{extension}'...")
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to install extension: {output}")
+
+    # Verify installation
+    installed, ver = is_extension_installed(service, extension)
+    if installed:
+        info(f"Successfully installed '{extension}' (v{ver})")
+        if deps:
+            info(f"Dependencies installed: {', '.join(deps)}")
+        return True
+    else:
+        error("Extension installation failed - not found after CREATE EXTENSION")
+    return False
+
+
+def uninstall_extension(service: str, extension: str) -> bool:
+    """Uninstall an extension."""
+    # Check if installed
+    installed, ver = is_extension_installed(service, extension)
+    if not installed:
+        info(f"Extension '{extension}' is not installed")
+        return True
+
+    # Check for dependents
+    dependents = get_extension_dependents(service, extension)
+    if dependents:
+        error(f"Cannot uninstall '{extension}' - these extensions depend on it: {', '.join(dependents)}")
+
+    # Confirm - REQUIRES interactive terminal
+    print(f"\nAbout to uninstall '{extension}' (v{ver})")
+    if not confirm_with_user("Continue? [y/N]"):
+        print("Cancelled.")
+        return False
+
+    # Uninstall
+    query = f'DROP EXTENSION IF EXISTS "{extension}"'
+    info(f"Uninstalling extension '{extension}'...")
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to uninstall extension: {output}")
+
+    # Verify
+    installed, _ = is_extension_installed(service, extension)
+    if not installed:
+        info(f"Successfully uninstalled '{extension}'")
+        return True
+    else:
+        error("Extension uninstall failed - still found after DROP EXTENSION")
+    return False
+
+
+def extension_info(service: str, extension: str, json_output: bool = False):
+    """Show detailed info about an extension."""
+    # Check availability
+    available = is_extension_available(service, extension)
+    if not available:
+        error(f"Extension '{extension}' is not available in this database image")
+
+    # Get info
+    query = f"SELECT name, default_version, comment FROM pg_available_extensions WHERE name = '{extension}'"
+    code, output = run_psql_query(service, query)
+    if code != 0:
+        error(f"Failed to get extension info: {output}")
+
+    parts = output.strip().split("|")
+    name = parts[0].strip() if parts else extension
+    default_version = parts[1].strip() if len(parts) > 1 else "unknown"
+    comment = parts[2].strip() if len(parts) > 2 else ""
+
+    installed, installed_version = is_extension_installed(service, extension)
+    deps = get_extension_dependencies(service, extension)
+    dependents = get_extension_dependents(service, extension) if installed else []
+
+    if json_output:
+        print(json.dumps({
+            "name": name,
+            "defaultVersion": default_version,
+            "installedVersion": installed_version,
+            "comment": comment,
+            "dependencies": deps,
+            "dependents": dependents
+        }, indent=2))
+    else:
+        print(f"\nExtension: {name}")
+        print("-" * 40)
+        print(f"  Default Version: {default_version}")
+        print(f"  Installed: {'Yes (v' + installed_version + ')' if installed else 'No'}")
+        if comment:
+            print(f"  Description: {comment}")
+        if deps:
+            print(f"  Dependencies: {', '.join(deps)}")
+        if dependents:
+            print(f"  Required by: {', '.join(dependents)}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Manage PostgreSQL extensions for Railway services.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  List all extensions (safe, no confirmation needed):
+    pg-extensions.py --service my-postgres list
+
+  Install an extension (requires interactive confirmation):
+    pg-extensions.py --service my-postgres install postgis
+    pg-extensions.py --service my-postgres install pgvector --version 0.5.0
+
+  Uninstall an extension (requires interactive confirmation):
+    pg-extensions.py --service my-postgres uninstall postgis
+
+  Get extension info (safe, no confirmation needed):
+    pg-extensions.py --service my-postgres info pg_stat_statements
+
+IMPORTANT: Install and uninstall require interactive terminal confirmation.
+They cannot be automated or run with piped input.
+        """
+    )
+
+    parser.add_argument("--service", required=True, help="Service name (requires linked project)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # list command (safe - no confirmation)
+    list_parser = subparsers.add_parser("list", help="List available and installed extensions")
+
+    # install command (requires interactive confirmation)
+    install_parser = subparsers.add_parser("install", help="Install an extension (requires confirmation)")
+    install_parser.add_argument("extension", help="Extension name")
+    install_parser.add_argument("--version", "-v", help="Specific version to install")
+
+    # uninstall command (requires interactive confirmation)
+    uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall an extension (requires confirmation)")
+    uninstall_parser.add_argument("extension", help="Extension name")
+
+    # info command
+    info_parser = subparsers.add_parser("info", help="Show extension info")
+    info_parser.add_argument("extension", help="Extension name")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    service = args.service
+
+    if args.command == "list":
+        list_extensions(service, json_output=args.json)
+    elif args.command == "install":
+        install_extension(service, args.extension, version=args.version)
+    elif args.command == "uninstall":
+        uninstall_extension(service, args.extension)
+    elif args.command == "info":
+        extension_info(service, args.extension, json_output=args.json)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/use-railway/scripts/railway-api.sh
+++ b/.claude/skills/use-railway/scripts/railway-api.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Railway GraphQL API helper
+# Usage: railway-api.sh '<graphql-query>' ['<variables-json>']
+
+set -e
+
+SKILL_ID="use-railway"
+SKILL_VERSION="${RAILWAY_SKILL_VERSION:-1.1.3}"
+
+export RAILWAY_CALLER="${RAILWAY_CALLER:-skill:${SKILL_ID}@${SKILL_VERSION}}"
+export RAILWAY_AGENT_SESSION="${RAILWAY_AGENT_SESSION:-railway-skill-$(date +%s)-$$}"
+
+if ! command -v jq &>/dev/null; then
+  echo '{"error": "jq not installed. Install with: brew install jq"}'
+  exit 1
+fi
+
+CONFIG_FILE="$HOME/.railway/config.json"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo '{"error": "Railway config not found. Run: railway login"}'
+  exit 1
+fi
+
+TOKEN=$(jq -r '.user.token' "$CONFIG_FILE")
+
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo '{"error": "No Railway token found. Run: railway login"}'
+  exit 1
+fi
+
+if [[ -z "$1" ]]; then
+  echo '{"error": "No query provided"}'
+  exit 1
+fi
+
+# Build payload with query and optional variables
+if [[ -n "$2" ]]; then
+  PAYLOAD=$(jq -n --arg q "$1" --argjson v "$2" '{query: $q, variables: $v}')
+else
+  PAYLOAD=$(jq -n --arg q "$1" '{query: $q}')
+fi
+
+HEADERS=(
+  -H "Authorization: Bearer $TOKEN"
+  -H "Content-Type: application/json"
+  -H "X-Railway-Skill-Id: $SKILL_ID"
+  -H "X-Railway-Skill-Version: $SKILL_VERSION"
+  -H "X-Railway-Agent-Session: $RAILWAY_AGENT_SESSION"
+)
+
+curl -s https://backboard.railway.com/graphql/v2 "${HEADERS[@]}" -d "$PAYLOAD"

--- a/.claude/skills/workos-widgets/SKILL.md
+++ b/.claude/skills/workos-widgets/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: workos-widgets
+description: Use when the user is implementing, embedding, or debugging a WorkOS Widget — specifically the User Management, User Profile, Admin Portal SSO Connection, or Admin Portal Domain Verification widgets. Handles the full stack — detecting the frontend (Next.js, React, React Router, TanStack Start, Vite, SvelteKit), generating access tokens via the backend SDK in use (Node, Python, Go, Ruby, PHP, Java, .NET), and wiring up the widget component correctly per the bundled OpenAPI spec. Also use when code imports from @workos-inc/widgets or the user pastes <UserManagement /> or <UserProfile /> JSX.
+---
+
+# WorkOS Widgets
+
+## Workflow Overview
+
+1. Identify widget target from the user request (`user-management`, `user-profile`, `admin-portal-sso-connection`, `admin-portal-domain-verification`).
+2. Scan project files in this order:
+   - package/dependency manifests
+   - framework/router entrypoints
+   - auth/token utilities
+   - styling/component patterns
+3. Detect stack, data-layer style, styling, component system, and package manager using [references/detection.md](references/detection.md).
+4. Check for AuthKit/WorkOS presence:
+   - if detected, continue;
+   - if not detected, ask the user to run `npx workos@latest install`, wait for confirmation, then continue.
+5. If detection is ambiguous or conflicting, ask one focused question, then continue.
+6. Load only the relevant reference files for the detected stack and widget.
+7. Implement integration based on stack shape:
+   - frontend route/page + widget component when widget UI lives in the same app
+   - token endpoint/service + client integration surface when backend-first/multi-app architecture is detected
+8. Validate routing/wiring, imports, and token/API usage before finishing.
+
+## Canonical Inputs
+
+Accept these inputs from the user request when available:
+
+- widget type (or infer from request intent)
+- optional component path
+- optional page/route path
+- optional token endpoint/service preference
+- optional constraints (for example: avoid broad refactors)
+
+When input is missing, infer from existing project conventions and detected stack.
+
+## Detection and Ambiguity Protocol
+
+- Apply detection heuristics from [references/detection.md](references/detection.md).
+- Explore before asking. Ask only when ambiguity remains after checking manifests and route/auth entrypoints.
+- Ask a single concrete question that resolves one decision.
+- Default to the strongest detected ownership signals when no user response is available.
+- When installs are required, use the package manager detected from project files/lockfiles.
+
+## Reference Loading Map
+
+Always load these core references:
+
+- [references/detection.md](references/detection.md)
+- [references/token-strategies.md](references/token-strategies.md)
+- [references/fetching-apis.md](references/fetching-apis.md)
+- [references/styling-and-components.md](references/styling-and-components.md)
+
+For React/TypeScript stacks (Next.js, React Router, TanStack Router, TanStack Start, Vite), also load:
+
+- [references/react-ts-standards.md](references/react-ts-standards.md)
+
+Load stack-specific reference guidance:
+
+- Next.js: [references/framework-nextjs.md](references/framework-nextjs.md)
+- React Router: [references/framework-react-router.md](references/framework-react-router.md)
+- TanStack Router: [references/framework-tanstack-router.md](references/framework-tanstack-router.md)
+- TanStack Start: [references/framework-tanstack-start.md](references/framework-tanstack-start.md)
+- Vite: [references/framework-vite.md](references/framework-vite.md)
+- SvelteKit: [references/framework-sveltekit.md](references/framework-sveltekit.md)
+- Ruby: [references/framework-ruby.md](references/framework-ruby.md)
+- Python: [references/framework-python.md](references/framework-python.md)
+- Go: [references/framework-go.md](references/framework-go.md)
+- PHP: [references/framework-php.md](references/framework-php.md)
+- Java: [references/framework-java.md](references/framework-java.md)
+- Mixed repositories: [references/framework-mixed-repositories.md](references/framework-mixed-repositories.md)
+
+Then load exactly one widget reference:
+
+- User Management: [references/widget-user-management.md](references/widget-user-management.md)
+- User Profile: [references/widget-user-profile.md](references/widget-user-profile.md)
+- Admin Portal SSO Connection: [references/widget-admin-portal-sso-connection.md](references/widget-admin-portal-sso-connection.md)
+- Admin Portal Domain Verification: [references/widget-admin-portal-domain-verification.md](references/widget-admin-portal-domain-verification.md)
+
+## Global Widget Guidance
+
+- Implement widget operations using endpoint paths/methods from [references/fetching-apis.md](references/fetching-apis.md). When building request bodies or parsing responses, query the OpenAPI spec for the relevant widget's schemas:
+  ```bash
+  node references/scripts/query-spec.cjs --widget <widget-name>
+  ```
+  Use `--list` to see available widget groups.
+- Keep loading, empty, and error states explicit and user-visible.
+- Keep mutation outcomes visible and refresh/reload affected data after successful changes.
+- Align table/list/action UI with existing project conventions.
+- Keep behavior resilient for partial/optional data and avoid brittle UI assumptions.
+
+## Core Guidelines
+
+- Reuse existing domain types from the host project and OpenAPI schemas; avoid duplicating model definitions.
+- Build widget requests using [references/fetching-apis.md](references/fetching-apis.md) for paths, methods, and schema queries.
+- Use direct `fetch`/HTTP calls (or equivalent server HTTP client) for endpoint calls.
+- Implement a consistent authorization layer for widget requests, including elevated-token handling for sensitive endpoints when required.
+- If the app already uses React Query or SWR, use them as orchestration/cache layers around those direct calls.
+- For React/TypeScript widget code quality expectations, follow [references/react-ts-standards.md](references/react-ts-standards.md).
+- If AuthKit/WorkOS is missing, prompt the user to run `npx workos@latest install` before continuing.
+- Install additional dependencies only when strictly necessary, using the detected package manager/tooling.
+- Keep server-state handling aligned with the selected data-layer approach.
+- Use local state/reducers for UI interaction state as needed.
+- Prefer existing design system and styling conventions.
+- Avoid broad unrelated refactors and global style rewrites.
+
+## Completion Requirements
+
+Before finishing, verify all relevant items:
+
+1. Widget component exists and accepts `accessToken: string` when component-level integration is in scope.
+2. Route/page wiring is complete when route integration is in scope.
+3. Token source matches existing app architecture (AuthKit client flow or backend WorkOS token flow).
+4. API methods and paths match the bundled OpenAPI spec, and data-layer usage matches project conventions.
+5. Loading and error branches exist for required query/mutation flows.
+
+## Validation Checklist
+
+1. Confirm endpoint paths and HTTP methods come from the bundled OpenAPI spec.
+2. Confirm request/response handling follows schema expectations from the spec.
+3. Confirm query/mutation invalidation/refetch is applied after successful mutations where required.
+4. Confirm empty/error/loading states are explicit and user-visible.
+5. Confirm package installs (if any) used the detected package manager/tooling.
+6. Confirm implementation stays aligned with existing codebase conventions.
+7. Confirm no existing component has been passed `className` or `style` props to override its built-in styling. Use each component as-is or via its own props API (`variant`, `size`, etc.).

--- a/.claude/skills/workos-widgets/references/detection.md
+++ b/.claude/skills/workos-widgets/references/detection.md
@@ -1,0 +1,89 @@
+# Detection
+
+## Objective
+
+Identify the active stack and integration surface using repository signals, then choose an approach that fits existing architecture.
+
+## Suggested Scan Order
+
+1. dependency manifests (`package.json`, `Gemfile`, `composer.json`, `pyproject.toml`, `requirements*.txt`, `go.mod`, `pom.xml`, `build.gradle*`)
+2. framework/router entrypoints
+3. auth and token utilities
+4. styling and component patterns
+5. package manager and lockfiles
+
+## Common Stack Signals
+
+### JavaScript/TypeScript
+
+- Next.js: `next`
+- TanStack Start: `@tanstack/react-start`
+- TanStack Router: `@tanstack/react-router`
+- React Router: `react-router` or `react-router-dom`
+- Vite: `vite` or `vite.config.*`
+- SvelteKit: `@sveltejs/kit` or `svelte.config.*`
+
+### Other Stacks
+
+- Ruby: `Gemfile` and WorkOS/AuthKit gems
+- PHP: `composer.json` and WorkOS/AuthKit packages
+- Python: `pyproject.toml` or `requirements*.txt` with WorkOS/AuthKit packages
+- Go: `go.mod` with `github.com/workos/workos-go`
+- Java: `pom.xml` or `build.gradle*` with WorkOS dependencies/imports
+
+## AuthKit/WorkOS Presence Signals
+
+Look for any existing AuthKit/WorkOS usage before implementing widgets.
+
+- JavaScript/TypeScript: `@workos-inc/*`, `@workos/*`, or WorkOS/AuthKit imports in app/server code
+- Ruby: WorkOS/AuthKit gems or initialization code
+- PHP: WorkOS/AuthKit composer packages or bootstrap usage
+- Python: WorkOS/AuthKit packages/imports and config usage
+- Go: WorkOS Go module imports/config
+- Java: WorkOS Java dependency/imports/config
+
+If no AuthKit/WorkOS signal is found, see SKILL.md step 4.
+
+## Detection Heuristics
+
+- Prefer entrypoint ownership over dependency names alone.
+- In mixed repositories, identify which app owns UI rendering and which service owns token generation.
+- Use the strongest cluster of signals, then validate by checking real route/auth files.
+
+## Data-Layer Signals
+
+- React Query signal: `@tanstack/react-query`
+- SWR signal: `swr`
+- No query library signal: use the project's native async/data approach with direct fetch/http calls.
+
+When React Query or SWR is already established, keep using it for caching/invalidation and wrap direct endpoint calls with it.
+
+## Package Manager/Tool Detection
+
+Use the project's existing package manager/tooling when installing missing dependencies.
+
+- JavaScript/TypeScript:
+  - `pnpm-lock.yaml` -> `pnpm`
+  - `yarn.lock` -> `yarn`
+  - `bun.lockb` or `bun.lock` -> `bun`
+  - `package-lock.json` -> `npm`
+  - if unclear, use existing install scripts or ask once
+- Ruby: use `bundle`/Bundler with `Gemfile`
+- PHP: use `composer` with `composer.json`
+- Python: follow existing tooling (`poetry.lock`, `uv.lock`, `requirements*.txt`, or existing project scripts)
+- Go: use Go modules tooling (`go mod` / existing project scripts)
+- Java: follow project tooling (`mvn`/Maven or `gradle`/Gradle wrappers)
+
+Install dependencies only when strictly necessary for the selected integration approach.
+
+## Ambiguity Handling
+
+- If multiple stacks/frameworks look active, ask one focused question.
+- If ownership is still unclear, choose the least invasive path and note assumptions.
+
+## Focused Question Examples
+
+- "I found multiple routers. Which one currently owns app routes?"
+- "I found backend and frontend apps. Which app should host the widget UI?"
+- "I found multiple data-fetching patterns. Which one should new widget code follow?"
+- "I found multiple services that could issue widget tokens. Which one should own token generation?"

--- a/.claude/skills/workos-widgets/references/fetching-apis.md
+++ b/.claude/skills/workos-widgets/references/fetching-apis.md
@@ -1,0 +1,129 @@
+# Fetching APIs
+
+## Objective
+
+Implement Widgets API calls using the endpoint tables and query script below, matching the host application's data layer.
+
+## Source of Truth
+
+Use the endpoint tables below for paths and methods. For request/response schemas, run:
+
+```bash
+node references/scripts/query-spec.cjs --widget <widget-name>
+```
+
+## Guidance
+
+- Build direct fetch/http client functions from the OpenAPI endpoints.
+- Keep request and mutation handling consistent with existing code style.
+- If React Query or SWR already exists, use it for query/mutation orchestration on top of the direct endpoint functions.
+- Prefer one consistent data pattern per widget flow unless the project already mixes patterns.
+- Reuse existing error/loading conventions from the host project.
+
+## Base URL
+
+Use `process.env.WORKOS_BASE_API_URL` (or the equivalent env access for the stack) as the base URL for all widget API calls. Fall back to `https://api.workos.com` when the env variable is not set.
+
+## Authorization Layer
+
+- Add a small shared request layer that injects authorization consistently for all widget calls.
+- Send the widget bearer token in the app's standard authenticated request path.
+- Keep authorization wiring close to existing auth/session utilities instead of duplicating token logic across components.
+- Handle `401`/`403` responses explicitly and surface clear recovery actions.
+
+## Error Responses
+
+All error responses (`400`, `403`, `404`, `422`) return a JSON object with a single `message` string field:
+
+```json
+{ "message": "Description of the error" }
+```
+
+For full request/response schemas, run `node references/scripts/query-spec.cjs --widget <widget-name>`.
+
+## Elevated Access Endpoints
+
+- Check the endpoint's description (via `node references/scripts/query-spec.cjs --widget <widget-name>`) **before calling it** — not on failure. If it mentions elevated access, acquire the elevated token first.
+- Use `POST /_widgets/UserProfile/verify` to obtain an elevated token, then pass it in header `x-elevated-access-token`.
+- Treat elevated tokens as short-lived (10 minutes) and scope them to sensitive operations only.
+
+## Endpoint Reference
+
+All available endpoints, grouped by widget. For request/response schemas, run `node references/scripts/query-spec.cjs --widget <widget-name>`.
+
+### User Management
+
+| Method   | Path                                               |
+| -------- | -------------------------------------------------- |
+| `GET`    | `/_widgets/UserManagement/members`                 |
+| `POST`   | `/_widgets/UserManagement/members/{userId}`        |
+| `DELETE` | `/_widgets/UserManagement/members/{userId}`        |
+| `GET`    | `/_widgets/UserManagement/roles`                   |
+| `GET`    | `/_widgets/UserManagement/roles-and-config`        |
+| `GET`    | `/_widgets/UserManagement/organizations`           |
+| `POST`   | `/_widgets/UserManagement/invite-user`             |
+| `POST`   | `/_widgets/UserManagement/invites/{userId}/resend` |
+| `DELETE` | `/_widgets/UserManagement/invites/{userId}`        |
+
+### User Profile
+
+| Method   | Path                                                     |
+| -------- | -------------------------------------------------------- |
+| `GET`    | `/_widgets/UserProfile/me`                               |
+| `POST`   | `/_widgets/UserProfile/me`                               |
+| `GET`    | `/_widgets/UserProfile/authentication-information`       |
+| `POST`   | `/_widgets/UserProfile/send-verification`                |
+| `POST`   | `/_widgets/UserProfile/verify`                           |
+| `POST`   | `/_widgets/UserProfile/update-password`                  |
+| `POST`   | `/_widgets/UserProfile/create-password` ⚠️ elevated      |
+| `POST`   | `/_widgets/UserProfile/create-totp-factor` ⚠️ elevated   |
+| `POST`   | `/_widgets/UserProfile/verify-totp-factor` ⚠️ elevated   |
+| `DELETE` | `/_widgets/UserProfile/totp-factors` ⚠️ elevated         |
+| `POST`   | `/_widgets/UserProfile/passkeys` ⚠️ elevated             |
+| `POST`   | `/_widgets/UserProfile/passkeys/verify` ⚠️ elevated      |
+| `DELETE` | `/_widgets/UserProfile/passkeys/{passkeyId}` ⚠️ elevated |
+| `GET`    | `/_widgets/UserProfile/sessions`                         |
+| `DELETE` | `/_widgets/UserProfile/sessions/revoke/{sessionId}`      |
+| `DELETE` | `/_widgets/UserProfile/sessions/revoke-all`              |
+
+### Admin Portal — SSO Connection
+
+| Method | Path                                     |
+| ------ | ---------------------------------------- |
+| `GET`  | `/_widgets/admin-portal/sso-connections` |
+| `POST` | `/_widgets/admin-portal/generate-link`   |
+
+### Admin Portal — Domain Verification
+
+| Method   | Path                                                              |
+| -------- | ----------------------------------------------------------------- |
+| `GET`    | `/_widgets/admin-portal/organization-domains`                     |
+| `DELETE` | `/_widgets/admin-portal/organization-domains/{domainId}`          |
+| `POST`   | `/_widgets/admin-portal/organization-domains/{domainId}/reverify` |
+| `POST`   | `/_widgets/admin-portal/generate-link`                            |
+
+### Other
+
+| Method   | Path                                                                          |
+| -------- | ----------------------------------------------------------------------------- |
+| `GET`    | `/_widgets/settings`                                                          |
+| `POST`   | `/_widgets/ApiKeys/organization-api-keys`                                     |
+| `GET`    | `/_widgets/ApiKeys/organization-api-keys`                                     |
+| `GET`    | `/_widgets/ApiKeys/permissions`                                               |
+| `DELETE` | `/_widgets/ApiKeys/{apiKeyId}`                                                |
+| `GET`    | `/_widgets/DataIntegrations/mine`                                             |
+| `GET`    | `/_widgets/DataIntegrations/{slug}/authorize`                                 |
+| `GET`    | `/_widgets/DataIntegrations/{dataIntegrationId}/authorization-status/{state}` |
+| `DELETE` | `/_widgets/DataIntegrations/installations/{installationId}`                   |
+| `GET`    | `/_widgets/directory-sync/directories`                                        |
+| `GET`    | `/_widgets/directory-sync/directories/{directoryId}`                          |
+
+## Pagination
+
+List endpoints use cursor-based pagination. Query parameters:
+
+- `limit` — number of results per page
+- `before` — cursor for the previous page
+- `after` — cursor for the next page
+
+Responses include a `list_metadata` object with `before` and `after` cursor strings. Pass `after` from the current response as the `after` param of the next request to advance pages.

--- a/.claude/skills/workos-widgets/references/framework-go.md
+++ b/.claude/skills/workos-widgets/references/framework-go.md
@@ -1,0 +1,34 @@
+# Framework: Go
+
+## Scope
+
+Use this guide for Go services that issue widget tokens and support widget API integration.
+
+## Guidance
+
+- Use the official WorkOS Go SDK.
+- Keep API key in environment configuration.
+- Place token generation in existing handler/service layers.
+- Reuse existing auth/session middleware to derive organization/user identifiers.
+
+## Token Pattern
+
+```go
+import (
+  "context"
+  "os"
+
+  "github.com/workos/workos-go/v4/pkg/widgets"
+)
+
+widgets.SetAPIKey(os.Getenv("WORKOS_API_KEY"))
+
+token, err := widgets.GetToken(
+  context.Background(),
+  widgets.GetTokenOpts{
+    OrganizationID: organizationID,
+    UserID:         userID,
+    Scopes:         []widgets.WidgetScope{widgets.UsersTableManage},
+  },
+)
+```

--- a/.claude/skills/workos-widgets/references/framework-java.md
+++ b/.claude/skills/workos-widgets/references/framework-java.md
@@ -1,0 +1,32 @@
+# Framework: Java
+
+## Scope
+
+Use this guide for Java services/apps that issue widget tokens and support widget integrations.
+
+## Guidance
+
+- Use the official WorkOS Java SDK.
+- Keep API key in environment configuration.
+- Place token creation in existing service/controller boundaries.
+- Reuse existing auth/session context for organization and user identifiers.
+
+## Token Pattern
+
+```java
+import com.workos.WorkOS;
+import com.workos.widgets.WidgetsApi.GetTokenOptions;
+import com.workos.widgets.models.WidgetScope;
+import com.workos.widgets.models.WidgetTokenResponse;
+
+WorkOS workos = new WorkOS(System.getenv("WORKOS_API_KEY"));
+
+GetTokenOptions options = GetTokenOptions.builder()
+    .organizationID(organizationId)
+    .userID(userId)
+    .scopes(Arrays.asList(WidgetScope.WidgetsUsersTableManage))
+    .build();
+
+WidgetTokenResponse response = workos.widgets.getToken(options);
+String token = response.token;
+```

--- a/.claude/skills/workos-widgets/references/framework-mixed-repositories.md
+++ b/.claude/skills/workos-widgets/references/framework-mixed-repositories.md
@@ -1,0 +1,13 @@
+# Framework: Mixed Repositories
+
+## Objective
+
+Handle repositories with multiple apps/services by integrating widgets at existing boundaries.
+
+## Guidance
+
+- Detect which app owns widget UI rendering.
+- Detect which service owns authenticated token generation.
+- Keep each side in its native conventions and integrate through existing API boundaries.
+- Avoid broad architecture moves when additive wiring is enough.
+- If unsure, prompt the user.

--- a/.claude/skills/workos-widgets/references/framework-nextjs.md
+++ b/.claude/skills/workos-widgets/references/framework-nextjs.md
@@ -1,0 +1,13 @@
+# Framework: Next.js
+
+## Guidance
+
+- Detect whether the project uses App Router or Pages Router, then follow that structure.
+- Place widget routes/pages where existing route modules live.
+- Keep token acquisition in the same server/client boundary already used by the app.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Integrate widget components through existing layout and provider patterns.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. Token generation belongs in a Next.js server boundary (Server Component, Route Handler, or `getServerSideProps`).

--- a/.claude/skills/workos-widgets/references/framework-php.md
+++ b/.claude/skills/workos-widgets/references/framework-php.md
@@ -1,0 +1,29 @@
+# Framework: PHP
+
+## Scope
+
+Use this guide for PHP apps (for example Laravel/Symfony) that create widget tokens and integrate widget APIs.
+
+## Guidance
+
+- Use the official WorkOS PHP SDK.
+- Keep API key in environment configuration.
+- Place token generation in existing controller/service boundaries.
+- Reuse current auth/session context to resolve organization/user identifiers.
+
+## Token Pattern
+
+```php
+<?php
+
+use WorkOS\Resource\WidgetScope;
+
+WorkOS\WorkOS::setApiKey($_ENV['WORKOS_API_KEY']);
+
+$widgets = new WorkOS\Widgets();
+$token_response = $widgets->getToken(
+    organization_id: $organizationId,
+    user_id: $userId,
+    scopes: [WidgetScope::UsersTableManage]
+);
+```

--- a/.claude/skills/workos-widgets/references/framework-python.md
+++ b/.claude/skills/workos-widgets/references/framework-python.md
@@ -1,0 +1,29 @@
+# Framework: Python
+
+## Scope
+
+Use this guide for Python apps (for example Django/Flask/FastAPI) that generate widget tokens and/or broker widget API requests.
+
+## Guidance
+
+- Use the official WorkOS Python SDK.
+- Keep API key and client id in environment configuration.
+- Place token generation in existing service/view/router boundaries.
+- Reuse established auth/session context for `organization_id` and `user_id`.
+
+## Token Pattern
+
+```py
+from workos import WorkOSClient
+
+workos_client = WorkOSClient(
+    api_key=os.environ["WORKOS_API_KEY"],
+    client_id=os.environ["WORKOS_CLIENT_ID"],
+)
+
+token_response = workos_client.widgets.get_token(
+    organization_id=organization_id,
+    user_id=user_id,
+    scopes=["widgets:users-table:manage"],
+)
+```

--- a/.claude/skills/workos-widgets/references/framework-react-router.md
+++ b/.claude/skills/workos-widgets/references/framework-react-router.md
@@ -1,0 +1,13 @@
+# Framework: React Router
+
+## Guidance
+
+- Follow the repository's route definition style (file-based or config-based).
+- Add widget routes/components in the same structure used by existing features.
+- Reuse existing loader/action or component-level token patterns.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Preserve current router/provider setup and conventions.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. Token generation belongs in a loader, action, or dedicated server route.

--- a/.claude/skills/workos-widgets/references/framework-ruby.md
+++ b/.claude/skills/workos-widgets/references/framework-ruby.md
@@ -1,0 +1,28 @@
+# Framework: Ruby
+
+## Scope
+
+Use this guide for Ruby apps (for example Rails/Sinatra) that generate widget tokens and/or proxy widget API calls.
+
+## Guidance
+
+- Use the official WorkOS Ruby SDK.
+- Keep API key in environment configuration.
+- Place token generation in existing service/controller boundaries.
+- Reuse existing session/auth context to resolve `organization_id` and `user_id`.
+
+## Token Pattern
+
+```rb
+require "workos"
+
+WorkOS.configure do |config|
+  config.key = ENV.fetch("WORKOS_API_KEY")
+end
+
+token = WorkOS::Widgets.get_token(
+  organization_id: organization_id,
+  user_id: user_id,
+  scopes: ["widgets:users-table:manage"]
+)
+```

--- a/.claude/skills/workos-widgets/references/framework-sveltekit.md
+++ b/.claude/skills/workos-widgets/references/framework-sveltekit.md
@@ -1,0 +1,13 @@
+# Framework: SvelteKit
+
+## Guidance
+
+- Follow existing `+page`, `+layout`, and `+server`/`+page.server` conventions.
+- Keep token generation in server/load boundaries that already handle auth/session context.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Keep frontend data calls aligned with current SvelteKit patterns.
+- Never embed a widget directly in a `+page.svelte`. Always extract it into its own `.svelte` component file. The page imports and renders that component.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. Token generation belongs in a `+page.server.ts`, `+layout.server.ts`, or `+server.ts` boundary.

--- a/.claude/skills/workos-widgets/references/framework-tanstack-router.md
+++ b/.claude/skills/workos-widgets/references/framework-tanstack-router.md
@@ -1,0 +1,13 @@
+# Framework: TanStack Router
+
+## Guidance
+
+- Follow current route module conventions and route tree workflow.
+- Place widget route files where the router expects them.
+- Keep token retrieval aligned with existing loader/client boundaries.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Reuse existing typing and routing patterns from the project.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. Token generation belongs in the route's loader or a dedicated server handler.

--- a/.claude/skills/workos-widgets/references/framework-tanstack-start.md
+++ b/.claude/skills/workos-widgets/references/framework-tanstack-start.md
@@ -1,0 +1,13 @@
+# Framework: TanStack Start
+
+## Guidance
+
+- Follow established Start route/file conventions.
+- Keep server/client boundaries consistent with existing auth and data flows.
+- Add widget integration with minimal structural changes.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Reuse current route and module organization patterns.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. Token generation belongs in a Start server function or server boundary.

--- a/.claude/skills/workos-widgets/references/framework-vite.md
+++ b/.claude/skills/workos-widgets/references/framework-vite.md
@@ -1,0 +1,13 @@
+# Framework: Vite
+
+## Guidance
+
+- Detect whether routing is framework-based or custom, then integrate accordingly.
+- Place widget pages/components in existing feature/page structure.
+- Reuse existing token/auth utilities rather than introducing new architecture.
+- For JS/TS token strategy details (AuthKit token vs backend `getToken` with scopes), follow [token-strategies.md](token-strategies.md).
+- Keep integration small and aligned with current app layout.
+
+## Server Token Pattern (JS/TS)
+
+For the token code pattern, see [token-strategies.md](token-strategies.md) → JS/TS Authorization Tokens. In a Vite app, token generation typically lives in an existing backend service or API route rather than the Vite dev server.

--- a/.claude/skills/workos-widgets/references/react-ts-standards.md
+++ b/.claude/skills/workos-widgets/references/react-ts-standards.md
@@ -1,0 +1,42 @@
+# React/TypeScript Standards
+
+## Objective
+
+Keep React + TypeScript widget code predictable, type-safe, and easy to maintain.
+
+## TypeScript Rules
+
+- Prefer inference and explicit interface/type definitions over type assertions.
+- Avoid `as` casts unless narrowing cannot be expressed safely another way.
+- Avoid `any`; use concrete types or `unknown` with safe narrowing.
+- Keep API response typing close to request functions and reuse shared domain types.
+
+## React State and Hooks Rules
+
+- Keep `useEffect` minimal and focused on true side effects.
+- Do not use `useEffect` for derivable render data.
+- Avoid `setState` inside `useEffect` unless syncing from external systems or subscriptions.
+- Prefer deriving values from props/query state with memoization only when needed.
+- Keep a single source of truth for server state (query/cache layer or explicit request state).
+- Use local state for transient UI interactions only.
+
+## Component Design Rules
+
+- Keep components small and composable; extract repeated logic into hooks/utilities.
+- Keep event handlers explicit and colocated with relevant UI.
+- Avoid deep prop drilling when existing context/provider patterns already exist.
+- Use clear loading/error/empty branches instead of implicit fallthrough behavior.
+- Never embed a widget directly in a page. Always extract it into its own component file. The page imports and renders that component.
+
+## Async and Mutation Rules
+
+- Keep async request functions separate from view rendering logic.
+- Prevent duplicate submits/actions while mutations are pending.
+- Reflect mutation success/failure in UI state clearly.
+- Refresh or invalidate affected data after successful mutations.
+
+## General Code Quality
+
+- Follow existing lint/format conventions in the host project.
+- Prefer readable code over clever abstractions.
+- Keep changes scoped to widget integration; avoid unrelated refactors.

--- a/.claude/skills/workos-widgets/references/scripts/query-spec.cjs
+++ b/.claude/skills/workos-widgets/references/scripts/query-spec.cjs
@@ -1,0 +1,7535 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js
+var require_identity = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/identity.js"(exports2) {
+    "use strict";
+    var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias");
+    var DOC = /* @__PURE__ */ Symbol.for("yaml.document");
+    var MAP = /* @__PURE__ */ Symbol.for("yaml.map");
+    var PAIR = /* @__PURE__ */ Symbol.for("yaml.pair");
+    var SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar");
+    var SEQ = /* @__PURE__ */ Symbol.for("yaml.seq");
+    var NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type");
+    var isAlias = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === ALIAS;
+    var isDocument = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === DOC;
+    var isMap = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
+    var isPair = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === PAIR;
+    var isScalar = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SCALAR;
+    var isSeq = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
+    function isCollection(node) {
+      if (node && typeof node === "object")
+        switch (node[NODE_TYPE]) {
+          case MAP:
+          case SEQ:
+            return true;
+        }
+      return false;
+    }
+    function isNode(node) {
+      if (node && typeof node === "object")
+        switch (node[NODE_TYPE]) {
+          case ALIAS:
+          case MAP:
+          case SCALAR:
+          case SEQ:
+            return true;
+        }
+      return false;
+    }
+    var hasAnchor = (node) => (isScalar(node) || isCollection(node)) && !!node.anchor;
+    exports2.ALIAS = ALIAS;
+    exports2.DOC = DOC;
+    exports2.MAP = MAP;
+    exports2.NODE_TYPE = NODE_TYPE;
+    exports2.PAIR = PAIR;
+    exports2.SCALAR = SCALAR;
+    exports2.SEQ = SEQ;
+    exports2.hasAnchor = hasAnchor;
+    exports2.isAlias = isAlias;
+    exports2.isCollection = isCollection;
+    exports2.isDocument = isDocument;
+    exports2.isMap = isMap;
+    exports2.isNode = isNode;
+    exports2.isPair = isPair;
+    exports2.isScalar = isScalar;
+    exports2.isSeq = isSeq;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js
+var require_visit = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/visit.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var BREAK = /* @__PURE__ */ Symbol("break visit");
+    var SKIP = /* @__PURE__ */ Symbol("skip children");
+    var REMOVE = /* @__PURE__ */ Symbol("remove node");
+    function visit(node, visitor) {
+      const visitor_ = initVisitor(visitor);
+      if (identity.isDocument(node)) {
+        const cd = visit_(null, node.contents, visitor_, Object.freeze([node]));
+        if (cd === REMOVE)
+          node.contents = null;
+      } else
+        visit_(null, node, visitor_, Object.freeze([]));
+    }
+    visit.BREAK = BREAK;
+    visit.SKIP = SKIP;
+    visit.REMOVE = REMOVE;
+    function visit_(key, node, visitor, path) {
+      const ctrl = callVisitor(key, node, visitor, path);
+      if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
+        replaceNode(key, path, ctrl);
+        return visit_(key, ctrl, visitor, path);
+      }
+      if (typeof ctrl !== "symbol") {
+        if (identity.isCollection(node)) {
+          path = Object.freeze(path.concat(node));
+          for (let i = 0; i < node.items.length; ++i) {
+            const ci = visit_(i, node.items[i], visitor, path);
+            if (typeof ci === "number")
+              i = ci - 1;
+            else if (ci === BREAK)
+              return BREAK;
+            else if (ci === REMOVE) {
+              node.items.splice(i, 1);
+              i -= 1;
+            }
+          }
+        } else if (identity.isPair(node)) {
+          path = Object.freeze(path.concat(node));
+          const ck = visit_("key", node.key, visitor, path);
+          if (ck === BREAK)
+            return BREAK;
+          else if (ck === REMOVE)
+            node.key = null;
+          const cv = visit_("value", node.value, visitor, path);
+          if (cv === BREAK)
+            return BREAK;
+          else if (cv === REMOVE)
+            node.value = null;
+        }
+      }
+      return ctrl;
+    }
+    async function visitAsync(node, visitor) {
+      const visitor_ = initVisitor(visitor);
+      if (identity.isDocument(node)) {
+        const cd = await visitAsync_(null, node.contents, visitor_, Object.freeze([node]));
+        if (cd === REMOVE)
+          node.contents = null;
+      } else
+        await visitAsync_(null, node, visitor_, Object.freeze([]));
+    }
+    visitAsync.BREAK = BREAK;
+    visitAsync.SKIP = SKIP;
+    visitAsync.REMOVE = REMOVE;
+    async function visitAsync_(key, node, visitor, path) {
+      const ctrl = await callVisitor(key, node, visitor, path);
+      if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
+        replaceNode(key, path, ctrl);
+        return visitAsync_(key, ctrl, visitor, path);
+      }
+      if (typeof ctrl !== "symbol") {
+        if (identity.isCollection(node)) {
+          path = Object.freeze(path.concat(node));
+          for (let i = 0; i < node.items.length; ++i) {
+            const ci = await visitAsync_(i, node.items[i], visitor, path);
+            if (typeof ci === "number")
+              i = ci - 1;
+            else if (ci === BREAK)
+              return BREAK;
+            else if (ci === REMOVE) {
+              node.items.splice(i, 1);
+              i -= 1;
+            }
+          }
+        } else if (identity.isPair(node)) {
+          path = Object.freeze(path.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path);
+          if (ck === BREAK)
+            return BREAK;
+          else if (ck === REMOVE)
+            node.key = null;
+          const cv = await visitAsync_("value", node.value, visitor, path);
+          if (cv === BREAK)
+            return BREAK;
+          else if (cv === REMOVE)
+            node.value = null;
+        }
+      }
+      return ctrl;
+    }
+    function initVisitor(visitor) {
+      if (typeof visitor === "object" && (visitor.Collection || visitor.Node || visitor.Value)) {
+        return Object.assign({
+          Alias: visitor.Node,
+          Map: visitor.Node,
+          Scalar: visitor.Node,
+          Seq: visitor.Node
+        }, visitor.Value && {
+          Map: visitor.Value,
+          Scalar: visitor.Value,
+          Seq: visitor.Value
+        }, visitor.Collection && {
+          Map: visitor.Collection,
+          Seq: visitor.Collection
+        }, visitor);
+      }
+      return visitor;
+    }
+    function callVisitor(key, node, visitor, path) {
+      if (typeof visitor === "function")
+        return visitor(key, node, path);
+      if (identity.isMap(node))
+        return visitor.Map?.(key, node, path);
+      if (identity.isSeq(node))
+        return visitor.Seq?.(key, node, path);
+      if (identity.isPair(node))
+        return visitor.Pair?.(key, node, path);
+      if (identity.isScalar(node))
+        return visitor.Scalar?.(key, node, path);
+      if (identity.isAlias(node))
+        return visitor.Alias?.(key, node, path);
+      return void 0;
+    }
+    function replaceNode(key, path, node) {
+      const parent = path[path.length - 1];
+      if (identity.isCollection(parent)) {
+        parent.items[key] = node;
+      } else if (identity.isPair(parent)) {
+        if (key === "key")
+          parent.key = node;
+        else
+          parent.value = node;
+      } else if (identity.isDocument(parent)) {
+        parent.contents = node;
+      } else {
+        const pt = identity.isAlias(parent) ? "alias" : "scalar";
+        throw new Error(`Cannot replace node with ${pt} parent`);
+      }
+    }
+    exports2.visit = visit;
+    exports2.visitAsync = visitAsync;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js
+var require_directives = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/directives.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var visit = require_visit();
+    var escapeChars = {
+      "!": "%21",
+      ",": "%2C",
+      "[": "%5B",
+      "]": "%5D",
+      "{": "%7B",
+      "}": "%7D"
+    };
+    var escapeTagName = (tn) => tn.replace(/[!,[\]{}]/g, (ch) => escapeChars[ch]);
+    var Directives = class _Directives {
+      constructor(yaml, tags) {
+        this.docStart = null;
+        this.docEnd = false;
+        this.yaml = Object.assign({}, _Directives.defaultYaml, yaml);
+        this.tags = Object.assign({}, _Directives.defaultTags, tags);
+      }
+      clone() {
+        const copy = new _Directives(this.yaml, this.tags);
+        copy.docStart = this.docStart;
+        return copy;
+      }
+      /**
+       * During parsing, get a Directives instance for the current document and
+       * update the stream state according to the current version's spec.
+       */
+      atDocument() {
+        const res = new _Directives(this.yaml, this.tags);
+        switch (this.yaml.version) {
+          case "1.1":
+            this.atNextDocument = true;
+            break;
+          case "1.2":
+            this.atNextDocument = false;
+            this.yaml = {
+              explicit: _Directives.defaultYaml.explicit,
+              version: "1.2"
+            };
+            this.tags = Object.assign({}, _Directives.defaultTags);
+            break;
+        }
+        return res;
+      }
+      /**
+       * @param onError - May be called even if the action was successful
+       * @returns `true` on success
+       */
+      add(line, onError) {
+        if (this.atNextDocument) {
+          this.yaml = { explicit: _Directives.defaultYaml.explicit, version: "1.1" };
+          this.tags = Object.assign({}, _Directives.defaultTags);
+          this.atNextDocument = false;
+        }
+        const parts = line.trim().split(/[ \t]+/);
+        const name = parts.shift();
+        switch (name) {
+          case "%TAG": {
+            if (parts.length !== 2) {
+              onError(0, "%TAG directive should contain exactly two parts");
+              if (parts.length < 2)
+                return false;
+            }
+            const [handle, prefix] = parts;
+            this.tags[handle] = prefix;
+            return true;
+          }
+          case "%YAML": {
+            this.yaml.explicit = true;
+            if (parts.length !== 1) {
+              onError(0, "%YAML directive should contain exactly one part");
+              return false;
+            }
+            const [version] = parts;
+            if (version === "1.1" || version === "1.2") {
+              this.yaml.version = version;
+              return true;
+            } else {
+              const isValid = /^\d+\.\d+$/.test(version);
+              onError(6, `Unsupported YAML version ${version}`, isValid);
+              return false;
+            }
+          }
+          default:
+            onError(0, `Unknown directive ${name}`, true);
+            return false;
+        }
+      }
+      /**
+       * Resolves a tag, matching handles to those defined in %TAG directives.
+       *
+       * @returns Resolved tag, which may also be the non-specific tag `'!'` or a
+       *   `'!local'` tag, or `null` if unresolvable.
+       */
+      tagName(source, onError) {
+        if (source === "!")
+          return "!";
+        if (source[0] !== "!") {
+          onError(`Not a valid tag: ${source}`);
+          return null;
+        }
+        if (source[1] === "<") {
+          const verbatim = source.slice(2, -1);
+          if (verbatim === "!" || verbatim === "!!") {
+            onError(`Verbatim tags aren't resolved, so ${source} is invalid.`);
+            return null;
+          }
+          if (source[source.length - 1] !== ">")
+            onError("Verbatim tags must end with a >");
+          return verbatim;
+        }
+        const [, handle, suffix] = source.match(/^(.*!)([^!]*)$/s);
+        if (!suffix)
+          onError(`The ${source} tag has no suffix`);
+        const prefix = this.tags[handle];
+        if (prefix) {
+          try {
+            return prefix + decodeURIComponent(suffix);
+          } catch (error) {
+            onError(String(error));
+            return null;
+          }
+        }
+        if (handle === "!")
+          return source;
+        onError(`Could not resolve tag: ${source}`);
+        return null;
+      }
+      /**
+       * Given a fully resolved tag, returns its printable string form,
+       * taking into account current tag prefixes and defaults.
+       */
+      tagString(tag) {
+        for (const [handle, prefix] of Object.entries(this.tags)) {
+          if (tag.startsWith(prefix))
+            return handle + escapeTagName(tag.substring(prefix.length));
+        }
+        return tag[0] === "!" ? tag : `!<${tag}>`;
+      }
+      toString(doc) {
+        const lines = this.yaml.explicit ? [`%YAML ${this.yaml.version || "1.2"}`] : [];
+        const tagEntries = Object.entries(this.tags);
+        let tagNames;
+        if (doc && tagEntries.length > 0 && identity.isNode(doc.contents)) {
+          const tags = {};
+          visit.visit(doc.contents, (_key, node) => {
+            if (identity.isNode(node) && node.tag)
+              tags[node.tag] = true;
+          });
+          tagNames = Object.keys(tags);
+        } else
+          tagNames = [];
+        for (const [handle, prefix] of tagEntries) {
+          if (handle === "!!" && prefix === "tag:yaml.org,2002:")
+            continue;
+          if (!doc || tagNames.some((tn) => tn.startsWith(prefix)))
+            lines.push(`%TAG ${handle} ${prefix}`);
+        }
+        return lines.join("\n");
+      }
+    };
+    Directives.defaultYaml = { explicit: false, version: "1.2" };
+    Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
+    exports2.Directives = Directives;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js
+var require_anchors = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/anchors.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var visit = require_visit();
+    function anchorIsValid(anchor) {
+      if (/[\x00-\x19\s,[\]{}]/.test(anchor)) {
+        const sa = JSON.stringify(anchor);
+        const msg = `Anchor must not contain whitespace or control characters: ${sa}`;
+        throw new Error(msg);
+      }
+      return true;
+    }
+    function anchorNames(root) {
+      const anchors = /* @__PURE__ */ new Set();
+      visit.visit(root, {
+        Value(_key, node) {
+          if (node.anchor)
+            anchors.add(node.anchor);
+        }
+      });
+      return anchors;
+    }
+    function findNewAnchor(prefix, exclude) {
+      for (let i = 1; true; ++i) {
+        const name = `${prefix}${i}`;
+        if (!exclude.has(name))
+          return name;
+      }
+    }
+    function createNodeAnchors(doc, prefix) {
+      const aliasObjects = [];
+      const sourceObjects = /* @__PURE__ */ new Map();
+      let prevAnchors = null;
+      return {
+        onAnchor: (source) => {
+          aliasObjects.push(source);
+          prevAnchors ?? (prevAnchors = anchorNames(doc));
+          const anchor = findNewAnchor(prefix, prevAnchors);
+          prevAnchors.add(anchor);
+          return anchor;
+        },
+        /**
+         * With circular references, the source node is only resolved after all
+         * of its child nodes are. This is why anchors are set only after all of
+         * the nodes have been created.
+         */
+        setAnchors: () => {
+          for (const source of aliasObjects) {
+            const ref = sourceObjects.get(source);
+            if (typeof ref === "object" && ref.anchor && (identity.isScalar(ref.node) || identity.isCollection(ref.node))) {
+              ref.node.anchor = ref.anchor;
+            } else {
+              const error = new Error("Failed to resolve repeated object (this should not happen)");
+              error.source = source;
+              throw error;
+            }
+          }
+        },
+        sourceObjects
+      };
+    }
+    exports2.anchorIsValid = anchorIsValid;
+    exports2.anchorNames = anchorNames;
+    exports2.createNodeAnchors = createNodeAnchors;
+    exports2.findNewAnchor = findNewAnchor;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js
+var require_applyReviver = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/applyReviver.js"(exports2) {
+    "use strict";
+    function applyReviver(reviver, obj, key, val) {
+      if (val && typeof val === "object") {
+        if (Array.isArray(val)) {
+          for (let i = 0, len = val.length; i < len; ++i) {
+            const v0 = val[i];
+            const v1 = applyReviver(reviver, val, String(i), v0);
+            if (v1 === void 0)
+              delete val[i];
+            else if (v1 !== v0)
+              val[i] = v1;
+          }
+        } else if (val instanceof Map) {
+          for (const k of Array.from(val.keys())) {
+            const v0 = val.get(k);
+            const v1 = applyReviver(reviver, val, k, v0);
+            if (v1 === void 0)
+              val.delete(k);
+            else if (v1 !== v0)
+              val.set(k, v1);
+          }
+        } else if (val instanceof Set) {
+          for (const v0 of Array.from(val)) {
+            const v1 = applyReviver(reviver, val, v0, v0);
+            if (v1 === void 0)
+              val.delete(v0);
+            else if (v1 !== v0) {
+              val.delete(v0);
+              val.add(v1);
+            }
+          }
+        } else {
+          for (const [k, v0] of Object.entries(val)) {
+            const v1 = applyReviver(reviver, val, k, v0);
+            if (v1 === void 0)
+              delete val[k];
+            else if (v1 !== v0)
+              val[k] = v1;
+          }
+        }
+      }
+      return reviver.call(obj, key, val);
+    }
+    exports2.applyReviver = applyReviver;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js
+var require_toJS = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/toJS.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    function toJS(value, arg, ctx) {
+      if (Array.isArray(value))
+        return value.map((v, i) => toJS(v, String(i), ctx));
+      if (value && typeof value.toJSON === "function") {
+        if (!ctx || !identity.hasAnchor(value))
+          return value.toJSON(arg, ctx);
+        const data = { aliasCount: 0, count: 1, res: void 0 };
+        ctx.anchors.set(value, data);
+        ctx.onCreate = (res2) => {
+          data.res = res2;
+          delete ctx.onCreate;
+        };
+        const res = value.toJSON(arg, ctx);
+        if (ctx.onCreate)
+          ctx.onCreate(res);
+        return res;
+      }
+      if (typeof value === "bigint" && !ctx?.keep)
+        return Number(value);
+      return value;
+    }
+    exports2.toJS = toJS;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js
+var require_Node = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Node.js"(exports2) {
+    "use strict";
+    var applyReviver = require_applyReviver();
+    var identity = require_identity();
+    var toJS = require_toJS();
+    var NodeBase = class {
+      constructor(type) {
+        Object.defineProperty(this, identity.NODE_TYPE, { value: type });
+      }
+      /** Create a copy of this node.  */
+      clone() {
+        const copy = Object.create(Object.getPrototypeOf(this), Object.getOwnPropertyDescriptors(this));
+        if (this.range)
+          copy.range = this.range.slice();
+        return copy;
+      }
+      /** A plain JavaScript representation of this node. */
+      toJS(doc, { mapAsMap, maxAliasCount, onAnchor, reviver } = {}) {
+        if (!identity.isDocument(doc))
+          throw new TypeError("A document argument is required");
+        const ctx = {
+          anchors: /* @__PURE__ */ new Map(),
+          doc,
+          keep: true,
+          mapAsMap: mapAsMap === true,
+          mapKeyWarned: false,
+          maxAliasCount: typeof maxAliasCount === "number" ? maxAliasCount : 100
+        };
+        const res = toJS.toJS(this, "", ctx);
+        if (typeof onAnchor === "function")
+          for (const { count, res: res2 } of ctx.anchors.values())
+            onAnchor(res2, count);
+        return typeof reviver === "function" ? applyReviver.applyReviver(reviver, { "": res }, "", res) : res;
+      }
+    };
+    exports2.NodeBase = NodeBase;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js
+var require_Alias = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Alias.js"(exports2) {
+    "use strict";
+    var anchors = require_anchors();
+    var visit = require_visit();
+    var identity = require_identity();
+    var Node = require_Node();
+    var toJS = require_toJS();
+    var Alias = class extends Node.NodeBase {
+      constructor(source) {
+        super(identity.ALIAS);
+        this.source = source;
+        Object.defineProperty(this, "tag", {
+          set() {
+            throw new Error("Alias nodes cannot have tags");
+          }
+        });
+      }
+      /**
+       * Resolve the value of this alias within `doc`, finding the last
+       * instance of the `source` anchor before this node.
+       */
+      resolve(doc, ctx) {
+        let nodes;
+        if (ctx?.aliasResolveCache) {
+          nodes = ctx.aliasResolveCache;
+        } else {
+          nodes = [];
+          visit.visit(doc, {
+            Node: (_key, node) => {
+              if (identity.isAlias(node) || identity.hasAnchor(node))
+                nodes.push(node);
+            }
+          });
+          if (ctx)
+            ctx.aliasResolveCache = nodes;
+        }
+        let found = void 0;
+        for (const node of nodes) {
+          if (node === this)
+            break;
+          if (node.anchor === this.source)
+            found = node;
+        }
+        return found;
+      }
+      toJSON(_arg, ctx) {
+        if (!ctx)
+          return { source: this.source };
+        const { anchors: anchors2, doc, maxAliasCount } = ctx;
+        const source = this.resolve(doc, ctx);
+        if (!source) {
+          const msg = `Unresolved alias (the anchor must be set before the alias): ${this.source}`;
+          throw new ReferenceError(msg);
+        }
+        let data = anchors2.get(source);
+        if (!data) {
+          toJS.toJS(source, null, ctx);
+          data = anchors2.get(source);
+        }
+        if (data?.res === void 0) {
+          const msg = "This should not happen: Alias anchor was not resolved?";
+          throw new ReferenceError(msg);
+        }
+        if (maxAliasCount >= 0) {
+          data.count += 1;
+          if (data.aliasCount === 0)
+            data.aliasCount = getAliasCount(doc, source, anchors2);
+          if (data.count * data.aliasCount > maxAliasCount) {
+            const msg = "Excessive alias count indicates a resource exhaustion attack";
+            throw new ReferenceError(msg);
+          }
+        }
+        return data.res;
+      }
+      toString(ctx, _onComment, _onChompKeep) {
+        const src = `*${this.source}`;
+        if (ctx) {
+          anchors.anchorIsValid(this.source);
+          if (ctx.options.verifyAliasOrder && !ctx.anchors.has(this.source)) {
+            const msg = `Unresolved alias (the anchor must be set before the alias): ${this.source}`;
+            throw new Error(msg);
+          }
+          if (ctx.implicitKey)
+            return `${src} `;
+        }
+        return src;
+      }
+    };
+    function getAliasCount(doc, node, anchors2) {
+      if (identity.isAlias(node)) {
+        const source = node.resolve(doc);
+        const anchor = anchors2 && source && anchors2.get(source);
+        return anchor ? anchor.count * anchor.aliasCount : 0;
+      } else if (identity.isCollection(node)) {
+        let count = 0;
+        for (const item of node.items) {
+          const c = getAliasCount(doc, item, anchors2);
+          if (c > count)
+            count = c;
+        }
+        return count;
+      } else if (identity.isPair(node)) {
+        const kc = getAliasCount(doc, node.key, anchors2);
+        const vc = getAliasCount(doc, node.value, anchors2);
+        return Math.max(kc, vc);
+      }
+      return 1;
+    }
+    exports2.Alias = Alias;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js
+var require_Scalar = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Scalar.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Node = require_Node();
+    var toJS = require_toJS();
+    var isScalarValue = (value) => !value || typeof value !== "function" && typeof value !== "object";
+    var Scalar = class extends Node.NodeBase {
+      constructor(value) {
+        super(identity.SCALAR);
+        this.value = value;
+      }
+      toJSON(arg, ctx) {
+        return ctx?.keep ? this.value : toJS.toJS(this.value, arg, ctx);
+      }
+      toString() {
+        return String(this.value);
+      }
+    };
+    Scalar.BLOCK_FOLDED = "BLOCK_FOLDED";
+    Scalar.BLOCK_LITERAL = "BLOCK_LITERAL";
+    Scalar.PLAIN = "PLAIN";
+    Scalar.QUOTE_DOUBLE = "QUOTE_DOUBLE";
+    Scalar.QUOTE_SINGLE = "QUOTE_SINGLE";
+    exports2.Scalar = Scalar;
+    exports2.isScalarValue = isScalarValue;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js
+var require_createNode = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/createNode.js"(exports2) {
+    "use strict";
+    var Alias = require_Alias();
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var defaultTagPrefix = "tag:yaml.org,2002:";
+    function findTagObject(value, tagName, tags) {
+      if (tagName) {
+        const match = tags.filter((t) => t.tag === tagName);
+        const tagObj = match.find((t) => !t.format) ?? match[0];
+        if (!tagObj)
+          throw new Error(`Tag ${tagName} not found`);
+        return tagObj;
+      }
+      return tags.find((t) => t.identify?.(value) && !t.format);
+    }
+    function createNode(value, tagName, ctx) {
+      if (identity.isDocument(value))
+        value = value.contents;
+      if (identity.isNode(value))
+        return value;
+      if (identity.isPair(value)) {
+        const map = ctx.schema[identity.MAP].createNode?.(ctx.schema, null, ctx);
+        map.items.push(value);
+        return map;
+      }
+      if (value instanceof String || value instanceof Number || value instanceof Boolean || typeof BigInt !== "undefined" && value instanceof BigInt) {
+        value = value.valueOf();
+      }
+      const { aliasDuplicateObjects, onAnchor, onTagObj, schema, sourceObjects } = ctx;
+      let ref = void 0;
+      if (aliasDuplicateObjects && value && typeof value === "object") {
+        ref = sourceObjects.get(value);
+        if (ref) {
+          ref.anchor ?? (ref.anchor = onAnchor(value));
+          return new Alias.Alias(ref.anchor);
+        } else {
+          ref = { anchor: null, node: null };
+          sourceObjects.set(value, ref);
+        }
+      }
+      if (tagName?.startsWith("!!"))
+        tagName = defaultTagPrefix + tagName.slice(2);
+      let tagObj = findTagObject(value, tagName, schema.tags);
+      if (!tagObj) {
+        if (value && typeof value.toJSON === "function") {
+          value = value.toJSON();
+        }
+        if (!value || typeof value !== "object") {
+          const node2 = new Scalar.Scalar(value);
+          if (ref)
+            ref.node = node2;
+          return node2;
+        }
+        tagObj = value instanceof Map ? schema[identity.MAP] : Symbol.iterator in Object(value) ? schema[identity.SEQ] : schema[identity.MAP];
+      }
+      if (onTagObj) {
+        onTagObj(tagObj);
+        delete ctx.onTagObj;
+      }
+      const node = tagObj?.createNode ? tagObj.createNode(ctx.schema, value, ctx) : typeof tagObj?.nodeClass?.from === "function" ? tagObj.nodeClass.from(ctx.schema, value, ctx) : new Scalar.Scalar(value);
+      if (tagName)
+        node.tag = tagName;
+      else if (!tagObj.default)
+        node.tag = tagObj.tag;
+      if (ref)
+        ref.node = node;
+      return node;
+    }
+    exports2.createNode = createNode;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js
+var require_Collection = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Collection.js"(exports2) {
+    "use strict";
+    var createNode = require_createNode();
+    var identity = require_identity();
+    var Node = require_Node();
+    function collectionFromPath(schema, path, value) {
+      let v = value;
+      for (let i = path.length - 1; i >= 0; --i) {
+        const k = path[i];
+        if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
+          const a = [];
+          a[k] = v;
+          v = a;
+        } else {
+          v = /* @__PURE__ */ new Map([[k, v]]);
+        }
+      }
+      return createNode.createNode(v, void 0, {
+        aliasDuplicateObjects: false,
+        keepUndefined: false,
+        onAnchor: () => {
+          throw new Error("This should not happen, please report a bug.");
+        },
+        schema,
+        sourceObjects: /* @__PURE__ */ new Map()
+      });
+    }
+    var isEmptyPath = (path) => path == null || typeof path === "object" && !!path[Symbol.iterator]().next().done;
+    var Collection = class extends Node.NodeBase {
+      constructor(type, schema) {
+        super(type);
+        Object.defineProperty(this, "schema", {
+          value: schema,
+          configurable: true,
+          enumerable: false,
+          writable: true
+        });
+      }
+      /**
+       * Create a copy of this collection.
+       *
+       * @param schema - If defined, overwrites the original's schema
+       */
+      clone(schema) {
+        const copy = Object.create(Object.getPrototypeOf(this), Object.getOwnPropertyDescriptors(this));
+        if (schema)
+          copy.schema = schema;
+        copy.items = copy.items.map((it) => identity.isNode(it) || identity.isPair(it) ? it.clone(schema) : it);
+        if (this.range)
+          copy.range = this.range.slice();
+        return copy;
+      }
+      /**
+       * Adds a value to the collection. For `!!map` and `!!omap` the value must
+       * be a Pair instance or a `{ key, value }` object, which may not have a key
+       * that already exists in the map.
+       */
+      addIn(path, value) {
+        if (isEmptyPath(path))
+          this.add(value);
+        else {
+          const [key, ...rest] = path;
+          const node = this.get(key, true);
+          if (identity.isCollection(node))
+            node.addIn(rest, value);
+          else if (node === void 0 && this.schema)
+            this.set(key, collectionFromPath(this.schema, rest, value));
+          else
+            throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
+        }
+      }
+      /**
+       * Removes a value from the collection.
+       * @returns `true` if the item was found and removed.
+       */
+      deleteIn(path) {
+        const [key, ...rest] = path;
+        if (rest.length === 0)
+          return this.delete(key);
+        const node = this.get(key, true);
+        if (identity.isCollection(node))
+          return node.deleteIn(rest);
+        else
+          throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
+      }
+      /**
+       * Returns item at `key`, or `undefined` if not found. By default unwraps
+       * scalar values from their surrounding node; to disable set `keepScalar` to
+       * `true` (collections are always returned intact).
+       */
+      getIn(path, keepScalar) {
+        const [key, ...rest] = path;
+        const node = this.get(key, true);
+        if (rest.length === 0)
+          return !keepScalar && identity.isScalar(node) ? node.value : node;
+        else
+          return identity.isCollection(node) ? node.getIn(rest, keepScalar) : void 0;
+      }
+      hasAllNullValues(allowScalar) {
+        return this.items.every((node) => {
+          if (!identity.isPair(node))
+            return false;
+          const n = node.value;
+          return n == null || allowScalar && identity.isScalar(n) && n.value == null && !n.commentBefore && !n.comment && !n.tag;
+        });
+      }
+      /**
+       * Checks if the collection includes a value with the key `key`.
+       */
+      hasIn(path) {
+        const [key, ...rest] = path;
+        if (rest.length === 0)
+          return this.has(key);
+        const node = this.get(key, true);
+        return identity.isCollection(node) ? node.hasIn(rest) : false;
+      }
+      /**
+       * Sets a value in this collection. For `!!set`, `value` needs to be a
+       * boolean to add/remove the item from the set.
+       */
+      setIn(path, value) {
+        const [key, ...rest] = path;
+        if (rest.length === 0) {
+          this.set(key, value);
+        } else {
+          const node = this.get(key, true);
+          if (identity.isCollection(node))
+            node.setIn(rest, value);
+          else if (node === void 0 && this.schema)
+            this.set(key, collectionFromPath(this.schema, rest, value));
+          else
+            throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
+        }
+      }
+    };
+    exports2.Collection = Collection;
+    exports2.collectionFromPath = collectionFromPath;
+    exports2.isEmptyPath = isEmptyPath;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js
+var require_stringifyComment = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyComment.js"(exports2) {
+    "use strict";
+    var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
+    function indentComment(comment, indent) {
+      if (/^\n+$/.test(comment))
+        return comment.substring(1);
+      return indent ? comment.replace(/^(?! *$)/gm, indent) : comment;
+    }
+    var lineComment = (str, indent, comment) => str.endsWith("\n") ? indentComment(comment, indent) : comment.includes("\n") ? "\n" + indentComment(comment, indent) : (str.endsWith(" ") ? "" : " ") + comment;
+    exports2.indentComment = indentComment;
+    exports2.lineComment = lineComment;
+    exports2.stringifyComment = stringifyComment;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js
+var require_foldFlowLines = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports2) {
+    "use strict";
+    var FOLD_FLOW = "flow";
+    var FOLD_BLOCK = "block";
+    var FOLD_QUOTED = "quoted";
+    function foldFlowLines(text, indent, mode = "flow", { indentAtStart, lineWidth = 80, minContentWidth = 20, onFold, onOverflow } = {}) {
+      if (!lineWidth || lineWidth < 0)
+        return text;
+      if (lineWidth < minContentWidth)
+        minContentWidth = 0;
+      const endStep = Math.max(1 + minContentWidth, 1 + lineWidth - indent.length);
+      if (text.length <= endStep)
+        return text;
+      const folds = [];
+      const escapedFolds = {};
+      let end = lineWidth - indent.length;
+      if (typeof indentAtStart === "number") {
+        if (indentAtStart > lineWidth - Math.max(2, minContentWidth))
+          folds.push(0);
+        else
+          end = lineWidth - indentAtStart;
+      }
+      let split = void 0;
+      let prev = void 0;
+      let overflow = false;
+      let i = -1;
+      let escStart = -1;
+      let escEnd = -1;
+      if (mode === FOLD_BLOCK) {
+        i = consumeMoreIndentedLines(text, i, indent.length);
+        if (i !== -1)
+          end = i + endStep;
+      }
+      for (let ch; ch = text[i += 1]; ) {
+        if (mode === FOLD_QUOTED && ch === "\\") {
+          escStart = i;
+          switch (text[i + 1]) {
+            case "x":
+              i += 3;
+              break;
+            case "u":
+              i += 5;
+              break;
+            case "U":
+              i += 9;
+              break;
+            default:
+              i += 1;
+          }
+          escEnd = i;
+        }
+        if (ch === "\n") {
+          if (mode === FOLD_BLOCK)
+            i = consumeMoreIndentedLines(text, i, indent.length);
+          end = i + indent.length + endStep;
+          split = void 0;
+        } else {
+          if (ch === " " && prev && prev !== " " && prev !== "\n" && prev !== "	") {
+            const next = text[i + 1];
+            if (next && next !== " " && next !== "\n" && next !== "	")
+              split = i;
+          }
+          if (i >= end) {
+            if (split) {
+              folds.push(split);
+              end = split + endStep;
+              split = void 0;
+            } else if (mode === FOLD_QUOTED) {
+              while (prev === " " || prev === "	") {
+                prev = ch;
+                ch = text[i += 1];
+                overflow = true;
+              }
+              const j = i > escEnd + 1 ? i - 2 : escStart - 1;
+              if (escapedFolds[j])
+                return text;
+              folds.push(j);
+              escapedFolds[j] = true;
+              end = j + endStep;
+              split = void 0;
+            } else {
+              overflow = true;
+            }
+          }
+        }
+        prev = ch;
+      }
+      if (overflow && onOverflow)
+        onOverflow();
+      if (folds.length === 0)
+        return text;
+      if (onFold)
+        onFold();
+      let res = text.slice(0, folds[0]);
+      for (let i2 = 0; i2 < folds.length; ++i2) {
+        const fold = folds[i2];
+        const end2 = folds[i2 + 1] || text.length;
+        if (fold === 0)
+          res = `
+${indent}${text.slice(0, end2)}`;
+        else {
+          if (mode === FOLD_QUOTED && escapedFolds[fold])
+            res += `${text[fold]}\\`;
+          res += `
+${indent}${text.slice(fold + 1, end2)}`;
+        }
+      }
+      return res;
+    }
+    function consumeMoreIndentedLines(text, i, indent) {
+      let end = i;
+      let start = i + 1;
+      let ch = text[start];
+      while (ch === " " || ch === "	") {
+        if (i < start + indent) {
+          ch = text[++i];
+        } else {
+          do {
+            ch = text[++i];
+          } while (ch && ch !== "\n");
+          end = i;
+          start = i + 1;
+          ch = text[start];
+        }
+      }
+      return end;
+    }
+    exports2.FOLD_BLOCK = FOLD_BLOCK;
+    exports2.FOLD_FLOW = FOLD_FLOW;
+    exports2.FOLD_QUOTED = FOLD_QUOTED;
+    exports2.foldFlowLines = foldFlowLines;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js
+var require_stringifyString = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyString.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var foldFlowLines = require_foldFlowLines();
+    var getFoldOptions = (ctx, isBlock) => ({
+      indentAtStart: isBlock ? ctx.indent.length : ctx.indentAtStart,
+      lineWidth: ctx.options.lineWidth,
+      minContentWidth: ctx.options.minContentWidth
+    });
+    var containsDocumentMarker = (str) => /^(%|---|\.\.\.)/m.test(str);
+    function lineLengthOverLimit(str, lineWidth, indentLength) {
+      if (!lineWidth || lineWidth < 0)
+        return false;
+      const limit = lineWidth - indentLength;
+      const strLen = str.length;
+      if (strLen <= limit)
+        return false;
+      for (let i = 0, start = 0; i < strLen; ++i) {
+        if (str[i] === "\n") {
+          if (i - start > limit)
+            return true;
+          start = i + 1;
+          if (strLen - start <= limit)
+            return false;
+        }
+      }
+      return true;
+    }
+    function doubleQuotedString(value, ctx) {
+      const json = JSON.stringify(value);
+      if (ctx.options.doubleQuotedAsJSON)
+        return json;
+      const { implicitKey } = ctx;
+      const minMultiLineLength = ctx.options.doubleQuotedMinMultiLineLength;
+      const indent = ctx.indent || (containsDocumentMarker(value) ? "  " : "");
+      let str = "";
+      let start = 0;
+      for (let i = 0, ch = json[i]; ch; ch = json[++i]) {
+        if (ch === " " && json[i + 1] === "\\" && json[i + 2] === "n") {
+          str += json.slice(start, i) + "\\ ";
+          i += 1;
+          start = i;
+          ch = "\\";
+        }
+        if (ch === "\\")
+          switch (json[i + 1]) {
+            case "u":
+              {
+                str += json.slice(start, i);
+                const code = json.substr(i + 2, 4);
+                switch (code) {
+                  case "0000":
+                    str += "\\0";
+                    break;
+                  case "0007":
+                    str += "\\a";
+                    break;
+                  case "000b":
+                    str += "\\v";
+                    break;
+                  case "001b":
+                    str += "\\e";
+                    break;
+                  case "0085":
+                    str += "\\N";
+                    break;
+                  case "00a0":
+                    str += "\\_";
+                    break;
+                  case "2028":
+                    str += "\\L";
+                    break;
+                  case "2029":
+                    str += "\\P";
+                    break;
+                  default:
+                    if (code.substr(0, 2) === "00")
+                      str += "\\x" + code.substr(2);
+                    else
+                      str += json.substr(i, 6);
+                }
+                i += 5;
+                start = i + 1;
+              }
+              break;
+            case "n":
+              if (implicitKey || json[i + 2] === '"' || json.length < minMultiLineLength) {
+                i += 1;
+              } else {
+                str += json.slice(start, i) + "\n\n";
+                while (json[i + 2] === "\\" && json[i + 3] === "n" && json[i + 4] !== '"') {
+                  str += "\n";
+                  i += 2;
+                }
+                str += indent;
+                if (json[i + 2] === " ")
+                  str += "\\";
+                i += 1;
+                start = i + 1;
+              }
+              break;
+            default:
+              i += 1;
+          }
+      }
+      str = start ? str + json.slice(start) : json;
+      return implicitKey ? str : foldFlowLines.foldFlowLines(str, indent, foldFlowLines.FOLD_QUOTED, getFoldOptions(ctx, false));
+    }
+    function singleQuotedString(value, ctx) {
+      if (ctx.options.singleQuote === false || ctx.implicitKey && value.includes("\n") || /[ \t]\n|\n[ \t]/.test(value))
+        return doubleQuotedString(value, ctx);
+      const indent = ctx.indent || (containsDocumentMarker(value) ? "  " : "");
+      const res = "'" + value.replace(/'/g, "''").replace(/\n+/g, `$&
+${indent}`) + "'";
+      return ctx.implicitKey ? res : foldFlowLines.foldFlowLines(res, indent, foldFlowLines.FOLD_FLOW, getFoldOptions(ctx, false));
+    }
+    function quotedString(value, ctx) {
+      const { singleQuote } = ctx.options;
+      let qs;
+      if (singleQuote === false)
+        qs = doubleQuotedString;
+      else {
+        const hasDouble = value.includes('"');
+        const hasSingle = value.includes("'");
+        if (hasDouble && !hasSingle)
+          qs = singleQuotedString;
+        else if (hasSingle && !hasDouble)
+          qs = doubleQuotedString;
+        else
+          qs = singleQuote ? singleQuotedString : doubleQuotedString;
+      }
+      return qs(value, ctx);
+    }
+    var blockEndNewlines;
+    try {
+      blockEndNewlines = new RegExp("(^|(?<!\n))\n+(?!\n|$)", "g");
+    } catch {
+      blockEndNewlines = /\n+(?!\n|$)/g;
+    }
+    function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
+      const { blockQuote, commentString, lineWidth } = ctx.options;
+      if (!blockQuote || /\n[\t ]+$/.test(value)) {
+        return quotedString(value, ctx);
+      }
+      const indent = ctx.indent || (ctx.forceBlockIndent || containsDocumentMarker(value) ? "  " : "");
+      const literal = blockQuote === "literal" ? true : blockQuote === "folded" || type === Scalar.Scalar.BLOCK_FOLDED ? false : type === Scalar.Scalar.BLOCK_LITERAL ? true : !lineLengthOverLimit(value, lineWidth, indent.length);
+      if (!value)
+        return literal ? "|\n" : ">\n";
+      let chomp;
+      let endStart;
+      for (endStart = value.length; endStart > 0; --endStart) {
+        const ch = value[endStart - 1];
+        if (ch !== "\n" && ch !== "	" && ch !== " ")
+          break;
+      }
+      let end = value.substring(endStart);
+      const endNlPos = end.indexOf("\n");
+      if (endNlPos === -1) {
+        chomp = "-";
+      } else if (value === end || endNlPos !== end.length - 1) {
+        chomp = "+";
+        if (onChompKeep)
+          onChompKeep();
+      } else {
+        chomp = "";
+      }
+      if (end) {
+        value = value.slice(0, -end.length);
+        if (end[end.length - 1] === "\n")
+          end = end.slice(0, -1);
+        end = end.replace(blockEndNewlines, `$&${indent}`);
+      }
+      let startWithSpace = false;
+      let startEnd;
+      let startNlPos = -1;
+      for (startEnd = 0; startEnd < value.length; ++startEnd) {
+        const ch = value[startEnd];
+        if (ch === " ")
+          startWithSpace = true;
+        else if (ch === "\n")
+          startNlPos = startEnd;
+        else
+          break;
+      }
+      let start = value.substring(0, startNlPos < startEnd ? startNlPos + 1 : startEnd);
+      if (start) {
+        value = value.substring(start.length);
+        start = start.replace(/\n+/g, `$&${indent}`);
+      }
+      const indentSize = indent ? "2" : "1";
+      let header = (startWithSpace ? indentSize : "") + chomp;
+      if (comment) {
+        header += " " + commentString(comment.replace(/ ?[\r\n]+/g, " "));
+        if (onComment)
+          onComment();
+      }
+      if (!literal) {
+        const foldedValue = value.replace(/\n+/g, "\n$&").replace(/(?:^|\n)([\t ].*)(?:([\n\t ]*)\n(?![\n\t ]))?/g, "$1$2").replace(/\n+/g, `$&${indent}`);
+        let literalFallback = false;
+        const foldOptions = getFoldOptions(ctx, true);
+        if (blockQuote !== "folded" && type !== Scalar.Scalar.BLOCK_FOLDED) {
+          foldOptions.onOverflow = () => {
+            literalFallback = true;
+          };
+        }
+        const body = foldFlowLines.foldFlowLines(`${start}${foldedValue}${end}`, indent, foldFlowLines.FOLD_BLOCK, foldOptions);
+        if (!literalFallback)
+          return `>${header}
+${indent}${body}`;
+      }
+      value = value.replace(/\n+/g, `$&${indent}`);
+      return `|${header}
+${indent}${start}${value}${end}`;
+    }
+    function plainString(item, ctx, onComment, onChompKeep) {
+      const { type, value } = item;
+      const { actualString, implicitKey, indent, indentStep, inFlow } = ctx;
+      if (implicitKey && value.includes("\n") || inFlow && /[[\]{},]/.test(value)) {
+        return quotedString(value, ctx);
+      }
+      if (/^[\n\t ,[\]{}#&*!|>'"%@`]|^[?-]$|^[?-][ \t]|[\n:][ \t]|[ \t]\n|[\n\t ]#|[\n\t :]$/.test(value)) {
+        return implicitKey || inFlow || !value.includes("\n") ? quotedString(value, ctx) : blockString(item, ctx, onComment, onChompKeep);
+      }
+      if (!implicitKey && !inFlow && type !== Scalar.Scalar.PLAIN && value.includes("\n")) {
+        return blockString(item, ctx, onComment, onChompKeep);
+      }
+      if (containsDocumentMarker(value)) {
+        if (indent === "") {
+          ctx.forceBlockIndent = true;
+          return blockString(item, ctx, onComment, onChompKeep);
+        } else if (implicitKey && indent === indentStep) {
+          return quotedString(value, ctx);
+        }
+      }
+      const str = value.replace(/\n+/g, `$&
+${indent}`);
+      if (actualString) {
+        const test = (tag) => tag.default && tag.tag !== "tag:yaml.org,2002:str" && tag.test?.test(str);
+        const { compat, tags } = ctx.doc.schema;
+        if (tags.some(test) || compat?.some(test))
+          return quotedString(value, ctx);
+      }
+      return implicitKey ? str : foldFlowLines.foldFlowLines(str, indent, foldFlowLines.FOLD_FLOW, getFoldOptions(ctx, false));
+    }
+    function stringifyString(item, ctx, onComment, onChompKeep) {
+      const { implicitKey, inFlow } = ctx;
+      const ss = typeof item.value === "string" ? item : Object.assign({}, item, { value: String(item.value) });
+      let { type } = item;
+      if (type !== Scalar.Scalar.QUOTE_DOUBLE) {
+        if (/[\x00-\x08\x0b-\x1f\x7f-\x9f\u{D800}-\u{DFFF}]/u.test(ss.value))
+          type = Scalar.Scalar.QUOTE_DOUBLE;
+      }
+      const _stringify = (_type) => {
+        switch (_type) {
+          case Scalar.Scalar.BLOCK_FOLDED:
+          case Scalar.Scalar.BLOCK_LITERAL:
+            return implicitKey || inFlow ? quotedString(ss.value, ctx) : blockString(ss, ctx, onComment, onChompKeep);
+          case Scalar.Scalar.QUOTE_DOUBLE:
+            return doubleQuotedString(ss.value, ctx);
+          case Scalar.Scalar.QUOTE_SINGLE:
+            return singleQuotedString(ss.value, ctx);
+          case Scalar.Scalar.PLAIN:
+            return plainString(ss, ctx, onComment, onChompKeep);
+          default:
+            return null;
+        }
+      };
+      let res = _stringify(type);
+      if (res === null) {
+        const { defaultKeyType, defaultStringType } = ctx.options;
+        const t = implicitKey && defaultKeyType || defaultStringType;
+        res = _stringify(t);
+        if (res === null)
+          throw new Error(`Unsupported default string type ${t}`);
+      }
+      return res;
+    }
+    exports2.stringifyString = stringifyString;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js
+var require_stringify = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringify.js"(exports2) {
+    "use strict";
+    var anchors = require_anchors();
+    var identity = require_identity();
+    var stringifyComment = require_stringifyComment();
+    var stringifyString = require_stringifyString();
+    function createStringifyContext(doc, options) {
+      const opt = Object.assign({
+        blockQuote: true,
+        commentString: stringifyComment.stringifyComment,
+        defaultKeyType: null,
+        defaultStringType: "PLAIN",
+        directives: null,
+        doubleQuotedAsJSON: false,
+        doubleQuotedMinMultiLineLength: 40,
+        falseStr: "false",
+        flowCollectionPadding: true,
+        indentSeq: true,
+        lineWidth: 80,
+        minContentWidth: 20,
+        nullStr: "null",
+        simpleKeys: false,
+        singleQuote: null,
+        trueStr: "true",
+        verifyAliasOrder: true
+      }, doc.schema.toStringOptions, options);
+      let inFlow;
+      switch (opt.collectionStyle) {
+        case "block":
+          inFlow = false;
+          break;
+        case "flow":
+          inFlow = true;
+          break;
+        default:
+          inFlow = null;
+      }
+      return {
+        anchors: /* @__PURE__ */ new Set(),
+        doc,
+        flowCollectionPadding: opt.flowCollectionPadding ? " " : "",
+        indent: "",
+        indentStep: typeof opt.indent === "number" ? " ".repeat(opt.indent) : "  ",
+        inFlow,
+        options: opt
+      };
+    }
+    function getTagObject(tags, item) {
+      if (item.tag) {
+        const match = tags.filter((t) => t.tag === item.tag);
+        if (match.length > 0)
+          return match.find((t) => t.format === item.format) ?? match[0];
+      }
+      let tagObj = void 0;
+      let obj;
+      if (identity.isScalar(item)) {
+        obj = item.value;
+        let match = tags.filter((t) => t.identify?.(obj));
+        if (match.length > 1) {
+          const testMatch = match.filter((t) => t.test);
+          if (testMatch.length > 0)
+            match = testMatch;
+        }
+        tagObj = match.find((t) => t.format === item.format) ?? match.find((t) => !t.format);
+      } else {
+        obj = item;
+        tagObj = tags.find((t) => t.nodeClass && obj instanceof t.nodeClass);
+      }
+      if (!tagObj) {
+        const name = obj?.constructor?.name ?? (obj === null ? "null" : typeof obj);
+        throw new Error(`Tag not resolved for ${name} value`);
+      }
+      return tagObj;
+    }
+    function stringifyProps(node, tagObj, { anchors: anchors$1, doc }) {
+      if (!doc.directives)
+        return "";
+      const props = [];
+      const anchor = (identity.isScalar(node) || identity.isCollection(node)) && node.anchor;
+      if (anchor && anchors.anchorIsValid(anchor)) {
+        anchors$1.add(anchor);
+        props.push(`&${anchor}`);
+      }
+      const tag = node.tag ?? (tagObj.default ? null : tagObj.tag);
+      if (tag)
+        props.push(doc.directives.tagString(tag));
+      return props.join(" ");
+    }
+    function stringify(item, ctx, onComment, onChompKeep) {
+      if (identity.isPair(item))
+        return item.toString(ctx, onComment, onChompKeep);
+      if (identity.isAlias(item)) {
+        if (ctx.doc.directives)
+          return item.toString(ctx);
+        if (ctx.resolvedAliases?.has(item)) {
+          throw new TypeError(`Cannot stringify circular structure without alias nodes`);
+        } else {
+          if (ctx.resolvedAliases)
+            ctx.resolvedAliases.add(item);
+          else
+            ctx.resolvedAliases = /* @__PURE__ */ new Set([item]);
+          item = item.resolve(ctx.doc);
+        }
+      }
+      let tagObj = void 0;
+      const node = identity.isNode(item) ? item : ctx.doc.createNode(item, { onTagObj: (o) => tagObj = o });
+      tagObj ?? (tagObj = getTagObject(ctx.doc.schema.tags, node));
+      const props = stringifyProps(node, tagObj, ctx);
+      if (props.length > 0)
+        ctx.indentAtStart = (ctx.indentAtStart ?? 0) + props.length + 1;
+      const str = typeof tagObj.stringify === "function" ? tagObj.stringify(node, ctx, onComment, onChompKeep) : identity.isScalar(node) ? stringifyString.stringifyString(node, ctx, onComment, onChompKeep) : node.toString(ctx, onComment, onChompKeep);
+      if (!props)
+        return str;
+      return identity.isScalar(node) || str[0] === "{" || str[0] === "[" ? `${props} ${str}` : `${props}
+${ctx.indent}${str}`;
+    }
+    exports2.createStringifyContext = createStringifyContext;
+    exports2.stringify = stringify;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js
+var require_stringifyPair = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyPair.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var stringify = require_stringify();
+    var stringifyComment = require_stringifyComment();
+    function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
+      const { allNullValues, doc, indent, indentStep, options: { commentString, indentSeq, simpleKeys } } = ctx;
+      let keyComment = identity.isNode(key) && key.comment || null;
+      if (simpleKeys) {
+        if (keyComment) {
+          throw new Error("With simple keys, key nodes cannot have comments");
+        }
+        if (identity.isCollection(key) || !identity.isNode(key) && typeof key === "object") {
+          const msg = "With simple keys, collection cannot be used as a key value";
+          throw new Error(msg);
+        }
+      }
+      let explicitKey = !simpleKeys && (!key || keyComment && value == null && !ctx.inFlow || identity.isCollection(key) || (identity.isScalar(key) ? key.type === Scalar.Scalar.BLOCK_FOLDED || key.type === Scalar.Scalar.BLOCK_LITERAL : typeof key === "object"));
+      ctx = Object.assign({}, ctx, {
+        allNullValues: false,
+        implicitKey: !explicitKey && (simpleKeys || !allNullValues),
+        indent: indent + indentStep
+      });
+      let keyCommentDone = false;
+      let chompKeep = false;
+      let str = stringify.stringify(key, ctx, () => keyCommentDone = true, () => chompKeep = true);
+      if (!explicitKey && !ctx.inFlow && str.length > 1024) {
+        if (simpleKeys)
+          throw new Error("With simple keys, single line scalar must not span more than 1024 characters");
+        explicitKey = true;
+      }
+      if (ctx.inFlow) {
+        if (allNullValues || value == null) {
+          if (keyCommentDone && onComment)
+            onComment();
+          return str === "" ? "?" : explicitKey ? `? ${str}` : str;
+        }
+      } else if (allNullValues && !simpleKeys || value == null && explicitKey) {
+        str = `? ${str}`;
+        if (keyComment && !keyCommentDone) {
+          str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
+        } else if (chompKeep && onChompKeep)
+          onChompKeep();
+        return str;
+      }
+      if (keyCommentDone)
+        keyComment = null;
+      if (explicitKey) {
+        if (keyComment)
+          str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
+        str = `? ${str}
+${indent}:`;
+      } else {
+        str = `${str}:`;
+        if (keyComment)
+          str += stringifyComment.lineComment(str, ctx.indent, commentString(keyComment));
+      }
+      let vsb, vcb, valueComment;
+      if (identity.isNode(value)) {
+        vsb = !!value.spaceBefore;
+        vcb = value.commentBefore;
+        valueComment = value.comment;
+      } else {
+        vsb = false;
+        vcb = null;
+        valueComment = null;
+        if (value && typeof value === "object")
+          value = doc.createNode(value);
+      }
+      ctx.implicitKey = false;
+      if (!explicitKey && !keyComment && identity.isScalar(value))
+        ctx.indentAtStart = str.length + 1;
+      chompKeep = false;
+      if (!indentSeq && indentStep.length >= 2 && !ctx.inFlow && !explicitKey && identity.isSeq(value) && !value.flow && !value.tag && !value.anchor) {
+        ctx.indent = ctx.indent.substring(2);
+      }
+      let valueCommentDone = false;
+      const valueStr = stringify.stringify(value, ctx, () => valueCommentDone = true, () => chompKeep = true);
+      let ws = " ";
+      if (keyComment || vsb || vcb) {
+        ws = vsb ? "\n" : "";
+        if (vcb) {
+          const cs = commentString(vcb);
+          ws += `
+${stringifyComment.indentComment(cs, ctx.indent)}`;
+        }
+        if (valueStr === "" && !ctx.inFlow) {
+          if (ws === "\n" && valueComment)
+            ws = "\n\n";
+        } else {
+          ws += `
+${ctx.indent}`;
+        }
+      } else if (!explicitKey && identity.isCollection(value)) {
+        const vs0 = valueStr[0];
+        const nl0 = valueStr.indexOf("\n");
+        const hasNewline = nl0 !== -1;
+        const flow = ctx.inFlow ?? value.flow ?? value.items.length === 0;
+        if (hasNewline || !flow) {
+          let hasPropsLine = false;
+          if (hasNewline && (vs0 === "&" || vs0 === "!")) {
+            let sp0 = valueStr.indexOf(" ");
+            if (vs0 === "&" && sp0 !== -1 && sp0 < nl0 && valueStr[sp0 + 1] === "!") {
+              sp0 = valueStr.indexOf(" ", sp0 + 1);
+            }
+            if (sp0 === -1 || nl0 < sp0)
+              hasPropsLine = true;
+          }
+          if (!hasPropsLine)
+            ws = `
+${ctx.indent}`;
+        }
+      } else if (valueStr === "" || valueStr[0] === "\n") {
+        ws = "";
+      }
+      str += ws + valueStr;
+      if (ctx.inFlow) {
+        if (valueCommentDone && onComment)
+          onComment();
+      } else if (valueComment && !valueCommentDone) {
+        str += stringifyComment.lineComment(str, ctx.indent, commentString(valueComment));
+      } else if (chompKeep && onChompKeep) {
+        onChompKeep();
+      }
+      return str;
+    }
+    exports2.stringifyPair = stringifyPair;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js
+var require_log = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/log.js"(exports2) {
+    "use strict";
+    var node_process = require("process");
+    function debug(logLevel, ...messages) {
+      if (logLevel === "debug")
+        console.log(...messages);
+    }
+    function warn(logLevel, warning) {
+      if (logLevel === "debug" || logLevel === "warn") {
+        if (typeof node_process.emitWarning === "function")
+          node_process.emitWarning(warning);
+        else
+          console.warn(warning);
+      }
+    }
+    exports2.debug = debug;
+    exports2.warn = warn;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js
+var require_merge = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var MERGE_KEY = "<<";
+    var merge = {
+      identify: (value) => value === MERGE_KEY || typeof value === "symbol" && value.description === MERGE_KEY,
+      default: "key",
+      tag: "tag:yaml.org,2002:merge",
+      test: /^<<$/,
+      resolve: () => Object.assign(new Scalar.Scalar(Symbol(MERGE_KEY)), {
+        addToJSMap: addMergeToJSMap
+      }),
+      stringify: () => MERGE_KEY
+    };
+    var isMergeKey = (ctx, key) => (merge.identify(key) || identity.isScalar(key) && (!key.type || key.type === Scalar.Scalar.PLAIN) && merge.identify(key.value)) && ctx?.doc.schema.tags.some((tag) => tag.tag === merge.tag && tag.default);
+    function addMergeToJSMap(ctx, map, value) {
+      value = ctx && identity.isAlias(value) ? value.resolve(ctx.doc) : value;
+      if (identity.isSeq(value))
+        for (const it of value.items)
+          mergeValue(ctx, map, it);
+      else if (Array.isArray(value))
+        for (const it of value)
+          mergeValue(ctx, map, it);
+      else
+        mergeValue(ctx, map, value);
+    }
+    function mergeValue(ctx, map, value) {
+      const source = ctx && identity.isAlias(value) ? value.resolve(ctx.doc) : value;
+      if (!identity.isMap(source))
+        throw new Error("Merge sources must be maps or map aliases");
+      const srcMap = source.toJSON(null, ctx, Map);
+      for (const [key, value2] of srcMap) {
+        if (map instanceof Map) {
+          if (!map.has(key))
+            map.set(key, value2);
+        } else if (map instanceof Set) {
+          map.add(key);
+        } else if (!Object.prototype.hasOwnProperty.call(map, key)) {
+          Object.defineProperty(map, key, {
+            value: value2,
+            writable: true,
+            enumerable: true,
+            configurable: true
+          });
+        }
+      }
+      return map;
+    }
+    exports2.addMergeToJSMap = addMergeToJSMap;
+    exports2.isMergeKey = isMergeKey;
+    exports2.merge = merge;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js
+var require_addPairToJSMap = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports2) {
+    "use strict";
+    var log = require_log();
+    var merge = require_merge();
+    var stringify = require_stringify();
+    var identity = require_identity();
+    var toJS = require_toJS();
+    function addPairToJSMap(ctx, map, { key, value }) {
+      if (identity.isNode(key) && key.addToJSMap)
+        key.addToJSMap(ctx, map, value);
+      else if (merge.isMergeKey(ctx, key))
+        merge.addMergeToJSMap(ctx, map, value);
+      else {
+        const jsKey = toJS.toJS(key, "", ctx);
+        if (map instanceof Map) {
+          map.set(jsKey, toJS.toJS(value, jsKey, ctx));
+        } else if (map instanceof Set) {
+          map.add(jsKey);
+        } else {
+          const stringKey = stringifyKey(key, jsKey, ctx);
+          const jsValue = toJS.toJS(value, stringKey, ctx);
+          if (stringKey in map)
+            Object.defineProperty(map, stringKey, {
+              value: jsValue,
+              writable: true,
+              enumerable: true,
+              configurable: true
+            });
+          else
+            map[stringKey] = jsValue;
+        }
+      }
+      return map;
+    }
+    function stringifyKey(key, jsKey, ctx) {
+      if (jsKey === null)
+        return "";
+      if (typeof jsKey !== "object")
+        return String(jsKey);
+      if (identity.isNode(key) && ctx?.doc) {
+        const strCtx = stringify.createStringifyContext(ctx.doc, {});
+        strCtx.anchors = /* @__PURE__ */ new Set();
+        for (const node of ctx.anchors.keys())
+          strCtx.anchors.add(node.anchor);
+        strCtx.inFlow = true;
+        strCtx.inStringifyKey = true;
+        const strKey = key.toString(strCtx);
+        if (!ctx.mapKeyWarned) {
+          let jsonStr = JSON.stringify(strKey);
+          if (jsonStr.length > 40)
+            jsonStr = jsonStr.substring(0, 36) + '..."';
+          log.warn(ctx.doc.options.logLevel, `Keys with collection values will be stringified due to JS Object restrictions: ${jsonStr}. Set mapAsMap: true to use object keys.`);
+          ctx.mapKeyWarned = true;
+        }
+        return strKey;
+      }
+      return JSON.stringify(jsKey);
+    }
+    exports2.addPairToJSMap = addPairToJSMap;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js
+var require_Pair = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/Pair.js"(exports2) {
+    "use strict";
+    var createNode = require_createNode();
+    var stringifyPair = require_stringifyPair();
+    var addPairToJSMap = require_addPairToJSMap();
+    var identity = require_identity();
+    function createPair(key, value, ctx) {
+      const k = createNode.createNode(key, void 0, ctx);
+      const v = createNode.createNode(value, void 0, ctx);
+      return new Pair(k, v);
+    }
+    var Pair = class _Pair {
+      constructor(key, value = null) {
+        Object.defineProperty(this, identity.NODE_TYPE, { value: identity.PAIR });
+        this.key = key;
+        this.value = value;
+      }
+      clone(schema) {
+        let { key, value } = this;
+        if (identity.isNode(key))
+          key = key.clone(schema);
+        if (identity.isNode(value))
+          value = value.clone(schema);
+        return new _Pair(key, value);
+      }
+      toJSON(_, ctx) {
+        const pair = ctx?.mapAsMap ? /* @__PURE__ */ new Map() : {};
+        return addPairToJSMap.addPairToJSMap(ctx, pair, this);
+      }
+      toString(ctx, onComment, onChompKeep) {
+        return ctx?.doc ? stringifyPair.stringifyPair(this, ctx, onComment, onChompKeep) : JSON.stringify(this);
+      }
+    };
+    exports2.Pair = Pair;
+    exports2.createPair = createPair;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js
+var require_stringifyCollection = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var stringify = require_stringify();
+    var stringifyComment = require_stringifyComment();
+    function stringifyCollection(collection, ctx, options) {
+      const flow = ctx.inFlow ?? collection.flow;
+      const stringify2 = flow ? stringifyFlowCollection : stringifyBlockCollection;
+      return stringify2(collection, ctx, options);
+    }
+    function stringifyBlockCollection({ comment, items }, ctx, { blockItemPrefix, flowChars, itemIndent, onChompKeep, onComment }) {
+      const { indent, options: { commentString } } = ctx;
+      const itemCtx = Object.assign({}, ctx, { indent: itemIndent, type: null });
+      let chompKeep = false;
+      const lines = [];
+      for (let i = 0; i < items.length; ++i) {
+        const item = items[i];
+        let comment2 = null;
+        if (identity.isNode(item)) {
+          if (!chompKeep && item.spaceBefore)
+            lines.push("");
+          addCommentBefore(ctx, lines, item.commentBefore, chompKeep);
+          if (item.comment)
+            comment2 = item.comment;
+        } else if (identity.isPair(item)) {
+          const ik = identity.isNode(item.key) ? item.key : null;
+          if (ik) {
+            if (!chompKeep && ik.spaceBefore)
+              lines.push("");
+            addCommentBefore(ctx, lines, ik.commentBefore, chompKeep);
+          }
+        }
+        chompKeep = false;
+        let str2 = stringify.stringify(item, itemCtx, () => comment2 = null, () => chompKeep = true);
+        if (comment2)
+          str2 += stringifyComment.lineComment(str2, itemIndent, commentString(comment2));
+        if (chompKeep && comment2)
+          chompKeep = false;
+        lines.push(blockItemPrefix + str2);
+      }
+      let str;
+      if (lines.length === 0) {
+        str = flowChars.start + flowChars.end;
+      } else {
+        str = lines[0];
+        for (let i = 1; i < lines.length; ++i) {
+          const line = lines[i];
+          str += line ? `
+${indent}${line}` : "\n";
+        }
+      }
+      if (comment) {
+        str += "\n" + stringifyComment.indentComment(commentString(comment), indent);
+        if (onComment)
+          onComment();
+      } else if (chompKeep && onChompKeep)
+        onChompKeep();
+      return str;
+    }
+    function stringifyFlowCollection({ items }, ctx, { flowChars, itemIndent }) {
+      const { indent, indentStep, flowCollectionPadding: fcPadding, options: { commentString } } = ctx;
+      itemIndent += indentStep;
+      const itemCtx = Object.assign({}, ctx, {
+        indent: itemIndent,
+        inFlow: true,
+        type: null
+      });
+      let reqNewline = false;
+      let linesAtValue = 0;
+      const lines = [];
+      for (let i = 0; i < items.length; ++i) {
+        const item = items[i];
+        let comment = null;
+        if (identity.isNode(item)) {
+          if (item.spaceBefore)
+            lines.push("");
+          addCommentBefore(ctx, lines, item.commentBefore, false);
+          if (item.comment)
+            comment = item.comment;
+        } else if (identity.isPair(item)) {
+          const ik = identity.isNode(item.key) ? item.key : null;
+          if (ik) {
+            if (ik.spaceBefore)
+              lines.push("");
+            addCommentBefore(ctx, lines, ik.commentBefore, false);
+            if (ik.comment)
+              reqNewline = true;
+          }
+          const iv = identity.isNode(item.value) ? item.value : null;
+          if (iv) {
+            if (iv.comment)
+              comment = iv.comment;
+            if (iv.commentBefore)
+              reqNewline = true;
+          } else if (item.value == null && ik?.comment) {
+            comment = ik.comment;
+          }
+        }
+        if (comment)
+          reqNewline = true;
+        let str = stringify.stringify(item, itemCtx, () => comment = null);
+        if (i < items.length - 1)
+          str += ",";
+        if (comment)
+          str += stringifyComment.lineComment(str, itemIndent, commentString(comment));
+        if (!reqNewline && (lines.length > linesAtValue || str.includes("\n")))
+          reqNewline = true;
+        lines.push(str);
+        linesAtValue = lines.length;
+      }
+      const { start, end } = flowChars;
+      if (lines.length === 0) {
+        return start + end;
+      } else {
+        if (!reqNewline) {
+          const len = lines.reduce((sum, line) => sum + line.length + 2, 2);
+          reqNewline = ctx.options.lineWidth > 0 && len > ctx.options.lineWidth;
+        }
+        if (reqNewline) {
+          let str = start;
+          for (const line of lines)
+            str += line ? `
+${indentStep}${indent}${line}` : "\n";
+          return `${str}
+${indent}${end}`;
+        } else {
+          return `${start}${fcPadding}${lines.join(" ")}${fcPadding}${end}`;
+        }
+      }
+    }
+    function addCommentBefore({ indent, options: { commentString } }, lines, comment, chompKeep) {
+      if (comment && chompKeep)
+        comment = comment.replace(/^\n+/, "");
+      if (comment) {
+        const ic = stringifyComment.indentComment(commentString(comment), indent);
+        lines.push(ic.trimStart());
+      }
+    }
+    exports2.stringifyCollection = stringifyCollection;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js
+var require_YAMLMap = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLMap.js"(exports2) {
+    "use strict";
+    var stringifyCollection = require_stringifyCollection();
+    var addPairToJSMap = require_addPairToJSMap();
+    var Collection = require_Collection();
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var Scalar = require_Scalar();
+    function findPair(items, key) {
+      const k = identity.isScalar(key) ? key.value : key;
+      for (const it of items) {
+        if (identity.isPair(it)) {
+          if (it.key === key || it.key === k)
+            return it;
+          if (identity.isScalar(it.key) && it.key.value === k)
+            return it;
+        }
+      }
+      return void 0;
+    }
+    var YAMLMap = class extends Collection.Collection {
+      static get tagName() {
+        return "tag:yaml.org,2002:map";
+      }
+      constructor(schema) {
+        super(identity.MAP, schema);
+        this.items = [];
+      }
+      /**
+       * A generic collection parsing method that can be extended
+       * to other node classes that inherit from YAMLMap
+       */
+      static from(schema, obj, ctx) {
+        const { keepUndefined, replacer } = ctx;
+        const map = new this(schema);
+        const add = (key, value) => {
+          if (typeof replacer === "function")
+            value = replacer.call(obj, key, value);
+          else if (Array.isArray(replacer) && !replacer.includes(key))
+            return;
+          if (value !== void 0 || keepUndefined)
+            map.items.push(Pair.createPair(key, value, ctx));
+        };
+        if (obj instanceof Map) {
+          for (const [key, value] of obj)
+            add(key, value);
+        } else if (obj && typeof obj === "object") {
+          for (const key of Object.keys(obj))
+            add(key, obj[key]);
+        }
+        if (typeof schema.sortMapEntries === "function") {
+          map.items.sort(schema.sortMapEntries);
+        }
+        return map;
+      }
+      /**
+       * Adds a value to the collection.
+       *
+       * @param overwrite - If not set `true`, using a key that is already in the
+       *   collection will throw. Otherwise, overwrites the previous value.
+       */
+      add(pair, overwrite) {
+        let _pair;
+        if (identity.isPair(pair))
+          _pair = pair;
+        else if (!pair || typeof pair !== "object" || !("key" in pair)) {
+          _pair = new Pair.Pair(pair, pair?.value);
+        } else
+          _pair = new Pair.Pair(pair.key, pair.value);
+        const prev = findPair(this.items, _pair.key);
+        const sortEntries = this.schema?.sortMapEntries;
+        if (prev) {
+          if (!overwrite)
+            throw new Error(`Key ${_pair.key} already set`);
+          if (identity.isScalar(prev.value) && Scalar.isScalarValue(_pair.value))
+            prev.value.value = _pair.value;
+          else
+            prev.value = _pair.value;
+        } else if (sortEntries) {
+          const i = this.items.findIndex((item) => sortEntries(_pair, item) < 0);
+          if (i === -1)
+            this.items.push(_pair);
+          else
+            this.items.splice(i, 0, _pair);
+        } else {
+          this.items.push(_pair);
+        }
+      }
+      delete(key) {
+        const it = findPair(this.items, key);
+        if (!it)
+          return false;
+        const del = this.items.splice(this.items.indexOf(it), 1);
+        return del.length > 0;
+      }
+      get(key, keepScalar) {
+        const it = findPair(this.items, key);
+        const node = it?.value;
+        return (!keepScalar && identity.isScalar(node) ? node.value : node) ?? void 0;
+      }
+      has(key) {
+        return !!findPair(this.items, key);
+      }
+      set(key, value) {
+        this.add(new Pair.Pair(key, value), true);
+      }
+      /**
+       * @param ctx - Conversion context, originally set in Document#toJS()
+       * @param {Class} Type - If set, forces the returned collection type
+       * @returns Instance of Type, Map, or Object
+       */
+      toJSON(_, ctx, Type) {
+        const map = Type ? new Type() : ctx?.mapAsMap ? /* @__PURE__ */ new Map() : {};
+        if (ctx?.onCreate)
+          ctx.onCreate(map);
+        for (const item of this.items)
+          addPairToJSMap.addPairToJSMap(ctx, map, item);
+        return map;
+      }
+      toString(ctx, onComment, onChompKeep) {
+        if (!ctx)
+          return JSON.stringify(this);
+        for (const item of this.items) {
+          if (!identity.isPair(item))
+            throw new Error(`Map items must all be pairs; found ${JSON.stringify(item)} instead`);
+        }
+        if (!ctx.allNullValues && this.hasAllNullValues(false))
+          ctx = Object.assign({}, ctx, { allNullValues: true });
+        return stringifyCollection.stringifyCollection(this, ctx, {
+          blockItemPrefix: "",
+          flowChars: { start: "{", end: "}" },
+          itemIndent: ctx.indent || "",
+          onChompKeep,
+          onComment
+        });
+      }
+    };
+    exports2.YAMLMap = YAMLMap;
+    exports2.findPair = findPair;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js
+var require_map = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/map.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var YAMLMap = require_YAMLMap();
+    var map = {
+      collection: "map",
+      default: true,
+      nodeClass: YAMLMap.YAMLMap,
+      tag: "tag:yaml.org,2002:map",
+      resolve(map2, onError) {
+        if (!identity.isMap(map2))
+          onError("Expected a mapping for this tag");
+        return map2;
+      },
+      createNode: (schema, obj, ctx) => YAMLMap.YAMLMap.from(schema, obj, ctx)
+    };
+    exports2.map = map;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js
+var require_YAMLSeq = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports2) {
+    "use strict";
+    var createNode = require_createNode();
+    var stringifyCollection = require_stringifyCollection();
+    var Collection = require_Collection();
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var toJS = require_toJS();
+    var YAMLSeq = class extends Collection.Collection {
+      static get tagName() {
+        return "tag:yaml.org,2002:seq";
+      }
+      constructor(schema) {
+        super(identity.SEQ, schema);
+        this.items = [];
+      }
+      add(value) {
+        this.items.push(value);
+      }
+      /**
+       * Removes a value from the collection.
+       *
+       * `key` must contain a representation of an integer for this to succeed.
+       * It may be wrapped in a `Scalar`.
+       *
+       * @returns `true` if the item was found and removed.
+       */
+      delete(key) {
+        const idx = asItemIndex(key);
+        if (typeof idx !== "number")
+          return false;
+        const del = this.items.splice(idx, 1);
+        return del.length > 0;
+      }
+      get(key, keepScalar) {
+        const idx = asItemIndex(key);
+        if (typeof idx !== "number")
+          return void 0;
+        const it = this.items[idx];
+        return !keepScalar && identity.isScalar(it) ? it.value : it;
+      }
+      /**
+       * Checks if the collection includes a value with the key `key`.
+       *
+       * `key` must contain a representation of an integer for this to succeed.
+       * It may be wrapped in a `Scalar`.
+       */
+      has(key) {
+        const idx = asItemIndex(key);
+        return typeof idx === "number" && idx < this.items.length;
+      }
+      /**
+       * Sets a value in this collection. For `!!set`, `value` needs to be a
+       * boolean to add/remove the item from the set.
+       *
+       * If `key` does not contain a representation of an integer, this will throw.
+       * It may be wrapped in a `Scalar`.
+       */
+      set(key, value) {
+        const idx = asItemIndex(key);
+        if (typeof idx !== "number")
+          throw new Error(`Expected a valid index, not ${key}.`);
+        const prev = this.items[idx];
+        if (identity.isScalar(prev) && Scalar.isScalarValue(value))
+          prev.value = value;
+        else
+          this.items[idx] = value;
+      }
+      toJSON(_, ctx) {
+        const seq = [];
+        if (ctx?.onCreate)
+          ctx.onCreate(seq);
+        let i = 0;
+        for (const item of this.items)
+          seq.push(toJS.toJS(item, String(i++), ctx));
+        return seq;
+      }
+      toString(ctx, onComment, onChompKeep) {
+        if (!ctx)
+          return JSON.stringify(this);
+        return stringifyCollection.stringifyCollection(this, ctx, {
+          blockItemPrefix: "- ",
+          flowChars: { start: "[", end: "]" },
+          itemIndent: (ctx.indent || "") + "  ",
+          onChompKeep,
+          onComment
+        });
+      }
+      static from(schema, obj, ctx) {
+        const { replacer } = ctx;
+        const seq = new this(schema);
+        if (obj && Symbol.iterator in Object(obj)) {
+          let i = 0;
+          for (let it of obj) {
+            if (typeof replacer === "function") {
+              const key = obj instanceof Set ? it : String(i++);
+              it = replacer.call(obj, key, it);
+            }
+            seq.items.push(createNode.createNode(it, void 0, ctx));
+          }
+        }
+        return seq;
+      }
+    };
+    function asItemIndex(key) {
+      let idx = identity.isScalar(key) ? key.value : key;
+      if (idx && typeof idx === "string")
+        idx = Number(idx);
+      return typeof idx === "number" && Number.isInteger(idx) && idx >= 0 ? idx : null;
+    }
+    exports2.YAMLSeq = YAMLSeq;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js
+var require_seq = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/seq.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var YAMLSeq = require_YAMLSeq();
+    var seq = {
+      collection: "seq",
+      default: true,
+      nodeClass: YAMLSeq.YAMLSeq,
+      tag: "tag:yaml.org,2002:seq",
+      resolve(seq2, onError) {
+        if (!identity.isSeq(seq2))
+          onError("Expected a sequence for this tag");
+        return seq2;
+      },
+      createNode: (schema, obj, ctx) => YAMLSeq.YAMLSeq.from(schema, obj, ctx)
+    };
+    exports2.seq = seq;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js
+var require_string = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/string.js"(exports2) {
+    "use strict";
+    var stringifyString = require_stringifyString();
+    var string = {
+      identify: (value) => typeof value === "string",
+      default: true,
+      tag: "tag:yaml.org,2002:str",
+      resolve: (str) => str,
+      stringify(item, ctx, onComment, onChompKeep) {
+        ctx = Object.assign({ actualString: true }, ctx);
+        return stringifyString.stringifyString(item, ctx, onComment, onChompKeep);
+      }
+    };
+    exports2.string = string;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js
+var require_null = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/common/null.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var nullTag = {
+      identify: (value) => value == null,
+      createNode: () => new Scalar.Scalar(null),
+      default: true,
+      tag: "tag:yaml.org,2002:null",
+      test: /^(?:~|[Nn]ull|NULL)?$/,
+      resolve: () => new Scalar.Scalar(null),
+      stringify: ({ source }, ctx) => typeof source === "string" && nullTag.test.test(source) ? source : ctx.options.nullStr
+    };
+    exports2.nullTag = nullTag;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js
+var require_bool = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/bool.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var boolTag = {
+      identify: (value) => typeof value === "boolean",
+      default: true,
+      tag: "tag:yaml.org,2002:bool",
+      test: /^(?:[Tt]rue|TRUE|[Ff]alse|FALSE)$/,
+      resolve: (str) => new Scalar.Scalar(str[0] === "t" || str[0] === "T"),
+      stringify({ source, value }, ctx) {
+        if (source && boolTag.test.test(source)) {
+          const sv = source[0] === "t" || source[0] === "T";
+          if (value === sv)
+            return source;
+        }
+        return value ? ctx.options.trueStr : ctx.options.falseStr;
+      }
+    };
+    exports2.boolTag = boolTag;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js
+var require_stringifyNumber = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports2) {
+    "use strict";
+    function stringifyNumber({ format, minFractionDigits, tag, value }) {
+      if (typeof value === "bigint")
+        return String(value);
+      const num = typeof value === "number" ? value : Number(value);
+      if (!isFinite(num))
+        return isNaN(num) ? ".nan" : num < 0 ? "-.inf" : ".inf";
+      let n = Object.is(value, -0) ? "-0" : JSON.stringify(value);
+      if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^\d/.test(n)) {
+        let i = n.indexOf(".");
+        if (i < 0) {
+          i = n.length;
+          n += ".";
+        }
+        let d = minFractionDigits - (n.length - i - 1);
+        while (d-- > 0)
+          n += "0";
+      }
+      return n;
+    }
+    exports2.stringifyNumber = stringifyNumber;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js
+var require_float = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/float.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var stringifyNumber = require_stringifyNumber();
+    var floatNaN = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      test: /^(?:[-+]?\.(?:inf|Inf|INF)|\.nan|\.NaN|\.NAN)$/,
+      resolve: (str) => str.slice(-3).toLowerCase() === "nan" ? NaN : str[0] === "-" ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY,
+      stringify: stringifyNumber.stringifyNumber
+    };
+    var floatExp = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      format: "EXP",
+      test: /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)[eE][-+]?[0-9]+$/,
+      resolve: (str) => parseFloat(str),
+      stringify(node) {
+        const num = Number(node.value);
+        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node);
+      }
+    };
+    var float = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      test: /^[-+]?(?:\.[0-9]+|[0-9]+\.[0-9]*)$/,
+      resolve(str) {
+        const node = new Scalar.Scalar(parseFloat(str));
+        const dot = str.indexOf(".");
+        if (dot !== -1 && str[str.length - 1] === "0")
+          node.minFractionDigits = str.length - dot - 1;
+        return node;
+      },
+      stringify: stringifyNumber.stringifyNumber
+    };
+    exports2.float = float;
+    exports2.floatExp = floatExp;
+    exports2.floatNaN = floatNaN;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js
+var require_int = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/int.js"(exports2) {
+    "use strict";
+    var stringifyNumber = require_stringifyNumber();
+    var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
+    var intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
+    function intStringify(node, radix, prefix) {
+      const { value } = node;
+      if (intIdentify(value) && value >= 0)
+        return prefix + value.toString(radix);
+      return stringifyNumber.stringifyNumber(node);
+    }
+    var intOct = {
+      identify: (value) => intIdentify(value) && value >= 0,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "OCT",
+      test: /^0o[0-7]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 2, 8, opt),
+      stringify: (node) => intStringify(node, 8, "0o")
+    };
+    var int = {
+      identify: intIdentify,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      test: /^[-+]?[0-9]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 0, 10, opt),
+      stringify: stringifyNumber.stringifyNumber
+    };
+    var intHex = {
+      identify: (value) => intIdentify(value) && value >= 0,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "HEX",
+      test: /^0x[0-9a-fA-F]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 2, 16, opt),
+      stringify: (node) => intStringify(node, 16, "0x")
+    };
+    exports2.int = int;
+    exports2.intHex = intHex;
+    exports2.intOct = intOct;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js
+var require_schema = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/core/schema.js"(exports2) {
+    "use strict";
+    var map = require_map();
+    var _null = require_null();
+    var seq = require_seq();
+    var string = require_string();
+    var bool = require_bool();
+    var float = require_float();
+    var int = require_int();
+    var schema = [
+      map.map,
+      seq.seq,
+      string.string,
+      _null.nullTag,
+      bool.boolTag,
+      int.intOct,
+      int.int,
+      int.intHex,
+      float.floatNaN,
+      float.floatExp,
+      float.float
+    ];
+    exports2.schema = schema;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js
+var require_schema2 = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/json/schema.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var map = require_map();
+    var seq = require_seq();
+    function intIdentify(value) {
+      return typeof value === "bigint" || Number.isInteger(value);
+    }
+    var stringifyJSON = ({ value }) => JSON.stringify(value);
+    var jsonScalars = [
+      {
+        identify: (value) => typeof value === "string",
+        default: true,
+        tag: "tag:yaml.org,2002:str",
+        resolve: (str) => str,
+        stringify: stringifyJSON
+      },
+      {
+        identify: (value) => value == null,
+        createNode: () => new Scalar.Scalar(null),
+        default: true,
+        tag: "tag:yaml.org,2002:null",
+        test: /^null$/,
+        resolve: () => null,
+        stringify: stringifyJSON
+      },
+      {
+        identify: (value) => typeof value === "boolean",
+        default: true,
+        tag: "tag:yaml.org,2002:bool",
+        test: /^true$|^false$/,
+        resolve: (str) => str === "true",
+        stringify: stringifyJSON
+      },
+      {
+        identify: intIdentify,
+        default: true,
+        tag: "tag:yaml.org,2002:int",
+        test: /^-?(?:0|[1-9][0-9]*)$/,
+        resolve: (str, _onError, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str, 10),
+        stringify: ({ value }) => intIdentify(value) ? value.toString() : JSON.stringify(value)
+      },
+      {
+        identify: (value) => typeof value === "number",
+        default: true,
+        tag: "tag:yaml.org,2002:float",
+        test: /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+)?$/,
+        resolve: (str) => parseFloat(str),
+        stringify: stringifyJSON
+      }
+    ];
+    var jsonError = {
+      default: true,
+      tag: "",
+      test: /^/,
+      resolve(str, onError) {
+        onError(`Unresolved plain scalar ${JSON.stringify(str)}`);
+        return str;
+      }
+    };
+    var schema = [map.map, seq.seq].concat(jsonScalars, jsonError);
+    exports2.schema = schema;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js
+var require_binary = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports2) {
+    "use strict";
+    var node_buffer = require("buffer");
+    var Scalar = require_Scalar();
+    var stringifyString = require_stringifyString();
+    var binary = {
+      identify: (value) => value instanceof Uint8Array,
+      // Buffer inherits from Uint8Array
+      default: false,
+      tag: "tag:yaml.org,2002:binary",
+      /**
+       * Returns a Buffer in node and an Uint8Array in browsers
+       *
+       * To use the resulting buffer as an image, you'll want to do something like:
+       *
+       *   const blob = new Blob([buffer], { type: 'image/jpeg' })
+       *   document.querySelector('#photo').src = URL.createObjectURL(blob)
+       */
+      resolve(src, onError) {
+        if (typeof node_buffer.Buffer === "function") {
+          return node_buffer.Buffer.from(src, "base64");
+        } else if (typeof atob === "function") {
+          const str = atob(src.replace(/[\n\r]/g, ""));
+          const buffer = new Uint8Array(str.length);
+          for (let i = 0; i < str.length; ++i)
+            buffer[i] = str.charCodeAt(i);
+          return buffer;
+        } else {
+          onError("This environment does not support reading binary tags; either Buffer or atob is required");
+          return src;
+        }
+      },
+      stringify({ comment, type, value }, ctx, onComment, onChompKeep) {
+        if (!value)
+          return "";
+        const buf = value;
+        let str;
+        if (typeof node_buffer.Buffer === "function") {
+          str = buf instanceof node_buffer.Buffer ? buf.toString("base64") : node_buffer.Buffer.from(buf.buffer).toString("base64");
+        } else if (typeof btoa === "function") {
+          let s = "";
+          for (let i = 0; i < buf.length; ++i)
+            s += String.fromCharCode(buf[i]);
+          str = btoa(s);
+        } else {
+          throw new Error("This environment does not support writing binary tags; either Buffer or btoa is required");
+        }
+        type ?? (type = Scalar.Scalar.BLOCK_LITERAL);
+        if (type !== Scalar.Scalar.QUOTE_DOUBLE) {
+          const lineWidth = Math.max(ctx.options.lineWidth - ctx.indent.length, ctx.options.minContentWidth);
+          const n = Math.ceil(str.length / lineWidth);
+          const lines = new Array(n);
+          for (let i = 0, o = 0; i < n; ++i, o += lineWidth) {
+            lines[i] = str.substr(o, lineWidth);
+          }
+          str = lines.join(type === Scalar.Scalar.BLOCK_LITERAL ? "\n" : " ");
+        }
+        return stringifyString.stringifyString({ comment, type, value: str }, ctx, onComment, onChompKeep);
+      }
+    };
+    exports2.binary = binary;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+var require_pairs = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var Scalar = require_Scalar();
+    var YAMLSeq = require_YAMLSeq();
+    function resolvePairs(seq, onError) {
+      if (identity.isSeq(seq)) {
+        for (let i = 0; i < seq.items.length; ++i) {
+          let item = seq.items[i];
+          if (identity.isPair(item))
+            continue;
+          else if (identity.isMap(item)) {
+            if (item.items.length > 1)
+              onError("Each pair must have its own sequence indicator");
+            const pair = item.items[0] || new Pair.Pair(new Scalar.Scalar(null));
+            if (item.commentBefore)
+              pair.key.commentBefore = pair.key.commentBefore ? `${item.commentBefore}
+${pair.key.commentBefore}` : item.commentBefore;
+            if (item.comment) {
+              const cn = pair.value ?? pair.key;
+              cn.comment = cn.comment ? `${item.comment}
+${cn.comment}` : item.comment;
+            }
+            item = pair;
+          }
+          seq.items[i] = identity.isPair(item) ? item : new Pair.Pair(item);
+        }
+      } else
+        onError("Expected a sequence for this tag");
+      return seq;
+    }
+    function createPairs(schema, iterable, ctx) {
+      const { replacer } = ctx;
+      const pairs2 = new YAMLSeq.YAMLSeq(schema);
+      pairs2.tag = "tag:yaml.org,2002:pairs";
+      let i = 0;
+      if (iterable && Symbol.iterator in Object(iterable))
+        for (let it of iterable) {
+          if (typeof replacer === "function")
+            it = replacer.call(iterable, String(i++), it);
+          let key, value;
+          if (Array.isArray(it)) {
+            if (it.length === 2) {
+              key = it[0];
+              value = it[1];
+            } else
+              throw new TypeError(`Expected [key, value] tuple: ${it}`);
+          } else if (it && it instanceof Object) {
+            const keys = Object.keys(it);
+            if (keys.length === 1) {
+              key = keys[0];
+              value = it[key];
+            } else {
+              throw new TypeError(`Expected tuple with one key, not ${keys.length} keys`);
+            }
+          } else {
+            key = it;
+          }
+          pairs2.items.push(Pair.createPair(key, value, ctx));
+        }
+      return pairs2;
+    }
+    var pairs = {
+      collection: "seq",
+      default: false,
+      tag: "tag:yaml.org,2002:pairs",
+      resolve: resolvePairs,
+      createNode: createPairs
+    };
+    exports2.createPairs = createPairs;
+    exports2.pairs = pairs;
+    exports2.resolvePairs = resolvePairs;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js
+var require_omap = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var toJS = require_toJS();
+    var YAMLMap = require_YAMLMap();
+    var YAMLSeq = require_YAMLSeq();
+    var pairs = require_pairs();
+    var YAMLOMap = class _YAMLOMap extends YAMLSeq.YAMLSeq {
+      constructor() {
+        super();
+        this.add = YAMLMap.YAMLMap.prototype.add.bind(this);
+        this.delete = YAMLMap.YAMLMap.prototype.delete.bind(this);
+        this.get = YAMLMap.YAMLMap.prototype.get.bind(this);
+        this.has = YAMLMap.YAMLMap.prototype.has.bind(this);
+        this.set = YAMLMap.YAMLMap.prototype.set.bind(this);
+        this.tag = _YAMLOMap.tag;
+      }
+      /**
+       * If `ctx` is given, the return type is actually `Map<unknown, unknown>`,
+       * but TypeScript won't allow widening the signature of a child method.
+       */
+      toJSON(_, ctx) {
+        if (!ctx)
+          return super.toJSON(_);
+        const map = /* @__PURE__ */ new Map();
+        if (ctx?.onCreate)
+          ctx.onCreate(map);
+        for (const pair of this.items) {
+          let key, value;
+          if (identity.isPair(pair)) {
+            key = toJS.toJS(pair.key, "", ctx);
+            value = toJS.toJS(pair.value, key, ctx);
+          } else {
+            key = toJS.toJS(pair, "", ctx);
+          }
+          if (map.has(key))
+            throw new Error("Ordered maps must not include duplicate keys");
+          map.set(key, value);
+        }
+        return map;
+      }
+      static from(schema, iterable, ctx) {
+        const pairs$1 = pairs.createPairs(schema, iterable, ctx);
+        const omap2 = new this();
+        omap2.items = pairs$1.items;
+        return omap2;
+      }
+    };
+    YAMLOMap.tag = "tag:yaml.org,2002:omap";
+    var omap = {
+      collection: "seq",
+      identify: (value) => value instanceof Map,
+      nodeClass: YAMLOMap,
+      default: false,
+      tag: "tag:yaml.org,2002:omap",
+      resolve(seq, onError) {
+        const pairs$1 = pairs.resolvePairs(seq, onError);
+        const seenKeys = [];
+        for (const { key } of pairs$1.items) {
+          if (identity.isScalar(key)) {
+            if (seenKeys.includes(key.value)) {
+              onError(`Ordered maps must not include duplicate keys: ${key.value}`);
+            } else {
+              seenKeys.push(key.value);
+            }
+          }
+        }
+        return Object.assign(new YAMLOMap(), pairs$1);
+      },
+      createNode: (schema, iterable, ctx) => YAMLOMap.from(schema, iterable, ctx)
+    };
+    exports2.YAMLOMap = YAMLOMap;
+    exports2.omap = omap;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js
+var require_bool2 = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    function boolStringify({ value, source }, ctx) {
+      const boolObj = value ? trueTag : falseTag;
+      if (source && boolObj.test.test(source))
+        return source;
+      return value ? ctx.options.trueStr : ctx.options.falseStr;
+    }
+    var trueTag = {
+      identify: (value) => value === true,
+      default: true,
+      tag: "tag:yaml.org,2002:bool",
+      test: /^(?:Y|y|[Yy]es|YES|[Tt]rue|TRUE|[Oo]n|ON)$/,
+      resolve: () => new Scalar.Scalar(true),
+      stringify: boolStringify
+    };
+    var falseTag = {
+      identify: (value) => value === false,
+      default: true,
+      tag: "tag:yaml.org,2002:bool",
+      test: /^(?:N|n|[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/,
+      resolve: () => new Scalar.Scalar(false),
+      stringify: boolStringify
+    };
+    exports2.falseTag = falseTag;
+    exports2.trueTag = trueTag;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js
+var require_float2 = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var stringifyNumber = require_stringifyNumber();
+    var floatNaN = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      test: /^(?:[-+]?\.(?:inf|Inf|INF)|\.nan|\.NaN|\.NAN)$/,
+      resolve: (str) => str.slice(-3).toLowerCase() === "nan" ? NaN : str[0] === "-" ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY,
+      stringify: stringifyNumber.stringifyNumber
+    };
+    var floatExp = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      format: "EXP",
+      test: /^[-+]?(?:[0-9][0-9_]*)?(?:\.[0-9_]*)?[eE][-+]?[0-9]+$/,
+      resolve: (str) => parseFloat(str.replace(/_/g, "")),
+      stringify(node) {
+        const num = Number(node.value);
+        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node);
+      }
+    };
+    var float = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      test: /^[-+]?(?:[0-9][0-9_]*)?\.[0-9_]*$/,
+      resolve(str) {
+        const node = new Scalar.Scalar(parseFloat(str.replace(/_/g, "")));
+        const dot = str.indexOf(".");
+        if (dot !== -1) {
+          const f = str.substring(dot + 1).replace(/_/g, "");
+          if (f[f.length - 1] === "0")
+            node.minFractionDigits = f.length;
+        }
+        return node;
+      },
+      stringify: stringifyNumber.stringifyNumber
+    };
+    exports2.float = float;
+    exports2.floatExp = floatExp;
+    exports2.floatNaN = floatNaN;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js
+var require_int2 = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports2) {
+    "use strict";
+    var stringifyNumber = require_stringifyNumber();
+    var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
+    function intResolve(str, offset, radix, { intAsBigInt }) {
+      const sign = str[0];
+      if (sign === "-" || sign === "+")
+        offset += 1;
+      str = str.substring(offset).replace(/_/g, "");
+      if (intAsBigInt) {
+        switch (radix) {
+          case 2:
+            str = `0b${str}`;
+            break;
+          case 8:
+            str = `0o${str}`;
+            break;
+          case 16:
+            str = `0x${str}`;
+            break;
+        }
+        const n2 = BigInt(str);
+        return sign === "-" ? BigInt(-1) * n2 : n2;
+      }
+      const n = parseInt(str, radix);
+      return sign === "-" ? -1 * n : n;
+    }
+    function intStringify(node, radix, prefix) {
+      const { value } = node;
+      if (intIdentify(value)) {
+        const str = value.toString(radix);
+        return value < 0 ? "-" + prefix + str.substr(1) : prefix + str;
+      }
+      return stringifyNumber.stringifyNumber(node);
+    }
+    var intBin = {
+      identify: intIdentify,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "BIN",
+      test: /^[-+]?0b[0-1_]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 2, 2, opt),
+      stringify: (node) => intStringify(node, 2, "0b")
+    };
+    var intOct = {
+      identify: intIdentify,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "OCT",
+      test: /^[-+]?0[0-7_]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 1, 8, opt),
+      stringify: (node) => intStringify(node, 8, "0")
+    };
+    var int = {
+      identify: intIdentify,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      test: /^[-+]?[0-9][0-9_]*$/,
+      resolve: (str, _onError, opt) => intResolve(str, 0, 10, opt),
+      stringify: stringifyNumber.stringifyNumber
+    };
+    var intHex = {
+      identify: intIdentify,
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "HEX",
+      test: /^[-+]?0x[0-9a-fA-F_]+$/,
+      resolve: (str, _onError, opt) => intResolve(str, 2, 16, opt),
+      stringify: (node) => intStringify(node, 16, "0x")
+    };
+    exports2.int = int;
+    exports2.intBin = intBin;
+    exports2.intHex = intHex;
+    exports2.intOct = intOct;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js
+var require_set = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var YAMLMap = require_YAMLMap();
+    var YAMLSet = class _YAMLSet extends YAMLMap.YAMLMap {
+      constructor(schema) {
+        super(schema);
+        this.tag = _YAMLSet.tag;
+      }
+      add(key) {
+        let pair;
+        if (identity.isPair(key))
+          pair = key;
+        else if (key && typeof key === "object" && "key" in key && "value" in key && key.value === null)
+          pair = new Pair.Pair(key.key, null);
+        else
+          pair = new Pair.Pair(key, null);
+        const prev = YAMLMap.findPair(this.items, pair.key);
+        if (!prev)
+          this.items.push(pair);
+      }
+      /**
+       * If `keepPair` is `true`, returns the Pair matching `key`.
+       * Otherwise, returns the value of that Pair's key.
+       */
+      get(key, keepPair) {
+        const pair = YAMLMap.findPair(this.items, key);
+        return !keepPair && identity.isPair(pair) ? identity.isScalar(pair.key) ? pair.key.value : pair.key : pair;
+      }
+      set(key, value) {
+        if (typeof value !== "boolean")
+          throw new Error(`Expected boolean value for set(key, value) in a YAML set, not ${typeof value}`);
+        const prev = YAMLMap.findPair(this.items, key);
+        if (prev && !value) {
+          this.items.splice(this.items.indexOf(prev), 1);
+        } else if (!prev && value) {
+          this.items.push(new Pair.Pair(key));
+        }
+      }
+      toJSON(_, ctx) {
+        return super.toJSON(_, ctx, Set);
+      }
+      toString(ctx, onComment, onChompKeep) {
+        if (!ctx)
+          return JSON.stringify(this);
+        if (this.hasAllNullValues(true))
+          return super.toString(Object.assign({}, ctx, { allNullValues: true }), onComment, onChompKeep);
+        else
+          throw new Error("Set items must all have null values");
+      }
+      static from(schema, iterable, ctx) {
+        const { replacer } = ctx;
+        const set2 = new this(schema);
+        if (iterable && Symbol.iterator in Object(iterable))
+          for (let value of iterable) {
+            if (typeof replacer === "function")
+              value = replacer.call(iterable, value, value);
+            set2.items.push(Pair.createPair(value, null, ctx));
+          }
+        return set2;
+      }
+    };
+    YAMLSet.tag = "tag:yaml.org,2002:set";
+    var set = {
+      collection: "map",
+      identify: (value) => value instanceof Set,
+      nodeClass: YAMLSet,
+      default: false,
+      tag: "tag:yaml.org,2002:set",
+      createNode: (schema, iterable, ctx) => YAMLSet.from(schema, iterable, ctx),
+      resolve(map, onError) {
+        if (identity.isMap(map)) {
+          if (map.hasAllNullValues(true))
+            return Object.assign(new YAMLSet(), map);
+          else
+            onError("Set items must all have null values");
+        } else
+          onError("Expected a mapping for this tag");
+        return map;
+      }
+    };
+    exports2.YAMLSet = YAMLSet;
+    exports2.set = set;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+var require_timestamp = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports2) {
+    "use strict";
+    var stringifyNumber = require_stringifyNumber();
+    function parseSexagesimal(str, asBigInt) {
+      const sign = str[0];
+      const parts = sign === "-" || sign === "+" ? str.substring(1) : str;
+      const num = (n) => asBigInt ? BigInt(n) : Number(n);
+      const res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
+      return sign === "-" ? num(-1) * res : res;
+    }
+    function stringifySexagesimal(node) {
+      let { value } = node;
+      let num = (n) => n;
+      if (typeof value === "bigint")
+        num = (n) => BigInt(n);
+      else if (isNaN(value) || !isFinite(value))
+        return stringifyNumber.stringifyNumber(node);
+      let sign = "";
+      if (value < 0) {
+        sign = "-";
+        value *= num(-1);
+      }
+      const _60 = num(60);
+      const parts = [value % _60];
+      if (value < 60) {
+        parts.unshift(0);
+      } else {
+        value = (value - parts[0]) / _60;
+        parts.unshift(value % _60);
+        if (value >= 60) {
+          value = (value - parts[0]) / _60;
+          parts.unshift(value);
+        }
+      }
+      return sign + parts.map((n) => String(n).padStart(2, "0")).join(":").replace(/000000\d*$/, "");
+    }
+    var intTime = {
+      identify: (value) => typeof value === "bigint" || Number.isInteger(value),
+      default: true,
+      tag: "tag:yaml.org,2002:int",
+      format: "TIME",
+      test: /^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+$/,
+      resolve: (str, _onError, { intAsBigInt }) => parseSexagesimal(str, intAsBigInt),
+      stringify: stringifySexagesimal
+    };
+    var floatTime = {
+      identify: (value) => typeof value === "number",
+      default: true,
+      tag: "tag:yaml.org,2002:float",
+      format: "TIME",
+      test: /^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*$/,
+      resolve: (str) => parseSexagesimal(str, false),
+      stringify: stringifySexagesimal
+    };
+    var timestamp = {
+      identify: (value) => value instanceof Date,
+      default: true,
+      tag: "tag:yaml.org,2002:timestamp",
+      // If the time zone is omitted, the timestamp is assumed to be specified in UTC. The time part
+      // may be omitted altogether, resulting in a date format. In such a case, the time part is
+      // assumed to be 00:00:00Z (start of day, UTC).
+      test: RegExp("^([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})(?:(?:t|T|[ \\t]+)([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2}(\\.[0-9]+)?)(?:[ \\t]*(Z|[-+][012]?[0-9](?::[0-9]{2})?))?)?$"),
+      resolve(str) {
+        const match = str.match(timestamp.test);
+        if (!match)
+          throw new Error("!!timestamp expects a date, starting with yyyy-mm-dd");
+        const [, year, month, day, hour, minute, second] = match.map(Number);
+        const millisec = match[7] ? Number((match[7] + "00").substr(1, 3)) : 0;
+        let date = Date.UTC(year, month - 1, day, hour || 0, minute || 0, second || 0, millisec);
+        const tz = match[8];
+        if (tz && tz !== "Z") {
+          let d = parseSexagesimal(tz, false);
+          if (Math.abs(d) < 30)
+            d *= 60;
+          date -= 6e4 * d;
+        }
+        return new Date(date);
+      },
+      stringify: ({ value }) => value?.toISOString().replace(/(T00:00:00)?\.000Z$/, "") ?? ""
+    };
+    exports2.floatTime = floatTime;
+    exports2.intTime = intTime;
+    exports2.timestamp = timestamp;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js
+var require_schema3 = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports2) {
+    "use strict";
+    var map = require_map();
+    var _null = require_null();
+    var seq = require_seq();
+    var string = require_string();
+    var binary = require_binary();
+    var bool = require_bool2();
+    var float = require_float2();
+    var int = require_int2();
+    var merge = require_merge();
+    var omap = require_omap();
+    var pairs = require_pairs();
+    var set = require_set();
+    var timestamp = require_timestamp();
+    var schema = [
+      map.map,
+      seq.seq,
+      string.string,
+      _null.nullTag,
+      bool.trueTag,
+      bool.falseTag,
+      int.intBin,
+      int.intOct,
+      int.int,
+      int.intHex,
+      float.floatNaN,
+      float.floatExp,
+      float.float,
+      binary.binary,
+      merge.merge,
+      omap.omap,
+      pairs.pairs,
+      set.set,
+      timestamp.intTime,
+      timestamp.floatTime,
+      timestamp.timestamp
+    ];
+    exports2.schema = schema;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js
+var require_tags = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/tags.js"(exports2) {
+    "use strict";
+    var map = require_map();
+    var _null = require_null();
+    var seq = require_seq();
+    var string = require_string();
+    var bool = require_bool();
+    var float = require_float();
+    var int = require_int();
+    var schema = require_schema();
+    var schema$1 = require_schema2();
+    var binary = require_binary();
+    var merge = require_merge();
+    var omap = require_omap();
+    var pairs = require_pairs();
+    var schema$2 = require_schema3();
+    var set = require_set();
+    var timestamp = require_timestamp();
+    var schemas = /* @__PURE__ */ new Map([
+      ["core", schema.schema],
+      ["failsafe", [map.map, seq.seq, string.string]],
+      ["json", schema$1.schema],
+      ["yaml11", schema$2.schema],
+      ["yaml-1.1", schema$2.schema]
+    ]);
+    var tagsByName = {
+      binary: binary.binary,
+      bool: bool.boolTag,
+      float: float.float,
+      floatExp: float.floatExp,
+      floatNaN: float.floatNaN,
+      floatTime: timestamp.floatTime,
+      int: int.int,
+      intHex: int.intHex,
+      intOct: int.intOct,
+      intTime: timestamp.intTime,
+      map: map.map,
+      merge: merge.merge,
+      null: _null.nullTag,
+      omap: omap.omap,
+      pairs: pairs.pairs,
+      seq: seq.seq,
+      set: set.set,
+      timestamp: timestamp.timestamp
+    };
+    var coreKnownTags = {
+      "tag:yaml.org,2002:binary": binary.binary,
+      "tag:yaml.org,2002:merge": merge.merge,
+      "tag:yaml.org,2002:omap": omap.omap,
+      "tag:yaml.org,2002:pairs": pairs.pairs,
+      "tag:yaml.org,2002:set": set.set,
+      "tag:yaml.org,2002:timestamp": timestamp.timestamp
+    };
+    function getTags(customTags, schemaName, addMergeTag) {
+      const schemaTags = schemas.get(schemaName);
+      if (schemaTags && !customTags) {
+        return addMergeTag && !schemaTags.includes(merge.merge) ? schemaTags.concat(merge.merge) : schemaTags.slice();
+      }
+      let tags = schemaTags;
+      if (!tags) {
+        if (Array.isArray(customTags))
+          tags = [];
+        else {
+          const keys = Array.from(schemas.keys()).filter((key) => key !== "yaml11").map((key) => JSON.stringify(key)).join(", ");
+          throw new Error(`Unknown schema "${schemaName}"; use one of ${keys} or define customTags array`);
+        }
+      }
+      if (Array.isArray(customTags)) {
+        for (const tag of customTags)
+          tags = tags.concat(tag);
+      } else if (typeof customTags === "function") {
+        tags = customTags(tags.slice());
+      }
+      if (addMergeTag)
+        tags = tags.concat(merge.merge);
+      return tags.reduce((tags2, tag) => {
+        const tagObj = typeof tag === "string" ? tagsByName[tag] : tag;
+        if (!tagObj) {
+          const tagName = JSON.stringify(tag);
+          const keys = Object.keys(tagsByName).map((key) => JSON.stringify(key)).join(", ");
+          throw new Error(`Unknown custom tag ${tagName}; use one of ${keys}`);
+        }
+        if (!tags2.includes(tagObj))
+          tags2.push(tagObj);
+        return tags2;
+      }, []);
+    }
+    exports2.coreKnownTags = coreKnownTags;
+    exports2.getTags = getTags;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js
+var require_Schema = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/schema/Schema.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var map = require_map();
+    var seq = require_seq();
+    var string = require_string();
+    var tags = require_tags();
+    var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+    var Schema = class _Schema {
+      constructor({ compat, customTags, merge, resolveKnownTags, schema, sortMapEntries, toStringDefaults }) {
+        this.compat = Array.isArray(compat) ? tags.getTags(compat, "compat") : compat ? tags.getTags(null, compat) : null;
+        this.name = typeof schema === "string" && schema || "core";
+        this.knownTags = resolveKnownTags ? tags.coreKnownTags : {};
+        this.tags = tags.getTags(customTags, this.name, merge);
+        this.toStringOptions = toStringDefaults ?? null;
+        Object.defineProperty(this, identity.MAP, { value: map.map });
+        Object.defineProperty(this, identity.SCALAR, { value: string.string });
+        Object.defineProperty(this, identity.SEQ, { value: seq.seq });
+        this.sortMapEntries = typeof sortMapEntries === "function" ? sortMapEntries : sortMapEntries === true ? sortMapEntriesByKey : null;
+      }
+      clone() {
+        const copy = Object.create(_Schema.prototype, Object.getOwnPropertyDescriptors(this));
+        copy.tags = this.tags.slice();
+        return copy;
+      }
+    };
+    exports2.Schema = Schema;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js
+var require_stringifyDocument = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var stringify = require_stringify();
+    var stringifyComment = require_stringifyComment();
+    function stringifyDocument(doc, options) {
+      const lines = [];
+      let hasDirectives = options.directives === true;
+      if (options.directives !== false && doc.directives) {
+        const dir = doc.directives.toString(doc);
+        if (dir) {
+          lines.push(dir);
+          hasDirectives = true;
+        } else if (doc.directives.docStart)
+          hasDirectives = true;
+      }
+      if (hasDirectives)
+        lines.push("---");
+      const ctx = stringify.createStringifyContext(doc, options);
+      const { commentString } = ctx.options;
+      if (doc.commentBefore) {
+        if (lines.length !== 1)
+          lines.unshift("");
+        const cs = commentString(doc.commentBefore);
+        lines.unshift(stringifyComment.indentComment(cs, ""));
+      }
+      let chompKeep = false;
+      let contentComment = null;
+      if (doc.contents) {
+        if (identity.isNode(doc.contents)) {
+          if (doc.contents.spaceBefore && hasDirectives)
+            lines.push("");
+          if (doc.contents.commentBefore) {
+            const cs = commentString(doc.contents.commentBefore);
+            lines.push(stringifyComment.indentComment(cs, ""));
+          }
+          ctx.forceBlockIndent = !!doc.comment;
+          contentComment = doc.contents.comment;
+        }
+        const onChompKeep = contentComment ? void 0 : () => chompKeep = true;
+        let body = stringify.stringify(doc.contents, ctx, () => contentComment = null, onChompKeep);
+        if (contentComment)
+          body += stringifyComment.lineComment(body, "", commentString(contentComment));
+        if ((body[0] === "|" || body[0] === ">") && lines[lines.length - 1] === "---") {
+          lines[lines.length - 1] = `--- ${body}`;
+        } else
+          lines.push(body);
+      } else {
+        lines.push(stringify.stringify(doc.contents, ctx));
+      }
+      if (doc.directives?.docEnd) {
+        if (doc.comment) {
+          const cs = commentString(doc.comment);
+          if (cs.includes("\n")) {
+            lines.push("...");
+            lines.push(stringifyComment.indentComment(cs, ""));
+          } else {
+            lines.push(`... ${cs}`);
+          }
+        } else {
+          lines.push("...");
+        }
+      } else {
+        let dc = doc.comment;
+        if (dc && chompKeep)
+          dc = dc.replace(/^\n+/, "");
+        if (dc) {
+          if ((!chompKeep || contentComment) && lines[lines.length - 1] !== "")
+            lines.push("");
+          lines.push(stringifyComment.indentComment(commentString(dc), ""));
+        }
+      }
+      return lines.join("\n") + "\n";
+    }
+    exports2.stringifyDocument = stringifyDocument;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js
+var require_Document = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/doc/Document.js"(exports2) {
+    "use strict";
+    var Alias = require_Alias();
+    var Collection = require_Collection();
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var toJS = require_toJS();
+    var Schema = require_Schema();
+    var stringifyDocument = require_stringifyDocument();
+    var anchors = require_anchors();
+    var applyReviver = require_applyReviver();
+    var createNode = require_createNode();
+    var directives = require_directives();
+    var Document = class _Document {
+      constructor(value, replacer, options) {
+        this.commentBefore = null;
+        this.comment = null;
+        this.errors = [];
+        this.warnings = [];
+        Object.defineProperty(this, identity.NODE_TYPE, { value: identity.DOC });
+        let _replacer = null;
+        if (typeof replacer === "function" || Array.isArray(replacer)) {
+          _replacer = replacer;
+        } else if (options === void 0 && replacer) {
+          options = replacer;
+          replacer = void 0;
+        }
+        const opt = Object.assign({
+          intAsBigInt: false,
+          keepSourceTokens: false,
+          logLevel: "warn",
+          prettyErrors: true,
+          strict: true,
+          stringKeys: false,
+          uniqueKeys: true,
+          version: "1.2"
+        }, options);
+        this.options = opt;
+        let { version } = opt;
+        if (options?._directives) {
+          this.directives = options._directives.atDocument();
+          if (this.directives.yaml.explicit)
+            version = this.directives.yaml.version;
+        } else
+          this.directives = new directives.Directives({ version });
+        this.setSchema(version, options);
+        this.contents = value === void 0 ? null : this.createNode(value, _replacer, options);
+      }
+      /**
+       * Create a deep copy of this Document and its contents.
+       *
+       * Custom Node values that inherit from `Object` still refer to their original instances.
+       */
+      clone() {
+        const copy = Object.create(_Document.prototype, {
+          [identity.NODE_TYPE]: { value: identity.DOC }
+        });
+        copy.commentBefore = this.commentBefore;
+        copy.comment = this.comment;
+        copy.errors = this.errors.slice();
+        copy.warnings = this.warnings.slice();
+        copy.options = Object.assign({}, this.options);
+        if (this.directives)
+          copy.directives = this.directives.clone();
+        copy.schema = this.schema.clone();
+        copy.contents = identity.isNode(this.contents) ? this.contents.clone(copy.schema) : this.contents;
+        if (this.range)
+          copy.range = this.range.slice();
+        return copy;
+      }
+      /** Adds a value to the document. */
+      add(value) {
+        if (assertCollection(this.contents))
+          this.contents.add(value);
+      }
+      /** Adds a value to the document. */
+      addIn(path, value) {
+        if (assertCollection(this.contents))
+          this.contents.addIn(path, value);
+      }
+      /**
+       * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
+       *
+       * If `node` already has an anchor, `name` is ignored.
+       * Otherwise, the `node.anchor` value will be set to `name`,
+       * or if an anchor with that name is already present in the document,
+       * `name` will be used as a prefix for a new unique anchor.
+       * If `name` is undefined, the generated anchor will use 'a' as a prefix.
+       */
+      createAlias(node, name) {
+        if (!node.anchor) {
+          const prev = anchors.anchorNames(this);
+          node.anchor = // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          !name || prev.has(name) ? anchors.findNewAnchor(name || "a", prev) : name;
+        }
+        return new Alias.Alias(node.anchor);
+      }
+      createNode(value, replacer, options) {
+        let _replacer = void 0;
+        if (typeof replacer === "function") {
+          value = replacer.call({ "": value }, "", value);
+          _replacer = replacer;
+        } else if (Array.isArray(replacer)) {
+          const keyToStr = (v) => typeof v === "number" || v instanceof String || v instanceof Number;
+          const asStr = replacer.filter(keyToStr).map(String);
+          if (asStr.length > 0)
+            replacer = replacer.concat(asStr);
+          _replacer = replacer;
+        } else if (options === void 0 && replacer) {
+          options = replacer;
+          replacer = void 0;
+        }
+        const { aliasDuplicateObjects, anchorPrefix, flow, keepUndefined, onTagObj, tag } = options ?? {};
+        const { onAnchor, setAnchors, sourceObjects } = anchors.createNodeAnchors(
+          this,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          anchorPrefix || "a"
+        );
+        const ctx = {
+          aliasDuplicateObjects: aliasDuplicateObjects ?? true,
+          keepUndefined: keepUndefined ?? false,
+          onAnchor,
+          onTagObj,
+          replacer: _replacer,
+          schema: this.schema,
+          sourceObjects
+        };
+        const node = createNode.createNode(value, tag, ctx);
+        if (flow && identity.isCollection(node))
+          node.flow = true;
+        setAnchors();
+        return node;
+      }
+      /**
+       * Convert a key and a value into a `Pair` using the current schema,
+       * recursively wrapping all values as `Scalar` or `Collection` nodes.
+       */
+      createPair(key, value, options = {}) {
+        const k = this.createNode(key, null, options);
+        const v = this.createNode(value, null, options);
+        return new Pair.Pair(k, v);
+      }
+      /**
+       * Removes a value from the document.
+       * @returns `true` if the item was found and removed.
+       */
+      delete(key) {
+        return assertCollection(this.contents) ? this.contents.delete(key) : false;
+      }
+      /**
+       * Removes a value from the document.
+       * @returns `true` if the item was found and removed.
+       */
+      deleteIn(path) {
+        if (Collection.isEmptyPath(path)) {
+          if (this.contents == null)
+            return false;
+          this.contents = null;
+          return true;
+        }
+        return assertCollection(this.contents) ? this.contents.deleteIn(path) : false;
+      }
+      /**
+       * Returns item at `key`, or `undefined` if not found. By default unwraps
+       * scalar values from their surrounding node; to disable set `keepScalar` to
+       * `true` (collections are always returned intact).
+       */
+      get(key, keepScalar) {
+        return identity.isCollection(this.contents) ? this.contents.get(key, keepScalar) : void 0;
+      }
+      /**
+       * Returns item at `path`, or `undefined` if not found. By default unwraps
+       * scalar values from their surrounding node; to disable set `keepScalar` to
+       * `true` (collections are always returned intact).
+       */
+      getIn(path, keepScalar) {
+        if (Collection.isEmptyPath(path))
+          return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path, keepScalar) : void 0;
+      }
+      /**
+       * Checks if the document includes a value with the key `key`.
+       */
+      has(key) {
+        return identity.isCollection(this.contents) ? this.contents.has(key) : false;
+      }
+      /**
+       * Checks if the document includes a value at `path`.
+       */
+      hasIn(path) {
+        if (Collection.isEmptyPath(path))
+          return this.contents !== void 0;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path) : false;
+      }
+      /**
+       * Sets a value in this document. For `!!set`, `value` needs to be a
+       * boolean to add/remove the item from the set.
+       */
+      set(key, value) {
+        if (this.contents == null) {
+          this.contents = Collection.collectionFromPath(this.schema, [key], value);
+        } else if (assertCollection(this.contents)) {
+          this.contents.set(key, value);
+        }
+      }
+      /**
+       * Sets a value in this document. For `!!set`, `value` needs to be a
+       * boolean to add/remove the item from the set.
+       */
+      setIn(path, value) {
+        if (Collection.isEmptyPath(path)) {
+          this.contents = value;
+        } else if (this.contents == null) {
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path), value);
+        } else if (assertCollection(this.contents)) {
+          this.contents.setIn(path, value);
+        }
+      }
+      /**
+       * Change the YAML version and schema used by the document.
+       * A `null` version disables support for directives, explicit tags, anchors, and aliases.
+       * It also requires the `schema` option to be given as a `Schema` instance value.
+       *
+       * Overrides all previously set schema options.
+       */
+      setSchema(version, options = {}) {
+        if (typeof version === "number")
+          version = String(version);
+        let opt;
+        switch (version) {
+          case "1.1":
+            if (this.directives)
+              this.directives.yaml.version = "1.1";
+            else
+              this.directives = new directives.Directives({ version: "1.1" });
+            opt = { resolveKnownTags: false, schema: "yaml-1.1" };
+            break;
+          case "1.2":
+          case "next":
+            if (this.directives)
+              this.directives.yaml.version = version;
+            else
+              this.directives = new directives.Directives({ version });
+            opt = { resolveKnownTags: true, schema: "core" };
+            break;
+          case null:
+            if (this.directives)
+              delete this.directives;
+            opt = null;
+            break;
+          default: {
+            const sv = JSON.stringify(version);
+            throw new Error(`Expected '1.1', '1.2' or null as first argument, but found: ${sv}`);
+          }
+        }
+        if (options.schema instanceof Object)
+          this.schema = options.schema;
+        else if (opt)
+          this.schema = new Schema.Schema(Object.assign(opt, options));
+        else
+          throw new Error(`With a null YAML version, the { schema: Schema } option is required`);
+      }
+      // json & jsonArg are only used from toJSON()
+      toJS({ json, jsonArg, mapAsMap, maxAliasCount, onAnchor, reviver } = {}) {
+        const ctx = {
+          anchors: /* @__PURE__ */ new Map(),
+          doc: this,
+          keep: !json,
+          mapAsMap: mapAsMap === true,
+          mapKeyWarned: false,
+          maxAliasCount: typeof maxAliasCount === "number" ? maxAliasCount : 100
+        };
+        const res = toJS.toJS(this.contents, jsonArg ?? "", ctx);
+        if (typeof onAnchor === "function")
+          for (const { count, res: res2 } of ctx.anchors.values())
+            onAnchor(res2, count);
+        return typeof reviver === "function" ? applyReviver.applyReviver(reviver, { "": res }, "", res) : res;
+      }
+      /**
+       * A JSON representation of the document `contents`.
+       *
+       * @param jsonArg Used by `JSON.stringify` to indicate the array index or
+       *   property name.
+       */
+      toJSON(jsonArg, onAnchor) {
+        return this.toJS({ json: true, jsonArg, mapAsMap: false, onAnchor });
+      }
+      /** A YAML representation of the document. */
+      toString(options = {}) {
+        if (this.errors.length > 0)
+          throw new Error("Document with errors cannot be stringified");
+        if ("indent" in options && (!Number.isInteger(options.indent) || Number(options.indent) <= 0)) {
+          const s = JSON.stringify(options.indent);
+          throw new Error(`"indent" option must be a positive integer, not ${s}`);
+        }
+        return stringifyDocument.stringifyDocument(this, options);
+      }
+    };
+    function assertCollection(contents) {
+      if (identity.isCollection(contents))
+        return true;
+      throw new Error("Expected a YAML collection as document contents");
+    }
+    exports2.Document = Document;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js
+var require_errors = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/errors.js"(exports2) {
+    "use strict";
+    var YAMLError = class extends Error {
+      constructor(name, pos, code, message) {
+        super();
+        this.name = name;
+        this.code = code;
+        this.message = message;
+        this.pos = pos;
+      }
+    };
+    var YAMLParseError = class extends YAMLError {
+      constructor(pos, code, message) {
+        super("YAMLParseError", pos, code, message);
+      }
+    };
+    var YAMLWarning = class extends YAMLError {
+      constructor(pos, code, message) {
+        super("YAMLWarning", pos, code, message);
+      }
+    };
+    var prettifyError = (src, lc) => (error) => {
+      if (error.pos[0] === -1)
+        return;
+      error.linePos = error.pos.map((pos) => lc.linePos(pos));
+      const { line, col } = error.linePos[0];
+      error.message += ` at line ${line}, column ${col}`;
+      let ci = col - 1;
+      let lineStr = src.substring(lc.lineStarts[line - 1], lc.lineStarts[line]).replace(/[\n\r]+$/, "");
+      if (ci >= 60 && lineStr.length > 80) {
+        const trimStart = Math.min(ci - 39, lineStr.length - 79);
+        lineStr = "\u2026" + lineStr.substring(trimStart);
+        ci -= trimStart - 1;
+      }
+      if (lineStr.length > 80)
+        lineStr = lineStr.substring(0, 79) + "\u2026";
+      if (line > 1 && /^ *$/.test(lineStr.substring(0, ci))) {
+        let prev = src.substring(lc.lineStarts[line - 2], lc.lineStarts[line - 1]);
+        if (prev.length > 80)
+          prev = prev.substring(0, 79) + "\u2026\n";
+        lineStr = prev + lineStr;
+      }
+      if (/[^ ]/.test(lineStr)) {
+        let count = 1;
+        const end = error.linePos[1];
+        if (end?.line === line && end.col > col) {
+          count = Math.max(1, Math.min(end.col - col, 80 - ci));
+        }
+        const pointer = " ".repeat(ci) + "^".repeat(count);
+        error.message += `:
+
+${lineStr}
+${pointer}
+`;
+      }
+    };
+    exports2.YAMLError = YAMLError;
+    exports2.YAMLParseError = YAMLParseError;
+    exports2.YAMLWarning = YAMLWarning;
+    exports2.prettifyError = prettifyError;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js
+var require_resolve_props = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-props.js"(exports2) {
+    "use strict";
+    function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
+      let spaceBefore = false;
+      let atNewline = startOnNewline;
+      let hasSpace = startOnNewline;
+      let comment = "";
+      let commentSep = "";
+      let hasNewline = false;
+      let reqSpace = false;
+      let tab = null;
+      let anchor = null;
+      let tag = null;
+      let newlineAfterProp = null;
+      let comma = null;
+      let found = null;
+      let start = null;
+      for (const token of tokens) {
+        if (reqSpace) {
+          if (token.type !== "space" && token.type !== "newline" && token.type !== "comma")
+            onError(token.offset, "MISSING_CHAR", "Tags and anchors must be separated from the next token by white space");
+          reqSpace = false;
+        }
+        if (tab) {
+          if (atNewline && token.type !== "comment" && token.type !== "newline") {
+            onError(tab, "TAB_AS_INDENT", "Tabs are not allowed as indentation");
+          }
+          tab = null;
+        }
+        switch (token.type) {
+          case "space":
+            if (!flow && (indicator !== "doc-start" || next?.type !== "flow-collection") && token.source.includes("	")) {
+              tab = token;
+            }
+            hasSpace = true;
+            break;
+          case "comment": {
+            if (!hasSpace)
+              onError(token, "MISSING_CHAR", "Comments must be separated from other tokens by white space characters");
+            const cb = token.source.substring(1) || " ";
+            if (!comment)
+              comment = cb;
+            else
+              comment += commentSep + cb;
+            commentSep = "";
+            atNewline = false;
+            break;
+          }
+          case "newline":
+            if (atNewline) {
+              if (comment)
+                comment += token.source;
+              else if (!found || indicator !== "seq-item-ind")
+                spaceBefore = true;
+            } else
+              commentSep += token.source;
+            atNewline = true;
+            hasNewline = true;
+            if (anchor || tag)
+              newlineAfterProp = token;
+            hasSpace = true;
+            break;
+          case "anchor":
+            if (anchor)
+              onError(token, "MULTIPLE_ANCHORS", "A node can have at most one anchor");
+            if (token.source.endsWith(":"))
+              onError(token.offset + token.source.length - 1, "BAD_ALIAS", "Anchor ending in : is ambiguous", true);
+            anchor = token;
+            start ?? (start = token.offset);
+            atNewline = false;
+            hasSpace = false;
+            reqSpace = true;
+            break;
+          case "tag": {
+            if (tag)
+              onError(token, "MULTIPLE_TAGS", "A node can have at most one tag");
+            tag = token;
+            start ?? (start = token.offset);
+            atNewline = false;
+            hasSpace = false;
+            reqSpace = true;
+            break;
+          }
+          case indicator:
+            if (anchor || tag)
+              onError(token, "BAD_PROP_ORDER", `Anchors and tags must be after the ${token.source} indicator`);
+            if (found)
+              onError(token, "UNEXPECTED_TOKEN", `Unexpected ${token.source} in ${flow ?? "collection"}`);
+            found = token;
+            atNewline = indicator === "seq-item-ind" || indicator === "explicit-key-ind";
+            hasSpace = false;
+            break;
+          case "comma":
+            if (flow) {
+              if (comma)
+                onError(token, "UNEXPECTED_TOKEN", `Unexpected , in ${flow}`);
+              comma = token;
+              atNewline = false;
+              hasSpace = false;
+              break;
+            }
+          // else fallthrough
+          default:
+            onError(token, "UNEXPECTED_TOKEN", `Unexpected ${token.type} token`);
+            atNewline = false;
+            hasSpace = false;
+        }
+      }
+      const last = tokens[tokens.length - 1];
+      const end = last ? last.offset + last.source.length : offset;
+      if (reqSpace && next && next.type !== "space" && next.type !== "newline" && next.type !== "comma" && (next.type !== "scalar" || next.source !== "")) {
+        onError(next.offset, "MISSING_CHAR", "Tags and anchors must be separated from the next token by white space");
+      }
+      if (tab && (atNewline && tab.indent <= parentIndent || next?.type === "block-map" || next?.type === "block-seq"))
+        onError(tab, "TAB_AS_INDENT", "Tabs are not allowed as indentation");
+      return {
+        comma,
+        found,
+        spaceBefore,
+        comment,
+        hasNewline,
+        anchor,
+        tag,
+        newlineAfterProp,
+        end,
+        start: start ?? end
+      };
+    }
+    exports2.resolveProps = resolveProps;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js
+var require_util_contains_newline = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-contains-newline.js"(exports2) {
+    "use strict";
+    function containsNewline(key) {
+      if (!key)
+        return null;
+      switch (key.type) {
+        case "alias":
+        case "scalar":
+        case "double-quoted-scalar":
+        case "single-quoted-scalar":
+          if (key.source.includes("\n"))
+            return true;
+          if (key.end) {
+            for (const st of key.end)
+              if (st.type === "newline")
+                return true;
+          }
+          return false;
+        case "flow-collection":
+          for (const it of key.items) {
+            for (const st of it.start)
+              if (st.type === "newline")
+                return true;
+            if (it.sep) {
+              for (const st of it.sep)
+                if (st.type === "newline")
+                  return true;
+            }
+            if (containsNewline(it.key) || containsNewline(it.value))
+              return true;
+          }
+          return false;
+        default:
+          return true;
+      }
+    }
+    exports2.containsNewline = containsNewline;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js
+var require_util_flow_indent_check = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports2) {
+    "use strict";
+    var utilContainsNewline = require_util_contains_newline();
+    function flowIndentCheck(indent, fc, onError) {
+      if (fc?.type === "flow-collection") {
+        const end = fc.end[0];
+        if (end.indent === indent && (end.source === "]" || end.source === "}") && utilContainsNewline.containsNewline(fc)) {
+          const msg = "Flow end indicator should be more indented than parent";
+          onError(end, "BAD_INDENT", msg, true);
+        }
+      }
+    }
+    exports2.flowIndentCheck = flowIndentCheck;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js
+var require_util_map_includes = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-map-includes.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    function mapIncludes(ctx, items, search) {
+      const { uniqueKeys } = ctx.options;
+      if (uniqueKeys === false)
+        return false;
+      const isEqual = typeof uniqueKeys === "function" ? uniqueKeys : (a, b) => a === b || identity.isScalar(a) && identity.isScalar(b) && a.value === b.value;
+      return items.some((pair) => isEqual(pair.key, search));
+    }
+    exports2.mapIncludes = mapIncludes;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js
+var require_resolve_block_map = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-map.js"(exports2) {
+    "use strict";
+    var Pair = require_Pair();
+    var YAMLMap = require_YAMLMap();
+    var resolveProps = require_resolve_props();
+    var utilContainsNewline = require_util_contains_newline();
+    var utilFlowIndentCheck = require_util_flow_indent_check();
+    var utilMapIncludes = require_util_map_includes();
+    var startColMsg = "All mapping items must start at the same column";
+    function resolveBlockMap({ composeNode, composeEmptyNode }, ctx, bm, onError, tag) {
+      const NodeClass = tag?.nodeClass ?? YAMLMap.YAMLMap;
+      const map = new NodeClass(ctx.schema);
+      if (ctx.atRoot)
+        ctx.atRoot = false;
+      let offset = bm.offset;
+      let commentEnd = null;
+      for (const collItem of bm.items) {
+        const { start, key, sep, value } = collItem;
+        const keyProps = resolveProps.resolveProps(start, {
+          indicator: "explicit-key-ind",
+          next: key ?? sep?.[0],
+          offset,
+          onError,
+          parentIndent: bm.indent,
+          startOnNewline: true
+        });
+        const implicitKey = !keyProps.found;
+        if (implicitKey) {
+          if (key) {
+            if (key.type === "block-seq")
+              onError(offset, "BLOCK_AS_IMPLICIT_KEY", "A block sequence may not be used as an implicit map key");
+            else if ("indent" in key && key.indent !== bm.indent)
+              onError(offset, "BAD_INDENT", startColMsg);
+          }
+          if (!keyProps.anchor && !keyProps.tag && !sep) {
+            commentEnd = keyProps.end;
+            if (keyProps.comment) {
+              if (map.comment)
+                map.comment += "\n" + keyProps.comment;
+              else
+                map.comment = keyProps.comment;
+            }
+            continue;
+          }
+          if (keyProps.newlineAfterProp || utilContainsNewline.containsNewline(key)) {
+            onError(key ?? start[start.length - 1], "MULTILINE_IMPLICIT_KEY", "Implicit keys need to be on a single line");
+          }
+        } else if (keyProps.found?.indent !== bm.indent) {
+          onError(offset, "BAD_INDENT", startColMsg);
+        }
+        ctx.atKey = true;
+        const keyStart = keyProps.end;
+        const keyNode = key ? composeNode(ctx, key, keyProps, onError) : composeEmptyNode(ctx, keyStart, start, null, keyProps, onError);
+        if (ctx.schema.compat)
+          utilFlowIndentCheck.flowIndentCheck(bm.indent, key, onError);
+        ctx.atKey = false;
+        if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
+          onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
+        const valueProps = resolveProps.resolveProps(sep ?? [], {
+          indicator: "map-value-ind",
+          next: value,
+          offset: keyNode.range[2],
+          onError,
+          parentIndent: bm.indent,
+          startOnNewline: !key || key.type === "block-scalar"
+        });
+        offset = valueProps.end;
+        if (valueProps.found) {
+          if (implicitKey) {
+            if (value?.type === "block-map" && !valueProps.hasNewline)
+              onError(offset, "BLOCK_AS_IMPLICIT_KEY", "Nested mappings are not allowed in compact mappings");
+            if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
+              onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
+          }
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep, null, valueProps, onError);
+          if (ctx.schema.compat)
+            utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
+          offset = valueNode.range[2];
+          const pair = new Pair.Pair(keyNode, valueNode);
+          if (ctx.options.keepSourceTokens)
+            pair.srcToken = collItem;
+          map.items.push(pair);
+        } else {
+          if (implicitKey)
+            onError(keyNode.range, "MISSING_CHAR", "Implicit map keys need to be followed by map values");
+          if (valueProps.comment) {
+            if (keyNode.comment)
+              keyNode.comment += "\n" + valueProps.comment;
+            else
+              keyNode.comment = valueProps.comment;
+          }
+          const pair = new Pair.Pair(keyNode);
+          if (ctx.options.keepSourceTokens)
+            pair.srcToken = collItem;
+          map.items.push(pair);
+        }
+      }
+      if (commentEnd && commentEnd < offset)
+        onError(commentEnd, "IMPOSSIBLE", "Map comment with trailing content");
+      map.range = [bm.offset, offset, commentEnd ?? offset];
+      return map;
+    }
+    exports2.resolveBlockMap = resolveBlockMap;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js
+var require_resolve_block_seq = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports2) {
+    "use strict";
+    var YAMLSeq = require_YAMLSeq();
+    var resolveProps = require_resolve_props();
+    var utilFlowIndentCheck = require_util_flow_indent_check();
+    function resolveBlockSeq({ composeNode, composeEmptyNode }, ctx, bs, onError, tag) {
+      const NodeClass = tag?.nodeClass ?? YAMLSeq.YAMLSeq;
+      const seq = new NodeClass(ctx.schema);
+      if (ctx.atRoot)
+        ctx.atRoot = false;
+      if (ctx.atKey)
+        ctx.atKey = false;
+      let offset = bs.offset;
+      let commentEnd = null;
+      for (const { start, value } of bs.items) {
+        const props = resolveProps.resolveProps(start, {
+          indicator: "seq-item-ind",
+          next: value,
+          offset,
+          onError,
+          parentIndent: bs.indent,
+          startOnNewline: true
+        });
+        if (!props.found) {
+          if (props.anchor || props.tag || value) {
+            if (value?.type === "block-seq")
+              onError(props.end, "BAD_INDENT", "All sequence items must start at the same column");
+            else
+              onError(offset, "MISSING_CHAR", "Sequence item without - indicator");
+          } else {
+            commentEnd = props.end;
+            if (props.comment)
+              seq.comment = props.comment;
+            continue;
+          }
+        }
+        const node = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, start, null, props, onError);
+        if (ctx.schema.compat)
+          utilFlowIndentCheck.flowIndentCheck(bs.indent, value, onError);
+        offset = node.range[2];
+        seq.items.push(node);
+      }
+      seq.range = [bs.offset, offset, commentEnd ?? offset];
+      return seq;
+    }
+    exports2.resolveBlockSeq = resolveBlockSeq;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js
+var require_resolve_end = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-end.js"(exports2) {
+    "use strict";
+    function resolveEnd(end, offset, reqSpace, onError) {
+      let comment = "";
+      if (end) {
+        let hasSpace = false;
+        let sep = "";
+        for (const token of end) {
+          const { source, type } = token;
+          switch (type) {
+            case "space":
+              hasSpace = true;
+              break;
+            case "comment": {
+              if (reqSpace && !hasSpace)
+                onError(token, "MISSING_CHAR", "Comments must be separated from other tokens by white space characters");
+              const cb = source.substring(1) || " ";
+              if (!comment)
+                comment = cb;
+              else
+                comment += sep + cb;
+              sep = "";
+              break;
+            }
+            case "newline":
+              if (comment)
+                sep += source;
+              hasSpace = true;
+              break;
+            default:
+              onError(token, "UNEXPECTED_TOKEN", `Unexpected ${type} at node end`);
+          }
+          offset += source.length;
+        }
+      }
+      return { comment, offset };
+    }
+    exports2.resolveEnd = resolveEnd;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js
+var require_resolve_flow_collection = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var YAMLMap = require_YAMLMap();
+    var YAMLSeq = require_YAMLSeq();
+    var resolveEnd = require_resolve_end();
+    var resolveProps = require_resolve_props();
+    var utilContainsNewline = require_util_contains_newline();
+    var utilMapIncludes = require_util_map_includes();
+    var blockMsg = "Block collections are not allowed within flow collections";
+    var isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
+    function resolveFlowCollection({ composeNode, composeEmptyNode }, ctx, fc, onError, tag) {
+      const isMap = fc.start.source === "{";
+      const fcName = isMap ? "flow map" : "flow sequence";
+      const NodeClass = tag?.nodeClass ?? (isMap ? YAMLMap.YAMLMap : YAMLSeq.YAMLSeq);
+      const coll = new NodeClass(ctx.schema);
+      coll.flow = true;
+      const atRoot = ctx.atRoot;
+      if (atRoot)
+        ctx.atRoot = false;
+      if (ctx.atKey)
+        ctx.atKey = false;
+      let offset = fc.offset + fc.start.source.length;
+      for (let i = 0; i < fc.items.length; ++i) {
+        const collItem = fc.items[i];
+        const { start, key, sep, value } = collItem;
+        const props = resolveProps.resolveProps(start, {
+          flow: fcName,
+          indicator: "explicit-key-ind",
+          next: key ?? sep?.[0],
+          offset,
+          onError,
+          parentIndent: fc.indent,
+          startOnNewline: false
+        });
+        if (!props.found) {
+          if (!props.anchor && !props.tag && !sep && !value) {
+            if (i === 0 && props.comma)
+              onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
+            else if (i < fc.items.length - 1)
+              onError(props.start, "UNEXPECTED_TOKEN", `Unexpected empty item in ${fcName}`);
+            if (props.comment) {
+              if (coll.comment)
+                coll.comment += "\n" + props.comment;
+              else
+                coll.comment = props.comment;
+            }
+            offset = props.end;
+            continue;
+          }
+          if (!isMap && ctx.options.strict && utilContainsNewline.containsNewline(key))
+            onError(
+              key,
+              // checked by containsNewline()
+              "MULTILINE_IMPLICIT_KEY",
+              "Implicit keys of flow sequence pairs need to be on a single line"
+            );
+        }
+        if (i === 0) {
+          if (props.comma)
+            onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
+        } else {
+          if (!props.comma)
+            onError(props.start, "MISSING_CHAR", `Missing , between ${fcName} items`);
+          if (props.comment) {
+            let prevItemComment = "";
+            loop: for (const st of start) {
+              switch (st.type) {
+                case "comma":
+                case "space":
+                  break;
+                case "comment":
+                  prevItemComment = st.source.substring(1);
+                  break loop;
+                default:
+                  break loop;
+              }
+            }
+            if (prevItemComment) {
+              let prev = coll.items[coll.items.length - 1];
+              if (identity.isPair(prev))
+                prev = prev.value ?? prev.key;
+              if (prev.comment)
+                prev.comment += "\n" + prevItemComment;
+              else
+                prev.comment = prevItemComment;
+              props.comment = props.comment.substring(prevItemComment.length + 1);
+            }
+          }
+        }
+        if (!isMap && !sep && !props.found) {
+          const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep, null, props, onError);
+          coll.items.push(valueNode);
+          offset = valueNode.range[2];
+          if (isBlock(value))
+            onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
+        } else {
+          ctx.atKey = true;
+          const keyStart = props.end;
+          const keyNode = key ? composeNode(ctx, key, props, onError) : composeEmptyNode(ctx, keyStart, start, null, props, onError);
+          if (isBlock(key))
+            onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
+          ctx.atKey = false;
+          const valueProps = resolveProps.resolveProps(sep ?? [], {
+            flow: fcName,
+            indicator: "map-value-ind",
+            next: value,
+            offset: keyNode.range[2],
+            onError,
+            parentIndent: fc.indent,
+            startOnNewline: false
+          });
+          if (valueProps.found) {
+            if (!isMap && !props.found && ctx.options.strict) {
+              if (sep)
+                for (const st of sep) {
+                  if (st === valueProps.found)
+                    break;
+                  if (st.type === "newline") {
+                    onError(st, "MULTILINE_IMPLICIT_KEY", "Implicit keys of flow sequence pairs need to be on a single line");
+                    break;
+                  }
+                }
+              if (props.start < valueProps.found.offset - 1024)
+                onError(valueProps.found, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit flow sequence key");
+            }
+          } else if (value) {
+            if ("source" in value && value.source?.[0] === ":")
+              onError(value, "MISSING_CHAR", `Missing space after : in ${fcName}`);
+            else
+              onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
+          }
+          const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep, null, valueProps, onError) : null;
+          if (valueNode) {
+            if (isBlock(value))
+              onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
+          } else if (valueProps.comment) {
+            if (keyNode.comment)
+              keyNode.comment += "\n" + valueProps.comment;
+            else
+              keyNode.comment = valueProps.comment;
+          }
+          const pair = new Pair.Pair(keyNode, valueNode);
+          if (ctx.options.keepSourceTokens)
+            pair.srcToken = collItem;
+          if (isMap) {
+            const map = coll;
+            if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
+              onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
+            map.items.push(pair);
+          } else {
+            const map = new YAMLMap.YAMLMap(ctx.schema);
+            map.flow = true;
+            map.items.push(pair);
+            const endRange = (valueNode ?? keyNode).range;
+            map.range = [keyNode.range[0], endRange[1], endRange[2]];
+            coll.items.push(map);
+          }
+          offset = valueNode ? valueNode.range[2] : valueProps.end;
+        }
+      }
+      const expectedEnd = isMap ? "}" : "]";
+      const [ce, ...ee] = fc.end;
+      let cePos = offset;
+      if (ce?.source === expectedEnd)
+        cePos = ce.offset + ce.source.length;
+      else {
+        const name = fcName[0].toUpperCase() + fcName.substring(1);
+        const msg = atRoot ? `${name} must end with a ${expectedEnd}` : `${name} in block collection must be sufficiently indented and end with a ${expectedEnd}`;
+        onError(offset, atRoot ? "MISSING_CHAR" : "BAD_INDENT", msg);
+        if (ce && ce.source.length !== 1)
+          ee.unshift(ce);
+      }
+      if (ee.length > 0) {
+        const end = resolveEnd.resolveEnd(ee, cePos, ctx.options.strict, onError);
+        if (end.comment) {
+          if (coll.comment)
+            coll.comment += "\n" + end.comment;
+          else
+            coll.comment = end.comment;
+        }
+        coll.range = [fc.offset, cePos, end.offset];
+      } else {
+        coll.range = [fc.offset, cePos, cePos];
+      }
+      return coll;
+    }
+    exports2.resolveFlowCollection = resolveFlowCollection;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js
+var require_compose_collection = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-collection.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var YAMLMap = require_YAMLMap();
+    var YAMLSeq = require_YAMLSeq();
+    var resolveBlockMap = require_resolve_block_map();
+    var resolveBlockSeq = require_resolve_block_seq();
+    var resolveFlowCollection = require_resolve_flow_collection();
+    function resolveCollection(CN, ctx, token, onError, tagName, tag) {
+      const coll = token.type === "block-map" ? resolveBlockMap.resolveBlockMap(CN, ctx, token, onError, tag) : token.type === "block-seq" ? resolveBlockSeq.resolveBlockSeq(CN, ctx, token, onError, tag) : resolveFlowCollection.resolveFlowCollection(CN, ctx, token, onError, tag);
+      const Coll = coll.constructor;
+      if (tagName === "!" || tagName === Coll.tagName) {
+        coll.tag = Coll.tagName;
+        return coll;
+      }
+      if (tagName)
+        coll.tag = tagName;
+      return coll;
+    }
+    function composeCollection(CN, ctx, token, props, onError) {
+      const tagToken = props.tag;
+      const tagName = !tagToken ? null : ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg));
+      if (token.type === "block-seq") {
+        const { anchor, newlineAfterProp: nl } = props;
+        const lastProp = anchor && tagToken ? anchor.offset > tagToken.offset ? anchor : tagToken : anchor ?? tagToken;
+        if (lastProp && (!nl || nl.offset < lastProp.offset)) {
+          const message = "Missing newline after block sequence props";
+          onError(lastProp, "MISSING_CHAR", message);
+        }
+      }
+      const expType = token.type === "block-map" ? "map" : token.type === "block-seq" ? "seq" : token.start.source === "{" ? "map" : "seq";
+      if (!tagToken || !tagName || tagName === "!" || tagName === YAMLMap.YAMLMap.tagName && expType === "map" || tagName === YAMLSeq.YAMLSeq.tagName && expType === "seq") {
+        return resolveCollection(CN, ctx, token, onError, tagName);
+      }
+      let tag = ctx.schema.tags.find((t) => t.tag === tagName && t.collection === expType);
+      if (!tag) {
+        const kt = ctx.schema.knownTags[tagName];
+        if (kt?.collection === expType) {
+          ctx.schema.tags.push(Object.assign({}, kt, { default: false }));
+          tag = kt;
+        } else {
+          if (kt) {
+            onError(tagToken, "BAD_COLLECTION_TYPE", `${kt.tag} used for ${expType} collection, but expects ${kt.collection ?? "scalar"}`, true);
+          } else {
+            onError(tagToken, "TAG_RESOLVE_FAILED", `Unresolved tag: ${tagName}`, true);
+          }
+          return resolveCollection(CN, ctx, token, onError, tagName);
+        }
+      }
+      const coll = resolveCollection(CN, ctx, token, onError, tagName, tag);
+      const res = tag.resolve?.(coll, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg), ctx.options) ?? coll;
+      const node = identity.isNode(res) ? res : new Scalar.Scalar(res);
+      node.range = coll.range;
+      node.tag = tagName;
+      if (tag?.format)
+        node.format = tag.format;
+      return node;
+    }
+    exports2.composeCollection = composeCollection;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js
+var require_resolve_block_scalar = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    function resolveBlockScalar(ctx, scalar, onError) {
+      const start = scalar.offset;
+      const header = parseBlockScalarHeader(scalar, ctx.options.strict, onError);
+      if (!header)
+        return { value: "", type: null, comment: "", range: [start, start, start] };
+      const type = header.mode === ">" ? Scalar.Scalar.BLOCK_FOLDED : Scalar.Scalar.BLOCK_LITERAL;
+      const lines = scalar.source ? splitLines(scalar.source) : [];
+      let chompStart = lines.length;
+      for (let i = lines.length - 1; i >= 0; --i) {
+        const content = lines[i][1];
+        if (content === "" || content === "\r")
+          chompStart = i;
+        else
+          break;
+      }
+      if (chompStart === 0) {
+        const value2 = header.chomp === "+" && lines.length > 0 ? "\n".repeat(Math.max(1, lines.length - 1)) : "";
+        let end2 = start + header.length;
+        if (scalar.source)
+          end2 += scalar.source.length;
+        return { value: value2, type, comment: header.comment, range: [start, end2, end2] };
+      }
+      let trimIndent = scalar.indent + header.indent;
+      let offset = scalar.offset + header.length;
+      let contentStart = 0;
+      for (let i = 0; i < chompStart; ++i) {
+        const [indent, content] = lines[i];
+        if (content === "" || content === "\r") {
+          if (header.indent === 0 && indent.length > trimIndent)
+            trimIndent = indent.length;
+        } else {
+          if (indent.length < trimIndent) {
+            const message = "Block scalars with more-indented leading empty lines must use an explicit indentation indicator";
+            onError(offset + indent.length, "MISSING_CHAR", message);
+          }
+          if (header.indent === 0)
+            trimIndent = indent.length;
+          contentStart = i;
+          if (trimIndent === 0 && !ctx.atRoot) {
+            const message = "Block scalar values in collections must be indented";
+            onError(offset, "BAD_INDENT", message);
+          }
+          break;
+        }
+        offset += indent.length + content.length + 1;
+      }
+      for (let i = lines.length - 1; i >= chompStart; --i) {
+        if (lines[i][0].length > trimIndent)
+          chompStart = i + 1;
+      }
+      let value = "";
+      let sep = "";
+      let prevMoreIndented = false;
+      for (let i = 0; i < contentStart; ++i)
+        value += lines[i][0].slice(trimIndent) + "\n";
+      for (let i = contentStart; i < chompStart; ++i) {
+        let [indent, content] = lines[i];
+        offset += indent.length + content.length + 1;
+        const crlf = content[content.length - 1] === "\r";
+        if (crlf)
+          content = content.slice(0, -1);
+        if (content && indent.length < trimIndent) {
+          const src = header.indent ? "explicit indentation indicator" : "first line";
+          const message = `Block scalar lines must not be less indented than their ${src}`;
+          onError(offset - content.length - (crlf ? 2 : 1), "BAD_INDENT", message);
+          indent = "";
+        }
+        if (type === Scalar.Scalar.BLOCK_LITERAL) {
+          value += sep + indent.slice(trimIndent) + content;
+          sep = "\n";
+        } else if (indent.length > trimIndent || content[0] === "	") {
+          if (sep === " ")
+            sep = "\n";
+          else if (!prevMoreIndented && sep === "\n")
+            sep = "\n\n";
+          value += sep + indent.slice(trimIndent) + content;
+          sep = "\n";
+          prevMoreIndented = true;
+        } else if (content === "") {
+          if (sep === "\n")
+            value += "\n";
+          else
+            sep = "\n";
+        } else {
+          value += sep + content;
+          sep = " ";
+          prevMoreIndented = false;
+        }
+      }
+      switch (header.chomp) {
+        case "-":
+          break;
+        case "+":
+          for (let i = chompStart; i < lines.length; ++i)
+            value += "\n" + lines[i][0].slice(trimIndent);
+          if (value[value.length - 1] !== "\n")
+            value += "\n";
+          break;
+        default:
+          value += "\n";
+      }
+      const end = start + header.length + scalar.source.length;
+      return { value, type, comment: header.comment, range: [start, end, end] };
+    }
+    function parseBlockScalarHeader({ offset, props }, strict, onError) {
+      if (props[0].type !== "block-scalar-header") {
+        onError(props[0], "IMPOSSIBLE", "Block scalar header not found");
+        return null;
+      }
+      const { source } = props[0];
+      const mode = source[0];
+      let indent = 0;
+      let chomp = "";
+      let error = -1;
+      for (let i = 1; i < source.length; ++i) {
+        const ch = source[i];
+        if (!chomp && (ch === "-" || ch === "+"))
+          chomp = ch;
+        else {
+          const n = Number(ch);
+          if (!indent && n)
+            indent = n;
+          else if (error === -1)
+            error = offset + i;
+        }
+      }
+      if (error !== -1)
+        onError(error, "UNEXPECTED_TOKEN", `Block scalar header includes extra characters: ${source}`);
+      let hasSpace = false;
+      let comment = "";
+      let length = source.length;
+      for (let i = 1; i < props.length; ++i) {
+        const token = props[i];
+        switch (token.type) {
+          case "space":
+            hasSpace = true;
+          // fallthrough
+          case "newline":
+            length += token.source.length;
+            break;
+          case "comment":
+            if (strict && !hasSpace) {
+              const message = "Comments must be separated from other tokens by white space characters";
+              onError(token, "MISSING_CHAR", message);
+            }
+            length += token.source.length;
+            comment = token.source.substring(1);
+            break;
+          case "error":
+            onError(token, "UNEXPECTED_TOKEN", token.message);
+            length += token.source.length;
+            break;
+          /* istanbul ignore next should not happen */
+          default: {
+            const message = `Unexpected token in block scalar header: ${token.type}`;
+            onError(token, "UNEXPECTED_TOKEN", message);
+            const ts = token.source;
+            if (ts && typeof ts === "string")
+              length += ts.length;
+          }
+        }
+      }
+      return { mode, indent, chomp, comment, length };
+    }
+    function splitLines(source) {
+      const split = source.split(/\n( *)/);
+      const first = split[0];
+      const m = first.match(/^( *)/);
+      const line0 = m?.[1] ? [m[1], first.slice(m[1].length)] : ["", first];
+      const lines = [line0];
+      for (let i = 1; i < split.length; i += 2)
+        lines.push([split[i], split[i + 1]]);
+      return lines;
+    }
+    exports2.resolveBlockScalar = resolveBlockScalar;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js
+var require_resolve_flow_scalar = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports2) {
+    "use strict";
+    var Scalar = require_Scalar();
+    var resolveEnd = require_resolve_end();
+    function resolveFlowScalar(scalar, strict, onError) {
+      const { offset, type, source, end } = scalar;
+      let _type;
+      let value;
+      const _onError = (rel, code, msg) => onError(offset + rel, code, msg);
+      switch (type) {
+        case "scalar":
+          _type = Scalar.Scalar.PLAIN;
+          value = plainValue(source, _onError);
+          break;
+        case "single-quoted-scalar":
+          _type = Scalar.Scalar.QUOTE_SINGLE;
+          value = singleQuotedValue(source, _onError);
+          break;
+        case "double-quoted-scalar":
+          _type = Scalar.Scalar.QUOTE_DOUBLE;
+          value = doubleQuotedValue(source, _onError);
+          break;
+        /* istanbul ignore next should not happen */
+        default:
+          onError(scalar, "UNEXPECTED_TOKEN", `Expected a flow scalar value, but found: ${type}`);
+          return {
+            value: "",
+            type: null,
+            comment: "",
+            range: [offset, offset + source.length, offset + source.length]
+          };
+      }
+      const valueEnd = offset + source.length;
+      const re = resolveEnd.resolveEnd(end, valueEnd, strict, onError);
+      return {
+        value,
+        type: _type,
+        comment: re.comment,
+        range: [offset, valueEnd, re.offset]
+      };
+    }
+    function plainValue(source, onError) {
+      let badChar = "";
+      switch (source[0]) {
+        /* istanbul ignore next should not happen */
+        case "	":
+          badChar = "a tab character";
+          break;
+        case ",":
+          badChar = "flow indicator character ,";
+          break;
+        case "%":
+          badChar = "directive indicator character %";
+          break;
+        case "|":
+        case ">": {
+          badChar = `block scalar indicator ${source[0]}`;
+          break;
+        }
+        case "@":
+        case "`": {
+          badChar = `reserved character ${source[0]}`;
+          break;
+        }
+      }
+      if (badChar)
+        onError(0, "BAD_SCALAR_START", `Plain value cannot start with ${badChar}`);
+      return foldLines(source);
+    }
+    function singleQuotedValue(source, onError) {
+      if (source[source.length - 1] !== "'" || source.length === 1)
+        onError(source.length, "MISSING_CHAR", "Missing closing 'quote");
+      return foldLines(source.slice(1, -1)).replace(/''/g, "'");
+    }
+    function foldLines(source) {
+      let first, line;
+      try {
+        first = new RegExp("(.*?)(?<![ 	])[ 	]*\r?\n", "sy");
+        line = new RegExp("[ 	]*(.*?)(?:(?<![ 	])[ 	]*)?\r?\n", "sy");
+      } catch {
+        first = /(.*?)[ \t]*\r?\n/sy;
+        line = /[ \t]*(.*?)[ \t]*\r?\n/sy;
+      }
+      let match = first.exec(source);
+      if (!match)
+        return source;
+      let res = match[1];
+      let sep = " ";
+      let pos = first.lastIndex;
+      line.lastIndex = pos;
+      while (match = line.exec(source)) {
+        if (match[1] === "") {
+          if (sep === "\n")
+            res += sep;
+          else
+            sep = "\n";
+        } else {
+          res += sep + match[1];
+          sep = " ";
+        }
+        pos = line.lastIndex;
+      }
+      const last = /[ \t]*(.*)/sy;
+      last.lastIndex = pos;
+      match = last.exec(source);
+      return res + sep + (match?.[1] ?? "");
+    }
+    function doubleQuotedValue(source, onError) {
+      let res = "";
+      for (let i = 1; i < source.length - 1; ++i) {
+        const ch = source[i];
+        if (ch === "\r" && source[i + 1] === "\n")
+          continue;
+        if (ch === "\n") {
+          const { fold, offset } = foldNewline(source, i);
+          res += fold;
+          i = offset;
+        } else if (ch === "\\") {
+          let next = source[++i];
+          const cc = escapeCodes[next];
+          if (cc)
+            res += cc;
+          else if (next === "\n") {
+            next = source[i + 1];
+            while (next === " " || next === "	")
+              next = source[++i + 1];
+          } else if (next === "\r" && source[i + 1] === "\n") {
+            next = source[++i + 1];
+            while (next === " " || next === "	")
+              next = source[++i + 1];
+          } else if (next === "x" || next === "u" || next === "U") {
+            const length = { x: 2, u: 4, U: 8 }[next];
+            res += parseCharCode(source, i + 1, length, onError);
+            i += length;
+          } else {
+            const raw = source.substr(i - 1, 2);
+            onError(i - 1, "BAD_DQ_ESCAPE", `Invalid escape sequence ${raw}`);
+            res += raw;
+          }
+        } else if (ch === " " || ch === "	") {
+          const wsStart = i;
+          let next = source[i + 1];
+          while (next === " " || next === "	")
+            next = source[++i + 1];
+          if (next !== "\n" && !(next === "\r" && source[i + 2] === "\n"))
+            res += i > wsStart ? source.slice(wsStart, i + 1) : ch;
+        } else {
+          res += ch;
+        }
+      }
+      if (source[source.length - 1] !== '"' || source.length === 1)
+        onError(source.length, "MISSING_CHAR", 'Missing closing "quote');
+      return res;
+    }
+    function foldNewline(source, offset) {
+      let fold = "";
+      let ch = source[offset + 1];
+      while (ch === " " || ch === "	" || ch === "\n" || ch === "\r") {
+        if (ch === "\r" && source[offset + 2] !== "\n")
+          break;
+        if (ch === "\n")
+          fold += "\n";
+        offset += 1;
+        ch = source[offset + 1];
+      }
+      if (!fold)
+        fold = " ";
+      return { fold, offset };
+    }
+    var escapeCodes = {
+      "0": "\0",
+      // null character
+      a: "\x07",
+      // bell character
+      b: "\b",
+      // backspace
+      e: "\x1B",
+      // escape character
+      f: "\f",
+      // form feed
+      n: "\n",
+      // line feed
+      r: "\r",
+      // carriage return
+      t: "	",
+      // horizontal tab
+      v: "\v",
+      // vertical tab
+      N: "\x85",
+      // Unicode next line
+      _: "\xA0",
+      // Unicode non-breaking space
+      L: "\u2028",
+      // Unicode line separator
+      P: "\u2029",
+      // Unicode paragraph separator
+      " ": " ",
+      '"': '"',
+      "/": "/",
+      "\\": "\\",
+      "	": "	"
+    };
+    function parseCharCode(source, offset, length, onError) {
+      const cc = source.substr(offset, length);
+      const ok = cc.length === length && /^[0-9a-fA-F]+$/.test(cc);
+      const code = ok ? parseInt(cc, 16) : NaN;
+      if (isNaN(code)) {
+        const raw = source.substr(offset - 2, length + 2);
+        onError(offset - 2, "BAD_DQ_ESCAPE", `Invalid escape sequence ${raw}`);
+        return raw;
+      }
+      return String.fromCodePoint(code);
+    }
+    exports2.resolveFlowScalar = resolveFlowScalar;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js
+var require_compose_scalar = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-scalar.js"(exports2) {
+    "use strict";
+    var identity = require_identity();
+    var Scalar = require_Scalar();
+    var resolveBlockScalar = require_resolve_block_scalar();
+    var resolveFlowScalar = require_resolve_flow_scalar();
+    function composeScalar(ctx, token, tagToken, onError) {
+      const { value, type, comment, range } = token.type === "block-scalar" ? resolveBlockScalar.resolveBlockScalar(ctx, token, onError) : resolveFlowScalar.resolveFlowScalar(token, ctx.options.strict, onError);
+      const tagName = tagToken ? ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg)) : null;
+      let tag;
+      if (ctx.options.stringKeys && ctx.atKey) {
+        tag = ctx.schema[identity.SCALAR];
+      } else if (tagName)
+        tag = findScalarTagByName(ctx.schema, value, tagName, tagToken, onError);
+      else if (token.type === "scalar")
+        tag = findScalarTagByTest(ctx, value, token, onError);
+      else
+        tag = ctx.schema[identity.SCALAR];
+      let scalar;
+      try {
+        const res = tag.resolve(value, (msg) => onError(tagToken ?? token, "TAG_RESOLVE_FAILED", msg), ctx.options);
+        scalar = identity.isScalar(res) ? res : new Scalar.Scalar(res);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        onError(tagToken ?? token, "TAG_RESOLVE_FAILED", msg);
+        scalar = new Scalar.Scalar(value);
+      }
+      scalar.range = range;
+      scalar.source = value;
+      if (type)
+        scalar.type = type;
+      if (tagName)
+        scalar.tag = tagName;
+      if (tag.format)
+        scalar.format = tag.format;
+      if (comment)
+        scalar.comment = comment;
+      return scalar;
+    }
+    function findScalarTagByName(schema, value, tagName, tagToken, onError) {
+      if (tagName === "!")
+        return schema[identity.SCALAR];
+      const matchWithTest = [];
+      for (const tag of schema.tags) {
+        if (!tag.collection && tag.tag === tagName) {
+          if (tag.default && tag.test)
+            matchWithTest.push(tag);
+          else
+            return tag;
+        }
+      }
+      for (const tag of matchWithTest)
+        if (tag.test?.test(value))
+          return tag;
+      const kt = schema.knownTags[tagName];
+      if (kt && !kt.collection) {
+        schema.tags.push(Object.assign({}, kt, { default: false, test: void 0 }));
+        return kt;
+      }
+      onError(tagToken, "TAG_RESOLVE_FAILED", `Unresolved tag: ${tagName}`, tagName !== "tag:yaml.org,2002:str");
+      return schema[identity.SCALAR];
+    }
+    function findScalarTagByTest({ atKey, directives, schema }, value, token, onError) {
+      const tag = schema.tags.find((tag2) => (tag2.default === true || atKey && tag2.default === "key") && tag2.test?.test(value)) || schema[identity.SCALAR];
+      if (schema.compat) {
+        const compat = schema.compat.find((tag2) => tag2.default && tag2.test?.test(value)) ?? schema[identity.SCALAR];
+        if (tag.tag !== compat.tag) {
+          const ts = directives.tagString(tag.tag);
+          const cs = directives.tagString(compat.tag);
+          const msg = `Value may be parsed as either ${ts} or ${cs}`;
+          onError(token, "TAG_RESOLVE_FAILED", msg, true);
+        }
+      }
+      return tag;
+    }
+    exports2.composeScalar = composeScalar;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js
+var require_util_empty_scalar_position = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports2) {
+    "use strict";
+    function emptyScalarPosition(offset, before, pos) {
+      if (before) {
+        pos ?? (pos = before.length);
+        for (let i = pos - 1; i >= 0; --i) {
+          let st = before[i];
+          switch (st.type) {
+            case "space":
+            case "comment":
+            case "newline":
+              offset -= st.source.length;
+              continue;
+          }
+          st = before[++i];
+          while (st?.type === "space") {
+            offset += st.source.length;
+            st = before[++i];
+          }
+          break;
+        }
+      }
+      return offset;
+    }
+    exports2.emptyScalarPosition = emptyScalarPosition;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js
+var require_compose_node = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-node.js"(exports2) {
+    "use strict";
+    var Alias = require_Alias();
+    var identity = require_identity();
+    var composeCollection = require_compose_collection();
+    var composeScalar = require_compose_scalar();
+    var resolveEnd = require_resolve_end();
+    var utilEmptyScalarPosition = require_util_empty_scalar_position();
+    var CN = { composeNode, composeEmptyNode };
+    function composeNode(ctx, token, props, onError) {
+      const atKey = ctx.atKey;
+      const { spaceBefore, comment, anchor, tag } = props;
+      let node;
+      let isSrcToken = true;
+      switch (token.type) {
+        case "alias":
+          node = composeAlias(ctx, token, onError);
+          if (anchor || tag)
+            onError(token, "ALIAS_PROPS", "An alias node must not specify any properties");
+          break;
+        case "scalar":
+        case "single-quoted-scalar":
+        case "double-quoted-scalar":
+        case "block-scalar":
+          node = composeScalar.composeScalar(ctx, token, tag, onError);
+          if (anchor)
+            node.anchor = anchor.source.substring(1);
+          break;
+        case "block-map":
+        case "block-seq":
+        case "flow-collection":
+          node = composeCollection.composeCollection(CN, ctx, token, props, onError);
+          if (anchor)
+            node.anchor = anchor.source.substring(1);
+          break;
+        default: {
+          const message = token.type === "error" ? token.message : `Unsupported token (type: ${token.type})`;
+          onError(token, "UNEXPECTED_TOKEN", message);
+          node = composeEmptyNode(ctx, token.offset, void 0, null, props, onError);
+          isSrcToken = false;
+        }
+      }
+      if (anchor && node.anchor === "")
+        onError(anchor, "BAD_ALIAS", "Anchor cannot be an empty string");
+      if (atKey && ctx.options.stringKeys && (!identity.isScalar(node) || typeof node.value !== "string" || node.tag && node.tag !== "tag:yaml.org,2002:str")) {
+        const msg = "With stringKeys, all keys must be strings";
+        onError(tag ?? token, "NON_STRING_KEY", msg);
+      }
+      if (spaceBefore)
+        node.spaceBefore = true;
+      if (comment) {
+        if (token.type === "scalar" && token.source === "")
+          node.comment = comment;
+        else
+          node.commentBefore = comment;
+      }
+      if (ctx.options.keepSourceTokens && isSrcToken)
+        node.srcToken = token;
+      return node;
+    }
+    function composeEmptyNode(ctx, offset, before, pos, { spaceBefore, comment, anchor, tag, end }, onError) {
+      const token = {
+        type: "scalar",
+        offset: utilEmptyScalarPosition.emptyScalarPosition(offset, before, pos),
+        indent: -1,
+        source: ""
+      };
+      const node = composeScalar.composeScalar(ctx, token, tag, onError);
+      if (anchor) {
+        node.anchor = anchor.source.substring(1);
+        if (node.anchor === "")
+          onError(anchor, "BAD_ALIAS", "Anchor cannot be an empty string");
+      }
+      if (spaceBefore)
+        node.spaceBefore = true;
+      if (comment) {
+        node.comment = comment;
+        node.range[2] = end;
+      }
+      return node;
+    }
+    function composeAlias({ options }, { offset, source, end }, onError) {
+      const alias = new Alias.Alias(source.substring(1));
+      if (alias.source === "")
+        onError(offset, "BAD_ALIAS", "Alias cannot be an empty string");
+      if (alias.source.endsWith(":"))
+        onError(offset + source.length - 1, "BAD_ALIAS", "Alias ending in : is ambiguous", true);
+      const valueEnd = offset + source.length;
+      const re = resolveEnd.resolveEnd(end, valueEnd, options.strict, onError);
+      alias.range = [offset, valueEnd, re.offset];
+      if (re.comment)
+        alias.comment = re.comment;
+      return alias;
+    }
+    exports2.composeEmptyNode = composeEmptyNode;
+    exports2.composeNode = composeNode;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js
+var require_compose_doc = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/compose-doc.js"(exports2) {
+    "use strict";
+    var Document = require_Document();
+    var composeNode = require_compose_node();
+    var resolveEnd = require_resolve_end();
+    var resolveProps = require_resolve_props();
+    function composeDoc(options, directives, { offset, start, value, end }, onError) {
+      const opts = Object.assign({ _directives: directives }, options);
+      const doc = new Document.Document(void 0, opts);
+      const ctx = {
+        atKey: false,
+        atRoot: true,
+        directives: doc.directives,
+        options: doc.options,
+        schema: doc.schema
+      };
+      const props = resolveProps.resolveProps(start, {
+        indicator: "doc-start",
+        next: value ?? end?.[0],
+        offset,
+        onError,
+        parentIndent: 0,
+        startOnNewline: true
+      });
+      if (props.found) {
+        doc.directives.docStart = true;
+        if (value && (value.type === "block-map" || value.type === "block-seq") && !props.hasNewline)
+          onError(props.end, "MISSING_CHAR", "Block collection cannot start on same line with directives-end marker");
+      }
+      doc.contents = value ? composeNode.composeNode(ctx, value, props, onError) : composeNode.composeEmptyNode(ctx, props.end, start, null, props, onError);
+      const contentEnd = doc.contents.range[2];
+      const re = resolveEnd.resolveEnd(end, contentEnd, false, onError);
+      if (re.comment)
+        doc.comment = re.comment;
+      doc.range = [offset, contentEnd, re.offset];
+      return doc;
+    }
+    exports2.composeDoc = composeDoc;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js
+var require_composer = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/compose/composer.js"(exports2) {
+    "use strict";
+    var node_process = require("process");
+    var directives = require_directives();
+    var Document = require_Document();
+    var errors = require_errors();
+    var identity = require_identity();
+    var composeDoc = require_compose_doc();
+    var resolveEnd = require_resolve_end();
+    function getErrorPos(src) {
+      if (typeof src === "number")
+        return [src, src + 1];
+      if (Array.isArray(src))
+        return src.length === 2 ? src : [src[0], src[1]];
+      const { offset, source } = src;
+      return [offset, offset + (typeof source === "string" ? source.length : 1)];
+    }
+    function parsePrelude(prelude) {
+      let comment = "";
+      let atComment = false;
+      let afterEmptyLine = false;
+      for (let i = 0; i < prelude.length; ++i) {
+        const source = prelude[i];
+        switch (source[0]) {
+          case "#":
+            comment += (comment === "" ? "" : afterEmptyLine ? "\n\n" : "\n") + (source.substring(1) || " ");
+            atComment = true;
+            afterEmptyLine = false;
+            break;
+          case "%":
+            if (prelude[i + 1]?.[0] !== "#")
+              i += 1;
+            atComment = false;
+            break;
+          default:
+            if (!atComment)
+              afterEmptyLine = true;
+            atComment = false;
+        }
+      }
+      return { comment, afterEmptyLine };
+    }
+    var Composer = class {
+      constructor(options = {}) {
+        this.doc = null;
+        this.atDirectives = false;
+        this.prelude = [];
+        this.errors = [];
+        this.warnings = [];
+        this.onError = (source, code, message, warning) => {
+          const pos = getErrorPos(source);
+          if (warning)
+            this.warnings.push(new errors.YAMLWarning(pos, code, message));
+          else
+            this.errors.push(new errors.YAMLParseError(pos, code, message));
+        };
+        this.directives = new directives.Directives({ version: options.version || "1.2" });
+        this.options = options;
+      }
+      decorate(doc, afterDoc) {
+        const { comment, afterEmptyLine } = parsePrelude(this.prelude);
+        if (comment) {
+          const dc = doc.contents;
+          if (afterDoc) {
+            doc.comment = doc.comment ? `${doc.comment}
+${comment}` : comment;
+          } else if (afterEmptyLine || doc.directives.docStart || !dc) {
+            doc.commentBefore = comment;
+          } else if (identity.isCollection(dc) && !dc.flow && dc.items.length > 0) {
+            let it = dc.items[0];
+            if (identity.isPair(it))
+              it = it.key;
+            const cb = it.commentBefore;
+            it.commentBefore = cb ? `${comment}
+${cb}` : comment;
+          } else {
+            const cb = dc.commentBefore;
+            dc.commentBefore = cb ? `${comment}
+${cb}` : comment;
+          }
+        }
+        if (afterDoc) {
+          Array.prototype.push.apply(doc.errors, this.errors);
+          Array.prototype.push.apply(doc.warnings, this.warnings);
+        } else {
+          doc.errors = this.errors;
+          doc.warnings = this.warnings;
+        }
+        this.prelude = [];
+        this.errors = [];
+        this.warnings = [];
+      }
+      /**
+       * Current stream status information.
+       *
+       * Mostly useful at the end of input for an empty stream.
+       */
+      streamInfo() {
+        return {
+          comment: parsePrelude(this.prelude).comment,
+          directives: this.directives,
+          errors: this.errors,
+          warnings: this.warnings
+        };
+      }
+      /**
+       * Compose tokens into documents.
+       *
+       * @param forceDoc - If the stream contains no document, still emit a final document including any comments and directives that would be applied to a subsequent document.
+       * @param endOffset - Should be set if `forceDoc` is also set, to set the document range end and to indicate errors correctly.
+       */
+      *compose(tokens, forceDoc = false, endOffset = -1) {
+        for (const token of tokens)
+          yield* this.next(token);
+        yield* this.end(forceDoc, endOffset);
+      }
+      /** Advance the composer by one CST token. */
+      *next(token) {
+        if (node_process.env.LOG_STREAM)
+          console.dir(token, { depth: null });
+        switch (token.type) {
+          case "directive":
+            this.directives.add(token.source, (offset, message, warning) => {
+              const pos = getErrorPos(token);
+              pos[0] += offset;
+              this.onError(pos, "BAD_DIRECTIVE", message, warning);
+            });
+            this.prelude.push(token.source);
+            this.atDirectives = true;
+            break;
+          case "document": {
+            const doc = composeDoc.composeDoc(this.options, this.directives, token, this.onError);
+            if (this.atDirectives && !doc.directives.docStart)
+              this.onError(token, "MISSING_CHAR", "Missing directives-end/doc-start indicator line");
+            this.decorate(doc, false);
+            if (this.doc)
+              yield this.doc;
+            this.doc = doc;
+            this.atDirectives = false;
+            break;
+          }
+          case "byte-order-mark":
+          case "space":
+            break;
+          case "comment":
+          case "newline":
+            this.prelude.push(token.source);
+            break;
+          case "error": {
+            const msg = token.source ? `${token.message}: ${JSON.stringify(token.source)}` : token.message;
+            const error = new errors.YAMLParseError(getErrorPos(token), "UNEXPECTED_TOKEN", msg);
+            if (this.atDirectives || !this.doc)
+              this.errors.push(error);
+            else
+              this.doc.errors.push(error);
+            break;
+          }
+          case "doc-end": {
+            if (!this.doc) {
+              const msg = "Unexpected doc-end without preceding document";
+              this.errors.push(new errors.YAMLParseError(getErrorPos(token), "UNEXPECTED_TOKEN", msg));
+              break;
+            }
+            this.doc.directives.docEnd = true;
+            const end = resolveEnd.resolveEnd(token.end, token.offset + token.source.length, this.doc.options.strict, this.onError);
+            this.decorate(this.doc, true);
+            if (end.comment) {
+              const dc = this.doc.comment;
+              this.doc.comment = dc ? `${dc}
+${end.comment}` : end.comment;
+            }
+            this.doc.range[2] = end.offset;
+            break;
+          }
+          default:
+            this.errors.push(new errors.YAMLParseError(getErrorPos(token), "UNEXPECTED_TOKEN", `Unsupported token ${token.type}`));
+        }
+      }
+      /**
+       * Call at end of input to yield any remaining document.
+       *
+       * @param forceDoc - If the stream contains no document, still emit a final document including any comments and directives that would be applied to a subsequent document.
+       * @param endOffset - Should be set if `forceDoc` is also set, to set the document range end and to indicate errors correctly.
+       */
+      *end(forceDoc = false, endOffset = -1) {
+        if (this.doc) {
+          this.decorate(this.doc, true);
+          yield this.doc;
+          this.doc = null;
+        } else if (forceDoc) {
+          const opts = Object.assign({ _directives: this.directives }, this.options);
+          const doc = new Document.Document(void 0, opts);
+          if (this.atDirectives)
+            this.onError(endOffset, "MISSING_CHAR", "Missing directives-end indicator line");
+          doc.range = [0, endOffset, endOffset];
+          this.decorate(doc, false);
+          yield doc;
+        }
+      }
+    };
+    exports2.Composer = Composer;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js
+var require_cst_scalar = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-scalar.js"(exports2) {
+    "use strict";
+    var resolveBlockScalar = require_resolve_block_scalar();
+    var resolveFlowScalar = require_resolve_flow_scalar();
+    var errors = require_errors();
+    var stringifyString = require_stringifyString();
+    function resolveAsScalar(token, strict = true, onError) {
+      if (token) {
+        const _onError = (pos, code, message) => {
+          const offset = typeof pos === "number" ? pos : Array.isArray(pos) ? pos[0] : pos.offset;
+          if (onError)
+            onError(offset, code, message);
+          else
+            throw new errors.YAMLParseError([offset, offset + 1], code, message);
+        };
+        switch (token.type) {
+          case "scalar":
+          case "single-quoted-scalar":
+          case "double-quoted-scalar":
+            return resolveFlowScalar.resolveFlowScalar(token, strict, _onError);
+          case "block-scalar":
+            return resolveBlockScalar.resolveBlockScalar({ options: { strict } }, token, _onError);
+        }
+      }
+      return null;
+    }
+    function createScalarToken(value, context) {
+      const { implicitKey = false, indent, inFlow = false, offset = -1, type = "PLAIN" } = context;
+      const source = stringifyString.stringifyString({ type, value }, {
+        implicitKey,
+        indent: indent > 0 ? " ".repeat(indent) : "",
+        inFlow,
+        options: { blockQuote: true, lineWidth: -1 }
+      });
+      const end = context.end ?? [
+        { type: "newline", offset: -1, indent, source: "\n" }
+      ];
+      switch (source[0]) {
+        case "|":
+        case ">": {
+          const he = source.indexOf("\n");
+          const head = source.substring(0, he);
+          const body = source.substring(he + 1) + "\n";
+          const props = [
+            { type: "block-scalar-header", offset, indent, source: head }
+          ];
+          if (!addEndtoBlockProps(props, end))
+            props.push({ type: "newline", offset: -1, indent, source: "\n" });
+          return { type: "block-scalar", offset, indent, props, source: body };
+        }
+        case '"':
+          return { type: "double-quoted-scalar", offset, indent, source, end };
+        case "'":
+          return { type: "single-quoted-scalar", offset, indent, source, end };
+        default:
+          return { type: "scalar", offset, indent, source, end };
+      }
+    }
+    function setScalarValue(token, value, context = {}) {
+      let { afterKey = false, implicitKey = false, inFlow = false, type } = context;
+      let indent = "indent" in token ? token.indent : null;
+      if (afterKey && typeof indent === "number")
+        indent += 2;
+      if (!type)
+        switch (token.type) {
+          case "single-quoted-scalar":
+            type = "QUOTE_SINGLE";
+            break;
+          case "double-quoted-scalar":
+            type = "QUOTE_DOUBLE";
+            break;
+          case "block-scalar": {
+            const header = token.props[0];
+            if (header.type !== "block-scalar-header")
+              throw new Error("Invalid block scalar header");
+            type = header.source[0] === ">" ? "BLOCK_FOLDED" : "BLOCK_LITERAL";
+            break;
+          }
+          default:
+            type = "PLAIN";
+        }
+      const source = stringifyString.stringifyString({ type, value }, {
+        implicitKey: implicitKey || indent === null,
+        indent: indent !== null && indent > 0 ? " ".repeat(indent) : "",
+        inFlow,
+        options: { blockQuote: true, lineWidth: -1 }
+      });
+      switch (source[0]) {
+        case "|":
+        case ">":
+          setBlockScalarValue(token, source);
+          break;
+        case '"':
+          setFlowScalarValue(token, source, "double-quoted-scalar");
+          break;
+        case "'":
+          setFlowScalarValue(token, source, "single-quoted-scalar");
+          break;
+        default:
+          setFlowScalarValue(token, source, "scalar");
+      }
+    }
+    function setBlockScalarValue(token, source) {
+      const he = source.indexOf("\n");
+      const head = source.substring(0, he);
+      const body = source.substring(he + 1) + "\n";
+      if (token.type === "block-scalar") {
+        const header = token.props[0];
+        if (header.type !== "block-scalar-header")
+          throw new Error("Invalid block scalar header");
+        header.source = head;
+        token.source = body;
+      } else {
+        const { offset } = token;
+        const indent = "indent" in token ? token.indent : -1;
+        const props = [
+          { type: "block-scalar-header", offset, indent, source: head }
+        ];
+        if (!addEndtoBlockProps(props, "end" in token ? token.end : void 0))
+          props.push({ type: "newline", offset: -1, indent, source: "\n" });
+        for (const key of Object.keys(token))
+          if (key !== "type" && key !== "offset")
+            delete token[key];
+        Object.assign(token, { type: "block-scalar", indent, props, source: body });
+      }
+    }
+    function addEndtoBlockProps(props, end) {
+      if (end)
+        for (const st of end)
+          switch (st.type) {
+            case "space":
+            case "comment":
+              props.push(st);
+              break;
+            case "newline":
+              props.push(st);
+              return true;
+          }
+      return false;
+    }
+    function setFlowScalarValue(token, source, type) {
+      switch (token.type) {
+        case "scalar":
+        case "double-quoted-scalar":
+        case "single-quoted-scalar":
+          token.type = type;
+          token.source = source;
+          break;
+        case "block-scalar": {
+          const end = token.props.slice(1);
+          let oa = source.length;
+          if (token.props[0].type === "block-scalar-header")
+            oa -= token.props[0].source.length;
+          for (const tok of end)
+            tok.offset += oa;
+          delete token.props;
+          Object.assign(token, { type, source, end });
+          break;
+        }
+        case "block-map":
+        case "block-seq": {
+          const offset = token.offset + source.length;
+          const nl = { type: "newline", offset, indent: token.indent, source: "\n" };
+          delete token.items;
+          Object.assign(token, { type, source, end: [nl] });
+          break;
+        }
+        default: {
+          const indent = "indent" in token ? token.indent : -1;
+          const end = "end" in token && Array.isArray(token.end) ? token.end.filter((st) => st.type === "space" || st.type === "comment" || st.type === "newline") : [];
+          for (const key of Object.keys(token))
+            if (key !== "type" && key !== "offset")
+              delete token[key];
+          Object.assign(token, { type, indent, source, end });
+        }
+      }
+    }
+    exports2.createScalarToken = createScalarToken;
+    exports2.resolveAsScalar = resolveAsScalar;
+    exports2.setScalarValue = setScalarValue;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js
+var require_cst_stringify = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-stringify.js"(exports2) {
+    "use strict";
+    var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
+    function stringifyToken(token) {
+      switch (token.type) {
+        case "block-scalar": {
+          let res = "";
+          for (const tok of token.props)
+            res += stringifyToken(tok);
+          return res + token.source;
+        }
+        case "block-map":
+        case "block-seq": {
+          let res = "";
+          for (const item of token.items)
+            res += stringifyItem(item);
+          return res;
+        }
+        case "flow-collection": {
+          let res = token.start.source;
+          for (const item of token.items)
+            res += stringifyItem(item);
+          for (const st of token.end)
+            res += st.source;
+          return res;
+        }
+        case "document": {
+          let res = stringifyItem(token);
+          if (token.end)
+            for (const st of token.end)
+              res += st.source;
+          return res;
+        }
+        default: {
+          let res = token.source;
+          if ("end" in token && token.end)
+            for (const st of token.end)
+              res += st.source;
+          return res;
+        }
+      }
+    }
+    function stringifyItem({ start, key, sep, value }) {
+      let res = "";
+      for (const st of start)
+        res += st.source;
+      if (key)
+        res += stringifyToken(key);
+      if (sep)
+        for (const st of sep)
+          res += st.source;
+      if (value)
+        res += stringifyToken(value);
+      return res;
+    }
+    exports2.stringify = stringify;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js
+var require_cst_visit = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst-visit.js"(exports2) {
+    "use strict";
+    var BREAK = /* @__PURE__ */ Symbol("break visit");
+    var SKIP = /* @__PURE__ */ Symbol("skip children");
+    var REMOVE = /* @__PURE__ */ Symbol("remove item");
+    function visit(cst, visitor) {
+      if ("type" in cst && cst.type === "document")
+        cst = { start: cst.start, value: cst.value };
+      _visit(Object.freeze([]), cst, visitor);
+    }
+    visit.BREAK = BREAK;
+    visit.SKIP = SKIP;
+    visit.REMOVE = REMOVE;
+    visit.itemAtPath = (cst, path) => {
+      let item = cst;
+      for (const [field, index] of path) {
+        const tok = item?.[field];
+        if (tok && "items" in tok) {
+          item = tok.items[index];
+        } else
+          return void 0;
+      }
+      return item;
+    };
+    visit.parentCollection = (cst, path) => {
+      const parent = visit.itemAtPath(cst, path.slice(0, -1));
+      const field = path[path.length - 1][0];
+      const coll = parent?.[field];
+      if (coll && "items" in coll)
+        return coll;
+      throw new Error("Parent collection not found");
+    };
+    function _visit(path, item, visitor) {
+      let ctrl = visitor(item, path);
+      if (typeof ctrl === "symbol")
+        return ctrl;
+      for (const field of ["key", "value"]) {
+        const token = item[field];
+        if (token && "items" in token) {
+          for (let i = 0; i < token.items.length; ++i) {
+            const ci = _visit(Object.freeze(path.concat([[field, i]])), token.items[i], visitor);
+            if (typeof ci === "number")
+              i = ci - 1;
+            else if (ci === BREAK)
+              return BREAK;
+            else if (ci === REMOVE) {
+              token.items.splice(i, 1);
+              i -= 1;
+            }
+          }
+          if (typeof ctrl === "function" && field === "key")
+            ctrl = ctrl(item, path);
+        }
+      }
+      return typeof ctrl === "function" ? ctrl(item, path) : ctrl;
+    }
+    exports2.visit = visit;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js
+var require_cst = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/cst.js"(exports2) {
+    "use strict";
+    var cstScalar = require_cst_scalar();
+    var cstStringify = require_cst_stringify();
+    var cstVisit = require_cst_visit();
+    var BOM = "\uFEFF";
+    var DOCUMENT = "";
+    var FLOW_END = "";
+    var SCALAR = "";
+    var isCollection = (token) => !!token && "items" in token;
+    var isScalar = (token) => !!token && (token.type === "scalar" || token.type === "single-quoted-scalar" || token.type === "double-quoted-scalar" || token.type === "block-scalar");
+    function prettyToken(token) {
+      switch (token) {
+        case BOM:
+          return "<BOM>";
+        case DOCUMENT:
+          return "<DOC>";
+        case FLOW_END:
+          return "<FLOW_END>";
+        case SCALAR:
+          return "<SCALAR>";
+        default:
+          return JSON.stringify(token);
+      }
+    }
+    function tokenType(source) {
+      switch (source) {
+        case BOM:
+          return "byte-order-mark";
+        case DOCUMENT:
+          return "doc-mode";
+        case FLOW_END:
+          return "flow-error-end";
+        case SCALAR:
+          return "scalar";
+        case "---":
+          return "doc-start";
+        case "...":
+          return "doc-end";
+        case "":
+        case "\n":
+        case "\r\n":
+          return "newline";
+        case "-":
+          return "seq-item-ind";
+        case "?":
+          return "explicit-key-ind";
+        case ":":
+          return "map-value-ind";
+        case "{":
+          return "flow-map-start";
+        case "}":
+          return "flow-map-end";
+        case "[":
+          return "flow-seq-start";
+        case "]":
+          return "flow-seq-end";
+        case ",":
+          return "comma";
+      }
+      switch (source[0]) {
+        case " ":
+        case "	":
+          return "space";
+        case "#":
+          return "comment";
+        case "%":
+          return "directive-line";
+        case "*":
+          return "alias";
+        case "&":
+          return "anchor";
+        case "!":
+          return "tag";
+        case "'":
+          return "single-quoted-scalar";
+        case '"':
+          return "double-quoted-scalar";
+        case "|":
+        case ">":
+          return "block-scalar-header";
+      }
+      return null;
+    }
+    exports2.createScalarToken = cstScalar.createScalarToken;
+    exports2.resolveAsScalar = cstScalar.resolveAsScalar;
+    exports2.setScalarValue = cstScalar.setScalarValue;
+    exports2.stringify = cstStringify.stringify;
+    exports2.visit = cstVisit.visit;
+    exports2.BOM = BOM;
+    exports2.DOCUMENT = DOCUMENT;
+    exports2.FLOW_END = FLOW_END;
+    exports2.SCALAR = SCALAR;
+    exports2.isCollection = isCollection;
+    exports2.isScalar = isScalar;
+    exports2.prettyToken = prettyToken;
+    exports2.tokenType = tokenType;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js
+var require_lexer = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/lexer.js"(exports2) {
+    "use strict";
+    var cst = require_cst();
+    function isEmpty(ch) {
+      switch (ch) {
+        case void 0:
+        case " ":
+        case "\n":
+        case "\r":
+        case "	":
+          return true;
+        default:
+          return false;
+      }
+    }
+    var hexDigits = new Set("0123456789ABCDEFabcdef");
+    var tagChars = new Set("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-#;/?:@&=+$_.!~*'()");
+    var flowIndicatorChars = new Set(",[]{}");
+    var invalidAnchorChars = new Set(" ,[]{}\n\r	");
+    var isNotAnchorChar = (ch) => !ch || invalidAnchorChars.has(ch);
+    var Lexer = class {
+      constructor() {
+        this.atEnd = false;
+        this.blockScalarIndent = -1;
+        this.blockScalarKeep = false;
+        this.buffer = "";
+        this.flowKey = false;
+        this.flowLevel = 0;
+        this.indentNext = 0;
+        this.indentValue = 0;
+        this.lineEndPos = null;
+        this.next = null;
+        this.pos = 0;
+      }
+      /**
+       * Generate YAML tokens from the `source` string. If `incomplete`,
+       * a part of the last line may be left as a buffer for the next call.
+       *
+       * @returns A generator of lexical tokens
+       */
+      *lex(source, incomplete = false) {
+        if (source) {
+          if (typeof source !== "string")
+            throw TypeError("source is not a string");
+          this.buffer = this.buffer ? this.buffer + source : source;
+          this.lineEndPos = null;
+        }
+        this.atEnd = !incomplete;
+        let next = this.next ?? "stream";
+        while (next && (incomplete || this.hasChars(1)))
+          next = yield* this.parseNext(next);
+      }
+      atLineEnd() {
+        let i = this.pos;
+        let ch = this.buffer[i];
+        while (ch === " " || ch === "	")
+          ch = this.buffer[++i];
+        if (!ch || ch === "#" || ch === "\n")
+          return true;
+        if (ch === "\r")
+          return this.buffer[i + 1] === "\n";
+        return false;
+      }
+      charAt(n) {
+        return this.buffer[this.pos + n];
+      }
+      continueScalar(offset) {
+        let ch = this.buffer[offset];
+        if (this.indentNext > 0) {
+          let indent = 0;
+          while (ch === " ")
+            ch = this.buffer[++indent + offset];
+          if (ch === "\r") {
+            const next = this.buffer[indent + offset + 1];
+            if (next === "\n" || !next && !this.atEnd)
+              return offset + indent + 1;
+          }
+          return ch === "\n" || indent >= this.indentNext || !ch && !this.atEnd ? offset + indent : -1;
+        }
+        if (ch === "-" || ch === ".") {
+          const dt = this.buffer.substr(offset, 3);
+          if ((dt === "---" || dt === "...") && isEmpty(this.buffer[offset + 3]))
+            return -1;
+        }
+        return offset;
+      }
+      getLine() {
+        let end = this.lineEndPos;
+        if (typeof end !== "number" || end !== -1 && end < this.pos) {
+          end = this.buffer.indexOf("\n", this.pos);
+          this.lineEndPos = end;
+        }
+        if (end === -1)
+          return this.atEnd ? this.buffer.substring(this.pos) : null;
+        if (this.buffer[end - 1] === "\r")
+          end -= 1;
+        return this.buffer.substring(this.pos, end);
+      }
+      hasChars(n) {
+        return this.pos + n <= this.buffer.length;
+      }
+      setNext(state) {
+        this.buffer = this.buffer.substring(this.pos);
+        this.pos = 0;
+        this.lineEndPos = null;
+        this.next = state;
+        return null;
+      }
+      peek(n) {
+        return this.buffer.substr(this.pos, n);
+      }
+      *parseNext(next) {
+        switch (next) {
+          case "stream":
+            return yield* this.parseStream();
+          case "line-start":
+            return yield* this.parseLineStart();
+          case "block-start":
+            return yield* this.parseBlockStart();
+          case "doc":
+            return yield* this.parseDocument();
+          case "flow":
+            return yield* this.parseFlowCollection();
+          case "quoted-scalar":
+            return yield* this.parseQuotedScalar();
+          case "block-scalar":
+            return yield* this.parseBlockScalar();
+          case "plain-scalar":
+            return yield* this.parsePlainScalar();
+        }
+      }
+      *parseStream() {
+        let line = this.getLine();
+        if (line === null)
+          return this.setNext("stream");
+        if (line[0] === cst.BOM) {
+          yield* this.pushCount(1);
+          line = line.substring(1);
+        }
+        if (line[0] === "%") {
+          let dirEnd = line.length;
+          let cs = line.indexOf("#");
+          while (cs !== -1) {
+            const ch = line[cs - 1];
+            if (ch === " " || ch === "	") {
+              dirEnd = cs - 1;
+              break;
+            } else {
+              cs = line.indexOf("#", cs + 1);
+            }
+          }
+          while (true) {
+            const ch = line[dirEnd - 1];
+            if (ch === " " || ch === "	")
+              dirEnd -= 1;
+            else
+              break;
+          }
+          const n = (yield* this.pushCount(dirEnd)) + (yield* this.pushSpaces(true));
+          yield* this.pushCount(line.length - n);
+          this.pushNewline();
+          return "stream";
+        }
+        if (this.atLineEnd()) {
+          const sp = yield* this.pushSpaces(true);
+          yield* this.pushCount(line.length - sp);
+          yield* this.pushNewline();
+          return "stream";
+        }
+        yield cst.DOCUMENT;
+        return yield* this.parseLineStart();
+      }
+      *parseLineStart() {
+        const ch = this.charAt(0);
+        if (!ch && !this.atEnd)
+          return this.setNext("line-start");
+        if (ch === "-" || ch === ".") {
+          if (!this.atEnd && !this.hasChars(4))
+            return this.setNext("line-start");
+          const s = this.peek(3);
+          if ((s === "---" || s === "...") && isEmpty(this.charAt(3))) {
+            yield* this.pushCount(3);
+            this.indentValue = 0;
+            this.indentNext = 0;
+            return s === "---" ? "doc" : "stream";
+          }
+        }
+        this.indentValue = yield* this.pushSpaces(false);
+        if (this.indentNext > this.indentValue && !isEmpty(this.charAt(1)))
+          this.indentNext = this.indentValue;
+        return yield* this.parseBlockStart();
+      }
+      *parseBlockStart() {
+        const [ch0, ch1] = this.peek(2);
+        if (!ch1 && !this.atEnd)
+          return this.setNext("block-start");
+        if ((ch0 === "-" || ch0 === "?" || ch0 === ":") && isEmpty(ch1)) {
+          const n = (yield* this.pushCount(1)) + (yield* this.pushSpaces(true));
+          this.indentNext = this.indentValue + 1;
+          this.indentValue += n;
+          return yield* this.parseBlockStart();
+        }
+        return "doc";
+      }
+      *parseDocument() {
+        yield* this.pushSpaces(true);
+        const line = this.getLine();
+        if (line === null)
+          return this.setNext("doc");
+        let n = yield* this.pushIndicators();
+        switch (line[n]) {
+          case "#":
+            yield* this.pushCount(line.length - n);
+          // fallthrough
+          case void 0:
+            yield* this.pushNewline();
+            return yield* this.parseLineStart();
+          case "{":
+          case "[":
+            yield* this.pushCount(1);
+            this.flowKey = false;
+            this.flowLevel = 1;
+            return "flow";
+          case "}":
+          case "]":
+            yield* this.pushCount(1);
+            return "doc";
+          case "*":
+            yield* this.pushUntil(isNotAnchorChar);
+            return "doc";
+          case '"':
+          case "'":
+            return yield* this.parseQuotedScalar();
+          case "|":
+          case ">":
+            n += yield* this.parseBlockScalarHeader();
+            n += yield* this.pushSpaces(true);
+            yield* this.pushCount(line.length - n);
+            yield* this.pushNewline();
+            return yield* this.parseBlockScalar();
+          default:
+            return yield* this.parsePlainScalar();
+        }
+      }
+      *parseFlowCollection() {
+        let nl, sp;
+        let indent = -1;
+        do {
+          nl = yield* this.pushNewline();
+          if (nl > 0) {
+            sp = yield* this.pushSpaces(false);
+            this.indentValue = indent = sp;
+          } else {
+            sp = 0;
+          }
+          sp += yield* this.pushSpaces(true);
+        } while (nl + sp > 0);
+        const line = this.getLine();
+        if (line === null)
+          return this.setNext("flow");
+        if (indent !== -1 && indent < this.indentNext && line[0] !== "#" || indent === 0 && (line.startsWith("---") || line.startsWith("...")) && isEmpty(line[3])) {
+          const atFlowEndMarker = indent === this.indentNext - 1 && this.flowLevel === 1 && (line[0] === "]" || line[0] === "}");
+          if (!atFlowEndMarker) {
+            this.flowLevel = 0;
+            yield cst.FLOW_END;
+            return yield* this.parseLineStart();
+          }
+        }
+        let n = 0;
+        while (line[n] === ",") {
+          n += yield* this.pushCount(1);
+          n += yield* this.pushSpaces(true);
+          this.flowKey = false;
+        }
+        n += yield* this.pushIndicators();
+        switch (line[n]) {
+          case void 0:
+            return "flow";
+          case "#":
+            yield* this.pushCount(line.length - n);
+            return "flow";
+          case "{":
+          case "[":
+            yield* this.pushCount(1);
+            this.flowKey = false;
+            this.flowLevel += 1;
+            return "flow";
+          case "}":
+          case "]":
+            yield* this.pushCount(1);
+            this.flowKey = true;
+            this.flowLevel -= 1;
+            return this.flowLevel ? "flow" : "doc";
+          case "*":
+            yield* this.pushUntil(isNotAnchorChar);
+            return "flow";
+          case '"':
+          case "'":
+            this.flowKey = true;
+            return yield* this.parseQuotedScalar();
+          case ":": {
+            const next = this.charAt(1);
+            if (this.flowKey || isEmpty(next) || next === ",") {
+              this.flowKey = false;
+              yield* this.pushCount(1);
+              yield* this.pushSpaces(true);
+              return "flow";
+            }
+          }
+          // fallthrough
+          default:
+            this.flowKey = false;
+            return yield* this.parsePlainScalar();
+        }
+      }
+      *parseQuotedScalar() {
+        const quote = this.charAt(0);
+        let end = this.buffer.indexOf(quote, this.pos + 1);
+        if (quote === "'") {
+          while (end !== -1 && this.buffer[end + 1] === "'")
+            end = this.buffer.indexOf("'", end + 2);
+        } else {
+          while (end !== -1) {
+            let n = 0;
+            while (this.buffer[end - 1 - n] === "\\")
+              n += 1;
+            if (n % 2 === 0)
+              break;
+            end = this.buffer.indexOf('"', end + 1);
+          }
+        }
+        const qb = this.buffer.substring(0, end);
+        let nl = qb.indexOf("\n", this.pos);
+        if (nl !== -1) {
+          while (nl !== -1) {
+            const cs = this.continueScalar(nl + 1);
+            if (cs === -1)
+              break;
+            nl = qb.indexOf("\n", cs);
+          }
+          if (nl !== -1) {
+            end = nl - (qb[nl - 1] === "\r" ? 2 : 1);
+          }
+        }
+        if (end === -1) {
+          if (!this.atEnd)
+            return this.setNext("quoted-scalar");
+          end = this.buffer.length;
+        }
+        yield* this.pushToIndex(end + 1, false);
+        return this.flowLevel ? "flow" : "doc";
+      }
+      *parseBlockScalarHeader() {
+        this.blockScalarIndent = -1;
+        this.blockScalarKeep = false;
+        let i = this.pos;
+        while (true) {
+          const ch = this.buffer[++i];
+          if (ch === "+")
+            this.blockScalarKeep = true;
+          else if (ch > "0" && ch <= "9")
+            this.blockScalarIndent = Number(ch) - 1;
+          else if (ch !== "-")
+            break;
+        }
+        return yield* this.pushUntil((ch) => isEmpty(ch) || ch === "#");
+      }
+      *parseBlockScalar() {
+        let nl = this.pos - 1;
+        let indent = 0;
+        let ch;
+        loop: for (let i2 = this.pos; ch = this.buffer[i2]; ++i2) {
+          switch (ch) {
+            case " ":
+              indent += 1;
+              break;
+            case "\n":
+              nl = i2;
+              indent = 0;
+              break;
+            case "\r": {
+              const next = this.buffer[i2 + 1];
+              if (!next && !this.atEnd)
+                return this.setNext("block-scalar");
+              if (next === "\n")
+                break;
+            }
+            // fallthrough
+            default:
+              break loop;
+          }
+        }
+        if (!ch && !this.atEnd)
+          return this.setNext("block-scalar");
+        if (indent >= this.indentNext) {
+          if (this.blockScalarIndent === -1)
+            this.indentNext = indent;
+          else {
+            this.indentNext = this.blockScalarIndent + (this.indentNext === 0 ? 1 : this.indentNext);
+          }
+          do {
+            const cs = this.continueScalar(nl + 1);
+            if (cs === -1)
+              break;
+            nl = this.buffer.indexOf("\n", cs);
+          } while (nl !== -1);
+          if (nl === -1) {
+            if (!this.atEnd)
+              return this.setNext("block-scalar");
+            nl = this.buffer.length;
+          }
+        }
+        let i = nl + 1;
+        ch = this.buffer[i];
+        while (ch === " ")
+          ch = this.buffer[++i];
+        if (ch === "	") {
+          while (ch === "	" || ch === " " || ch === "\r" || ch === "\n")
+            ch = this.buffer[++i];
+          nl = i - 1;
+        } else if (!this.blockScalarKeep) {
+          do {
+            let i2 = nl - 1;
+            let ch2 = this.buffer[i2];
+            if (ch2 === "\r")
+              ch2 = this.buffer[--i2];
+            const lastChar = i2;
+            while (ch2 === " ")
+              ch2 = this.buffer[--i2];
+            if (ch2 === "\n" && i2 >= this.pos && i2 + 1 + indent > lastChar)
+              nl = i2;
+            else
+              break;
+          } while (true);
+        }
+        yield cst.SCALAR;
+        yield* this.pushToIndex(nl + 1, true);
+        return yield* this.parseLineStart();
+      }
+      *parsePlainScalar() {
+        const inFlow = this.flowLevel > 0;
+        let end = this.pos - 1;
+        let i = this.pos - 1;
+        let ch;
+        while (ch = this.buffer[++i]) {
+          if (ch === ":") {
+            const next = this.buffer[i + 1];
+            if (isEmpty(next) || inFlow && flowIndicatorChars.has(next))
+              break;
+            end = i;
+          } else if (isEmpty(ch)) {
+            let next = this.buffer[i + 1];
+            if (ch === "\r") {
+              if (next === "\n") {
+                i += 1;
+                ch = "\n";
+                next = this.buffer[i + 1];
+              } else
+                end = i;
+            }
+            if (next === "#" || inFlow && flowIndicatorChars.has(next))
+              break;
+            if (ch === "\n") {
+              const cs = this.continueScalar(i + 1);
+              if (cs === -1)
+                break;
+              i = Math.max(i, cs - 2);
+            }
+          } else {
+            if (inFlow && flowIndicatorChars.has(ch))
+              break;
+            end = i;
+          }
+        }
+        if (!ch && !this.atEnd)
+          return this.setNext("plain-scalar");
+        yield cst.SCALAR;
+        yield* this.pushToIndex(end + 1, true);
+        return inFlow ? "flow" : "doc";
+      }
+      *pushCount(n) {
+        if (n > 0) {
+          yield this.buffer.substr(this.pos, n);
+          this.pos += n;
+          return n;
+        }
+        return 0;
+      }
+      *pushToIndex(i, allowEmpty) {
+        const s = this.buffer.slice(this.pos, i);
+        if (s) {
+          yield s;
+          this.pos += s.length;
+          return s.length;
+        } else if (allowEmpty)
+          yield "";
+        return 0;
+      }
+      *pushIndicators() {
+        switch (this.charAt(0)) {
+          case "!":
+            return (yield* this.pushTag()) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
+          case "&":
+            return (yield* this.pushUntil(isNotAnchorChar)) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
+          case "-":
+          // this is an error
+          case "?":
+          // this is an error outside flow collections
+          case ":": {
+            const inFlow = this.flowLevel > 0;
+            const ch1 = this.charAt(1);
+            if (isEmpty(ch1) || inFlow && flowIndicatorChars.has(ch1)) {
+              if (!inFlow)
+                this.indentNext = this.indentValue + 1;
+              else if (this.flowKey)
+                this.flowKey = false;
+              return (yield* this.pushCount(1)) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
+            }
+          }
+        }
+        return 0;
+      }
+      *pushTag() {
+        if (this.charAt(1) === "<") {
+          let i = this.pos + 2;
+          let ch = this.buffer[i];
+          while (!isEmpty(ch) && ch !== ">")
+            ch = this.buffer[++i];
+          return yield* this.pushToIndex(ch === ">" ? i + 1 : i, false);
+        } else {
+          let i = this.pos + 1;
+          let ch = this.buffer[i];
+          while (ch) {
+            if (tagChars.has(ch))
+              ch = this.buffer[++i];
+            else if (ch === "%" && hexDigits.has(this.buffer[i + 1]) && hexDigits.has(this.buffer[i + 2])) {
+              ch = this.buffer[i += 3];
+            } else
+              break;
+          }
+          return yield* this.pushToIndex(i, false);
+        }
+      }
+      *pushNewline() {
+        const ch = this.buffer[this.pos];
+        if (ch === "\n")
+          return yield* this.pushCount(1);
+        else if (ch === "\r" && this.charAt(1) === "\n")
+          return yield* this.pushCount(2);
+        else
+          return 0;
+      }
+      *pushSpaces(allowTabs) {
+        let i = this.pos - 1;
+        let ch;
+        do {
+          ch = this.buffer[++i];
+        } while (ch === " " || allowTabs && ch === "	");
+        const n = i - this.pos;
+        if (n > 0) {
+          yield this.buffer.substr(this.pos, n);
+          this.pos = i;
+        }
+        return n;
+      }
+      *pushUntil(test) {
+        let i = this.pos;
+        let ch = this.buffer[i];
+        while (!test(ch))
+          ch = this.buffer[++i];
+        return yield* this.pushToIndex(i, false);
+      }
+    };
+    exports2.Lexer = Lexer;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js
+var require_line_counter = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/line-counter.js"(exports2) {
+    "use strict";
+    var LineCounter = class {
+      constructor() {
+        this.lineStarts = [];
+        this.addNewLine = (offset) => this.lineStarts.push(offset);
+        this.linePos = (offset) => {
+          let low = 0;
+          let high = this.lineStarts.length;
+          while (low < high) {
+            const mid = low + high >> 1;
+            if (this.lineStarts[mid] < offset)
+              low = mid + 1;
+            else
+              high = mid;
+          }
+          if (this.lineStarts[low] === offset)
+            return { line: low + 1, col: 1 };
+          if (low === 0)
+            return { line: 0, col: offset };
+          const start = this.lineStarts[low - 1];
+          return { line: low, col: offset - start + 1 };
+        };
+      }
+    };
+    exports2.LineCounter = LineCounter;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js
+var require_parser = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/parse/parser.js"(exports2) {
+    "use strict";
+    var node_process = require("process");
+    var cst = require_cst();
+    var lexer = require_lexer();
+    function includesToken(list, type) {
+      for (let i = 0; i < list.length; ++i)
+        if (list[i].type === type)
+          return true;
+      return false;
+    }
+    function findNonEmptyIndex(list) {
+      for (let i = 0; i < list.length; ++i) {
+        switch (list[i].type) {
+          case "space":
+          case "comment":
+          case "newline":
+            break;
+          default:
+            return i;
+        }
+      }
+      return -1;
+    }
+    function isFlowToken(token) {
+      switch (token?.type) {
+        case "alias":
+        case "scalar":
+        case "single-quoted-scalar":
+        case "double-quoted-scalar":
+        case "flow-collection":
+          return true;
+        default:
+          return false;
+      }
+    }
+    function getPrevProps(parent) {
+      switch (parent.type) {
+        case "document":
+          return parent.start;
+        case "block-map": {
+          const it = parent.items[parent.items.length - 1];
+          return it.sep ?? it.start;
+        }
+        case "block-seq":
+          return parent.items[parent.items.length - 1].start;
+        /* istanbul ignore next should not happen */
+        default:
+          return [];
+      }
+    }
+    function getFirstKeyStartProps(prev) {
+      if (prev.length === 0)
+        return [];
+      let i = prev.length;
+      loop: while (--i >= 0) {
+        switch (prev[i].type) {
+          case "doc-start":
+          case "explicit-key-ind":
+          case "map-value-ind":
+          case "seq-item-ind":
+          case "newline":
+            break loop;
+        }
+      }
+      while (prev[++i]?.type === "space") {
+      }
+      return prev.splice(i, prev.length);
+    }
+    function fixFlowSeqItems(fc) {
+      if (fc.start.type === "flow-seq-start") {
+        for (const it of fc.items) {
+          if (it.sep && !it.value && !includesToken(it.start, "explicit-key-ind") && !includesToken(it.sep, "map-value-ind")) {
+            if (it.key)
+              it.value = it.key;
+            delete it.key;
+            if (isFlowToken(it.value)) {
+              if (it.value.end)
+                Array.prototype.push.apply(it.value.end, it.sep);
+              else
+                it.value.end = it.sep;
+            } else
+              Array.prototype.push.apply(it.start, it.sep);
+            delete it.sep;
+          }
+        }
+      }
+    }
+    var Parser = class {
+      /**
+       * @param onNewLine - If defined, called separately with the start position of
+       *   each new line (in `parse()`, including the start of input).
+       */
+      constructor(onNewLine) {
+        this.atNewLine = true;
+        this.atScalar = false;
+        this.indent = 0;
+        this.offset = 0;
+        this.onKeyLine = false;
+        this.stack = [];
+        this.source = "";
+        this.type = "";
+        this.lexer = new lexer.Lexer();
+        this.onNewLine = onNewLine;
+      }
+      /**
+       * Parse `source` as a YAML stream.
+       * If `incomplete`, a part of the last line may be left as a buffer for the next call.
+       *
+       * Errors are not thrown, but yielded as `{ type: 'error', message }` tokens.
+       *
+       * @returns A generator of tokens representing each directive, document, and other structure.
+       */
+      *parse(source, incomplete = false) {
+        if (this.onNewLine && this.offset === 0)
+          this.onNewLine(0);
+        for (const lexeme of this.lexer.lex(source, incomplete))
+          yield* this.next(lexeme);
+        if (!incomplete)
+          yield* this.end();
+      }
+      /**
+       * Advance the parser by the `source` of one lexical token.
+       */
+      *next(source) {
+        this.source = source;
+        if (node_process.env.LOG_TOKENS)
+          console.log("|", cst.prettyToken(source));
+        if (this.atScalar) {
+          this.atScalar = false;
+          yield* this.step();
+          this.offset += source.length;
+          return;
+        }
+        const type = cst.tokenType(source);
+        if (!type) {
+          const message = `Not a YAML token: ${source}`;
+          yield* this.pop({ type: "error", offset: this.offset, message, source });
+          this.offset += source.length;
+        } else if (type === "scalar") {
+          this.atNewLine = false;
+          this.atScalar = true;
+          this.type = "scalar";
+        } else {
+          this.type = type;
+          yield* this.step();
+          switch (type) {
+            case "newline":
+              this.atNewLine = true;
+              this.indent = 0;
+              if (this.onNewLine)
+                this.onNewLine(this.offset + source.length);
+              break;
+            case "space":
+              if (this.atNewLine && source[0] === " ")
+                this.indent += source.length;
+              break;
+            case "explicit-key-ind":
+            case "map-value-ind":
+            case "seq-item-ind":
+              if (this.atNewLine)
+                this.indent += source.length;
+              break;
+            case "doc-mode":
+            case "flow-error-end":
+              return;
+            default:
+              this.atNewLine = false;
+          }
+          this.offset += source.length;
+        }
+      }
+      /** Call at end of input to push out any remaining constructions */
+      *end() {
+        while (this.stack.length > 0)
+          yield* this.pop();
+      }
+      get sourceToken() {
+        const st = {
+          type: this.type,
+          offset: this.offset,
+          indent: this.indent,
+          source: this.source
+        };
+        return st;
+      }
+      *step() {
+        const top = this.peek(1);
+        if (this.type === "doc-end" && top?.type !== "doc-end") {
+          while (this.stack.length > 0)
+            yield* this.pop();
+          this.stack.push({
+            type: "doc-end",
+            offset: this.offset,
+            source: this.source
+          });
+          return;
+        }
+        if (!top)
+          return yield* this.stream();
+        switch (top.type) {
+          case "document":
+            return yield* this.document(top);
+          case "alias":
+          case "scalar":
+          case "single-quoted-scalar":
+          case "double-quoted-scalar":
+            return yield* this.scalar(top);
+          case "block-scalar":
+            return yield* this.blockScalar(top);
+          case "block-map":
+            return yield* this.blockMap(top);
+          case "block-seq":
+            return yield* this.blockSequence(top);
+          case "flow-collection":
+            return yield* this.flowCollection(top);
+          case "doc-end":
+            return yield* this.documentEnd(top);
+        }
+        yield* this.pop();
+      }
+      peek(n) {
+        return this.stack[this.stack.length - n];
+      }
+      *pop(error) {
+        const token = error ?? this.stack.pop();
+        if (!token) {
+          const message = "Tried to pop an empty stack";
+          yield { type: "error", offset: this.offset, source: "", message };
+        } else if (this.stack.length === 0) {
+          yield token;
+        } else {
+          const top = this.peek(1);
+          if (token.type === "block-scalar") {
+            token.indent = "indent" in top ? top.indent : 0;
+          } else if (token.type === "flow-collection" && top.type === "document") {
+            token.indent = 0;
+          }
+          if (token.type === "flow-collection")
+            fixFlowSeqItems(token);
+          switch (top.type) {
+            case "document":
+              top.value = token;
+              break;
+            case "block-scalar":
+              top.props.push(token);
+              break;
+            case "block-map": {
+              const it = top.items[top.items.length - 1];
+              if (it.value) {
+                top.items.push({ start: [], key: token, sep: [] });
+                this.onKeyLine = true;
+                return;
+              } else if (it.sep) {
+                it.value = token;
+              } else {
+                Object.assign(it, { key: token, sep: [] });
+                this.onKeyLine = !it.explicitKey;
+                return;
+              }
+              break;
+            }
+            case "block-seq": {
+              const it = top.items[top.items.length - 1];
+              if (it.value)
+                top.items.push({ start: [], value: token });
+              else
+                it.value = token;
+              break;
+            }
+            case "flow-collection": {
+              const it = top.items[top.items.length - 1];
+              if (!it || it.value)
+                top.items.push({ start: [], key: token, sep: [] });
+              else if (it.sep)
+                it.value = token;
+              else
+                Object.assign(it, { key: token, sep: [] });
+              return;
+            }
+            /* istanbul ignore next should not happen */
+            default:
+              yield* this.pop();
+              yield* this.pop(token);
+          }
+          if ((top.type === "document" || top.type === "block-map" || top.type === "block-seq") && (token.type === "block-map" || token.type === "block-seq")) {
+            const last = token.items[token.items.length - 1];
+            if (last && !last.sep && !last.value && last.start.length > 0 && findNonEmptyIndex(last.start) === -1 && (token.indent === 0 || last.start.every((st) => st.type !== "comment" || st.indent < token.indent))) {
+              if (top.type === "document")
+                top.end = last.start;
+              else
+                top.items.push({ start: last.start });
+              token.items.splice(-1, 1);
+            }
+          }
+        }
+      }
+      *stream() {
+        switch (this.type) {
+          case "directive-line":
+            yield { type: "directive", offset: this.offset, source: this.source };
+            return;
+          case "byte-order-mark":
+          case "space":
+          case "comment":
+          case "newline":
+            yield this.sourceToken;
+            return;
+          case "doc-mode":
+          case "doc-start": {
+            const doc = {
+              type: "document",
+              offset: this.offset,
+              start: []
+            };
+            if (this.type === "doc-start")
+              doc.start.push(this.sourceToken);
+            this.stack.push(doc);
+            return;
+          }
+        }
+        yield {
+          type: "error",
+          offset: this.offset,
+          message: `Unexpected ${this.type} token in YAML stream`,
+          source: this.source
+        };
+      }
+      *document(doc) {
+        if (doc.value)
+          return yield* this.lineEnd(doc);
+        switch (this.type) {
+          case "doc-start": {
+            if (findNonEmptyIndex(doc.start) !== -1) {
+              yield* this.pop();
+              yield* this.step();
+            } else
+              doc.start.push(this.sourceToken);
+            return;
+          }
+          case "anchor":
+          case "tag":
+          case "space":
+          case "comment":
+          case "newline":
+            doc.start.push(this.sourceToken);
+            return;
+        }
+        const bv = this.startBlockValue(doc);
+        if (bv)
+          this.stack.push(bv);
+        else {
+          yield {
+            type: "error",
+            offset: this.offset,
+            message: `Unexpected ${this.type} token in YAML document`,
+            source: this.source
+          };
+        }
+      }
+      *scalar(scalar) {
+        if (this.type === "map-value-ind") {
+          const prev = getPrevProps(this.peek(2));
+          const start = getFirstKeyStartProps(prev);
+          let sep;
+          if (scalar.end) {
+            sep = scalar.end;
+            sep.push(this.sourceToken);
+            delete scalar.end;
+          } else
+            sep = [this.sourceToken];
+          const map = {
+            type: "block-map",
+            offset: scalar.offset,
+            indent: scalar.indent,
+            items: [{ start, key: scalar, sep }]
+          };
+          this.onKeyLine = true;
+          this.stack[this.stack.length - 1] = map;
+        } else
+          yield* this.lineEnd(scalar);
+      }
+      *blockScalar(scalar) {
+        switch (this.type) {
+          case "space":
+          case "comment":
+          case "newline":
+            scalar.props.push(this.sourceToken);
+            return;
+          case "scalar":
+            scalar.source = this.source;
+            this.atNewLine = true;
+            this.indent = 0;
+            if (this.onNewLine) {
+              let nl = this.source.indexOf("\n") + 1;
+              while (nl !== 0) {
+                this.onNewLine(this.offset + nl);
+                nl = this.source.indexOf("\n", nl) + 1;
+              }
+            }
+            yield* this.pop();
+            break;
+          /* istanbul ignore next should not happen */
+          default:
+            yield* this.pop();
+            yield* this.step();
+        }
+      }
+      *blockMap(map) {
+        const it = map.items[map.items.length - 1];
+        switch (this.type) {
+          case "newline":
+            this.onKeyLine = false;
+            if (it.value) {
+              const end = "end" in it.value ? it.value.end : void 0;
+              const last = Array.isArray(end) ? end[end.length - 1] : void 0;
+              if (last?.type === "comment")
+                end?.push(this.sourceToken);
+              else
+                map.items.push({ start: [this.sourceToken] });
+            } else if (it.sep) {
+              it.sep.push(this.sourceToken);
+            } else {
+              it.start.push(this.sourceToken);
+            }
+            return;
+          case "space":
+          case "comment":
+            if (it.value) {
+              map.items.push({ start: [this.sourceToken] });
+            } else if (it.sep) {
+              it.sep.push(this.sourceToken);
+            } else {
+              if (this.atIndentedComment(it.start, map.indent)) {
+                const prev = map.items[map.items.length - 2];
+                const end = prev?.value?.end;
+                if (Array.isArray(end)) {
+                  Array.prototype.push.apply(end, it.start);
+                  end.push(this.sourceToken);
+                  map.items.pop();
+                  return;
+                }
+              }
+              it.start.push(this.sourceToken);
+            }
+            return;
+        }
+        if (this.indent >= map.indent) {
+          const atMapIndent = !this.onKeyLine && this.indent === map.indent;
+          const atNextItem = atMapIndent && (it.sep || it.explicitKey) && this.type !== "seq-item-ind";
+          let start = [];
+          if (atNextItem && it.sep && !it.value) {
+            const nl = [];
+            for (let i = 0; i < it.sep.length; ++i) {
+              const st = it.sep[i];
+              switch (st.type) {
+                case "newline":
+                  nl.push(i);
+                  break;
+                case "space":
+                  break;
+                case "comment":
+                  if (st.indent > map.indent)
+                    nl.length = 0;
+                  break;
+                default:
+                  nl.length = 0;
+              }
+            }
+            if (nl.length >= 2)
+              start = it.sep.splice(nl[1]);
+          }
+          switch (this.type) {
+            case "anchor":
+            case "tag":
+              if (atNextItem || it.value) {
+                start.push(this.sourceToken);
+                map.items.push({ start });
+                this.onKeyLine = true;
+              } else if (it.sep) {
+                it.sep.push(this.sourceToken);
+              } else {
+                it.start.push(this.sourceToken);
+              }
+              return;
+            case "explicit-key-ind":
+              if (!it.sep && !it.explicitKey) {
+                it.start.push(this.sourceToken);
+                it.explicitKey = true;
+              } else if (atNextItem || it.value) {
+                start.push(this.sourceToken);
+                map.items.push({ start, explicitKey: true });
+              } else {
+                this.stack.push({
+                  type: "block-map",
+                  offset: this.offset,
+                  indent: this.indent,
+                  items: [{ start: [this.sourceToken], explicitKey: true }]
+                });
+              }
+              this.onKeyLine = true;
+              return;
+            case "map-value-ind":
+              if (it.explicitKey) {
+                if (!it.sep) {
+                  if (includesToken(it.start, "newline")) {
+                    Object.assign(it, { key: null, sep: [this.sourceToken] });
+                  } else {
+                    const start2 = getFirstKeyStartProps(it.start);
+                    this.stack.push({
+                      type: "block-map",
+                      offset: this.offset,
+                      indent: this.indent,
+                      items: [{ start: start2, key: null, sep: [this.sourceToken] }]
+                    });
+                  }
+                } else if (it.value) {
+                  map.items.push({ start: [], key: null, sep: [this.sourceToken] });
+                } else if (includesToken(it.sep, "map-value-ind")) {
+                  this.stack.push({
+                    type: "block-map",
+                    offset: this.offset,
+                    indent: this.indent,
+                    items: [{ start, key: null, sep: [this.sourceToken] }]
+                  });
+                } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
+                  const start2 = getFirstKeyStartProps(it.start);
+                  const key = it.key;
+                  const sep = it.sep;
+                  sep.push(this.sourceToken);
+                  delete it.key;
+                  delete it.sep;
+                  this.stack.push({
+                    type: "block-map",
+                    offset: this.offset,
+                    indent: this.indent,
+                    items: [{ start: start2, key, sep }]
+                  });
+                } else if (start.length > 0) {
+                  it.sep = it.sep.concat(start, this.sourceToken);
+                } else {
+                  it.sep.push(this.sourceToken);
+                }
+              } else {
+                if (!it.sep) {
+                  Object.assign(it, { key: null, sep: [this.sourceToken] });
+                } else if (it.value || atNextItem) {
+                  map.items.push({ start, key: null, sep: [this.sourceToken] });
+                } else if (includesToken(it.sep, "map-value-ind")) {
+                  this.stack.push({
+                    type: "block-map",
+                    offset: this.offset,
+                    indent: this.indent,
+                    items: [{ start: [], key: null, sep: [this.sourceToken] }]
+                  });
+                } else {
+                  it.sep.push(this.sourceToken);
+                }
+              }
+              this.onKeyLine = true;
+              return;
+            case "alias":
+            case "scalar":
+            case "single-quoted-scalar":
+            case "double-quoted-scalar": {
+              const fs = this.flowScalar(this.type);
+              if (atNextItem || it.value) {
+                map.items.push({ start, key: fs, sep: [] });
+                this.onKeyLine = true;
+              } else if (it.sep) {
+                this.stack.push(fs);
+              } else {
+                Object.assign(it, { key: fs, sep: [] });
+                this.onKeyLine = true;
+              }
+              return;
+            }
+            default: {
+              const bv = this.startBlockValue(map);
+              if (bv) {
+                if (bv.type === "block-seq") {
+                  if (!it.explicitKey && it.sep && !includesToken(it.sep, "newline")) {
+                    yield* this.pop({
+                      type: "error",
+                      offset: this.offset,
+                      message: "Unexpected block-seq-ind on same line with key",
+                      source: this.source
+                    });
+                    return;
+                  }
+                } else if (atMapIndent) {
+                  map.items.push({ start });
+                }
+                this.stack.push(bv);
+                return;
+              }
+            }
+          }
+        }
+        yield* this.pop();
+        yield* this.step();
+      }
+      *blockSequence(seq) {
+        const it = seq.items[seq.items.length - 1];
+        switch (this.type) {
+          case "newline":
+            if (it.value) {
+              const end = "end" in it.value ? it.value.end : void 0;
+              const last = Array.isArray(end) ? end[end.length - 1] : void 0;
+              if (last?.type === "comment")
+                end?.push(this.sourceToken);
+              else
+                seq.items.push({ start: [this.sourceToken] });
+            } else
+              it.start.push(this.sourceToken);
+            return;
+          case "space":
+          case "comment":
+            if (it.value)
+              seq.items.push({ start: [this.sourceToken] });
+            else {
+              if (this.atIndentedComment(it.start, seq.indent)) {
+                const prev = seq.items[seq.items.length - 2];
+                const end = prev?.value?.end;
+                if (Array.isArray(end)) {
+                  Array.prototype.push.apply(end, it.start);
+                  end.push(this.sourceToken);
+                  seq.items.pop();
+                  return;
+                }
+              }
+              it.start.push(this.sourceToken);
+            }
+            return;
+          case "anchor":
+          case "tag":
+            if (it.value || this.indent <= seq.indent)
+              break;
+            it.start.push(this.sourceToken);
+            return;
+          case "seq-item-ind":
+            if (this.indent !== seq.indent)
+              break;
+            if (it.value || includesToken(it.start, "seq-item-ind"))
+              seq.items.push({ start: [this.sourceToken] });
+            else
+              it.start.push(this.sourceToken);
+            return;
+        }
+        if (this.indent > seq.indent) {
+          const bv = this.startBlockValue(seq);
+          if (bv) {
+            this.stack.push(bv);
+            return;
+          }
+        }
+        yield* this.pop();
+        yield* this.step();
+      }
+      *flowCollection(fc) {
+        const it = fc.items[fc.items.length - 1];
+        if (this.type === "flow-error-end") {
+          let top;
+          do {
+            yield* this.pop();
+            top = this.peek(1);
+          } while (top?.type === "flow-collection");
+        } else if (fc.end.length === 0) {
+          switch (this.type) {
+            case "comma":
+            case "explicit-key-ind":
+              if (!it || it.sep)
+                fc.items.push({ start: [this.sourceToken] });
+              else
+                it.start.push(this.sourceToken);
+              return;
+            case "map-value-ind":
+              if (!it || it.value)
+                fc.items.push({ start: [], key: null, sep: [this.sourceToken] });
+              else if (it.sep)
+                it.sep.push(this.sourceToken);
+              else
+                Object.assign(it, { key: null, sep: [this.sourceToken] });
+              return;
+            case "space":
+            case "comment":
+            case "newline":
+            case "anchor":
+            case "tag":
+              if (!it || it.value)
+                fc.items.push({ start: [this.sourceToken] });
+              else if (it.sep)
+                it.sep.push(this.sourceToken);
+              else
+                it.start.push(this.sourceToken);
+              return;
+            case "alias":
+            case "scalar":
+            case "single-quoted-scalar":
+            case "double-quoted-scalar": {
+              const fs = this.flowScalar(this.type);
+              if (!it || it.value)
+                fc.items.push({ start: [], key: fs, sep: [] });
+              else if (it.sep)
+                this.stack.push(fs);
+              else
+                Object.assign(it, { key: fs, sep: [] });
+              return;
+            }
+            case "flow-map-end":
+            case "flow-seq-end":
+              fc.end.push(this.sourceToken);
+              return;
+          }
+          const bv = this.startBlockValue(fc);
+          if (bv)
+            this.stack.push(bv);
+          else {
+            yield* this.pop();
+            yield* this.step();
+          }
+        } else {
+          const parent = this.peek(2);
+          if (parent.type === "block-map" && (this.type === "map-value-ind" && parent.indent === fc.indent || this.type === "newline" && !parent.items[parent.items.length - 1].sep)) {
+            yield* this.pop();
+            yield* this.step();
+          } else if (this.type === "map-value-ind" && parent.type !== "flow-collection") {
+            const prev = getPrevProps(parent);
+            const start = getFirstKeyStartProps(prev);
+            fixFlowSeqItems(fc);
+            const sep = fc.end.splice(1, fc.end.length);
+            sep.push(this.sourceToken);
+            const map = {
+              type: "block-map",
+              offset: fc.offset,
+              indent: fc.indent,
+              items: [{ start, key: fc, sep }]
+            };
+            this.onKeyLine = true;
+            this.stack[this.stack.length - 1] = map;
+          } else {
+            yield* this.lineEnd(fc);
+          }
+        }
+      }
+      flowScalar(type) {
+        if (this.onNewLine) {
+          let nl = this.source.indexOf("\n") + 1;
+          while (nl !== 0) {
+            this.onNewLine(this.offset + nl);
+            nl = this.source.indexOf("\n", nl) + 1;
+          }
+        }
+        return {
+          type,
+          offset: this.offset,
+          indent: this.indent,
+          source: this.source
+        };
+      }
+      startBlockValue(parent) {
+        switch (this.type) {
+          case "alias":
+          case "scalar":
+          case "single-quoted-scalar":
+          case "double-quoted-scalar":
+            return this.flowScalar(this.type);
+          case "block-scalar-header":
+            return {
+              type: "block-scalar",
+              offset: this.offset,
+              indent: this.indent,
+              props: [this.sourceToken],
+              source: ""
+            };
+          case "flow-map-start":
+          case "flow-seq-start":
+            return {
+              type: "flow-collection",
+              offset: this.offset,
+              indent: this.indent,
+              start: this.sourceToken,
+              items: [],
+              end: []
+            };
+          case "seq-item-ind":
+            return {
+              type: "block-seq",
+              offset: this.offset,
+              indent: this.indent,
+              items: [{ start: [this.sourceToken] }]
+            };
+          case "explicit-key-ind": {
+            this.onKeyLine = true;
+            const prev = getPrevProps(parent);
+            const start = getFirstKeyStartProps(prev);
+            start.push(this.sourceToken);
+            return {
+              type: "block-map",
+              offset: this.offset,
+              indent: this.indent,
+              items: [{ start, explicitKey: true }]
+            };
+          }
+          case "map-value-ind": {
+            this.onKeyLine = true;
+            const prev = getPrevProps(parent);
+            const start = getFirstKeyStartProps(prev);
+            return {
+              type: "block-map",
+              offset: this.offset,
+              indent: this.indent,
+              items: [{ start, key: null, sep: [this.sourceToken] }]
+            };
+          }
+        }
+        return null;
+      }
+      atIndentedComment(start, indent) {
+        if (this.type !== "comment")
+          return false;
+        if (this.indent <= indent)
+          return false;
+        return start.every((st) => st.type === "newline" || st.type === "space");
+      }
+      *documentEnd(docEnd) {
+        if (this.type !== "doc-mode") {
+          if (docEnd.end)
+            docEnd.end.push(this.sourceToken);
+          else
+            docEnd.end = [this.sourceToken];
+          if (this.type === "newline")
+            yield* this.pop();
+        }
+      }
+      *lineEnd(token) {
+        switch (this.type) {
+          case "comma":
+          case "doc-start":
+          case "doc-end":
+          case "flow-seq-end":
+          case "flow-map-end":
+          case "map-value-ind":
+            yield* this.pop();
+            yield* this.step();
+            break;
+          case "newline":
+            this.onKeyLine = false;
+          // fallthrough
+          case "space":
+          case "comment":
+          default:
+            if (token.end)
+              token.end.push(this.sourceToken);
+            else
+              token.end = [this.sourceToken];
+            if (this.type === "newline")
+              yield* this.pop();
+        }
+      }
+    };
+    exports2.Parser = Parser;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js
+var require_public_api = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/public-api.js"(exports2) {
+    "use strict";
+    var composer = require_composer();
+    var Document = require_Document();
+    var errors = require_errors();
+    var log = require_log();
+    var identity = require_identity();
+    var lineCounter = require_line_counter();
+    var parser = require_parser();
+    function parseOptions(options) {
+      const prettyErrors = options.prettyErrors !== false;
+      const lineCounter$1 = options.lineCounter || prettyErrors && new lineCounter.LineCounter() || null;
+      return { lineCounter: lineCounter$1, prettyErrors };
+    }
+    function parseAllDocuments(source, options = {}) {
+      const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
+      const parser$1 = new parser.Parser(lineCounter2?.addNewLine);
+      const composer$1 = new composer.Composer(options);
+      const docs = Array.from(composer$1.compose(parser$1.parse(source)));
+      if (prettyErrors && lineCounter2)
+        for (const doc of docs) {
+          doc.errors.forEach(errors.prettifyError(source, lineCounter2));
+          doc.warnings.forEach(errors.prettifyError(source, lineCounter2));
+        }
+      if (docs.length > 0)
+        return docs;
+      return Object.assign([], { empty: true }, composer$1.streamInfo());
+    }
+    function parseDocument(source, options = {}) {
+      const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
+      const parser$1 = new parser.Parser(lineCounter2?.addNewLine);
+      const composer$1 = new composer.Composer(options);
+      let doc = null;
+      for (const _doc of composer$1.compose(parser$1.parse(source), true, source.length)) {
+        if (!doc)
+          doc = _doc;
+        else if (doc.options.logLevel !== "silent") {
+          doc.errors.push(new errors.YAMLParseError(_doc.range.slice(0, 2), "MULTIPLE_DOCS", "Source contains multiple documents; please use YAML.parseAllDocuments()"));
+          break;
+        }
+      }
+      if (prettyErrors && lineCounter2) {
+        doc.errors.forEach(errors.prettifyError(source, lineCounter2));
+        doc.warnings.forEach(errors.prettifyError(source, lineCounter2));
+      }
+      return doc;
+    }
+    function parse2(src, reviver, options) {
+      let _reviver = void 0;
+      if (typeof reviver === "function") {
+        _reviver = reviver;
+      } else if (options === void 0 && reviver && typeof reviver === "object") {
+        options = reviver;
+      }
+      const doc = parseDocument(src, options);
+      if (!doc)
+        return null;
+      doc.warnings.forEach((warning) => log.warn(doc.options.logLevel, warning));
+      if (doc.errors.length > 0) {
+        if (doc.options.logLevel !== "silent")
+          throw doc.errors[0];
+        else
+          doc.errors = [];
+      }
+      return doc.toJS(Object.assign({ reviver: _reviver }, options));
+    }
+    function stringify(value, replacer, options) {
+      let _replacer = null;
+      if (typeof replacer === "function" || Array.isArray(replacer)) {
+        _replacer = replacer;
+      } else if (options === void 0 && replacer) {
+        options = replacer;
+      }
+      if (typeof options === "string")
+        options = options.length;
+      if (typeof options === "number") {
+        const indent = Math.round(options);
+        options = indent < 1 ? void 0 : indent > 8 ? { indent: 8 } : { indent };
+      }
+      if (value === void 0) {
+        const { keepUndefined } = options ?? replacer ?? {};
+        if (!keepUndefined)
+          return void 0;
+      }
+      if (identity.isDocument(value) && !_replacer)
+        return value.toString(options);
+      return new Document.Document(value, _replacer, options).toString(options);
+    }
+    exports2.parse = parse2;
+    exports2.parseAllDocuments = parseAllDocuments;
+    exports2.parseDocument = parseDocument;
+    exports2.stringify = stringify;
+  }
+});
+
+// node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js
+var require_dist = __commonJS({
+  "node_modules/.pnpm/yaml@2.8.2/node_modules/yaml/dist/index.js"(exports2) {
+    "use strict";
+    var composer = require_composer();
+    var Document = require_Document();
+    var Schema = require_Schema();
+    var errors = require_errors();
+    var Alias = require_Alias();
+    var identity = require_identity();
+    var Pair = require_Pair();
+    var Scalar = require_Scalar();
+    var YAMLMap = require_YAMLMap();
+    var YAMLSeq = require_YAMLSeq();
+    var cst = require_cst();
+    var lexer = require_lexer();
+    var lineCounter = require_line_counter();
+    var parser = require_parser();
+    var publicApi = require_public_api();
+    var visit = require_visit();
+    exports2.Composer = composer.Composer;
+    exports2.Document = Document.Document;
+    exports2.Schema = Schema.Schema;
+    exports2.YAMLError = errors.YAMLError;
+    exports2.YAMLParseError = errors.YAMLParseError;
+    exports2.YAMLWarning = errors.YAMLWarning;
+    exports2.Alias = Alias.Alias;
+    exports2.isAlias = identity.isAlias;
+    exports2.isCollection = identity.isCollection;
+    exports2.isDocument = identity.isDocument;
+    exports2.isMap = identity.isMap;
+    exports2.isNode = identity.isNode;
+    exports2.isPair = identity.isPair;
+    exports2.isScalar = identity.isScalar;
+    exports2.isSeq = identity.isSeq;
+    exports2.Pair = Pair.Pair;
+    exports2.Scalar = Scalar.Scalar;
+    exports2.YAMLMap = YAMLMap.YAMLMap;
+    exports2.YAMLSeq = YAMLSeq.YAMLSeq;
+    exports2.CST = cst;
+    exports2.Lexer = lexer.Lexer;
+    exports2.LineCounter = lineCounter.LineCounter;
+    exports2.Parser = parser.Parser;
+    exports2.parse = publicApi.parse;
+    exports2.parseAllDocuments = publicApi.parseAllDocuments;
+    exports2.parseDocument = publicApi.parseDocument;
+    exports2.stringify = publicApi.stringify;
+    exports2.visit = visit.visit;
+    exports2.visitAsync = visit.visitAsync;
+  }
+});
+
+// plugins/workos/skills/workos-widgets/references/scripts/query-spec.ts
+var query_spec_exports = {};
+__export(query_spec_exports, {
+  WIDGET_PREFIXES: () => WIDGET_PREFIXES,
+  extractEndpoints: () => extractEndpoints,
+  formatEndpoint: () => formatEndpoint,
+  groupPathsByWidget: () => groupPathsByWidget,
+  loadSpec: () => loadSpec,
+  resolveRef: () => resolveRef,
+  resolveSchema: () => resolveSchema
+});
+module.exports = __toCommonJS(query_spec_exports);
+var import_node_fs = require("node:fs");
+var import_node_path = require("node:path");
+var import_yaml = __toESM(require_dist(), 1);
+var import_meta = {};
+var _dir = typeof __dirname !== "undefined" ? __dirname : (0, import_node_path.dirname)(new URL(import_meta.url).pathname);
+var SPEC_PATH = (0, import_node_path.join)(_dir, "../widgets-open-api-spec.yaml");
+var WIDGET_PREFIXES = {
+  // Primary names (match SKILL.md widget slugs)
+  "user-management": "/_widgets/UserManagement",
+  "user-profile": "/_widgets/UserProfile",
+  "admin-portal-sso-connection": "/_widgets/admin-portal/sso-connections",
+  "admin-portal-domain-verification": "/_widgets/admin-portal/organization-domains",
+  // Alternate forms
+  usermanagement: "/_widgets/UserManagement",
+  userprofile: "/_widgets/UserProfile",
+  "admin-portal": "/_widgets/admin-portal",
+  adminportal: "/_widgets/admin-portal",
+  "sso-connection": "/_widgets/admin-portal/sso-connections",
+  "domain-verification": "/_widgets/admin-portal/organization-domains",
+  apikeys: "/_widgets/ApiKeys",
+  dataintegrations: "/_widgets/DataIntegrations",
+  "directory-sync": "/_widgets/directory-sync",
+  settings: "/_widgets/settings"
+};
+function loadSpec(path) {
+  return (0, import_yaml.parse)((0, import_node_fs.readFileSync)(path ?? SPEC_PATH, "utf-8"));
+}
+function resolveRef(spec, ref) {
+  const parts = ref.replace("#/", "").split("/");
+  let current = spec;
+  for (const part of parts) {
+    if (current && typeof current === "object") {
+      current = current[part];
+    } else {
+      return void 0;
+    }
+  }
+  return current;
+}
+function resolveSchema(spec, schema) {
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) {
+    return schema.map((item) => resolveSchema(spec, item));
+  }
+  const s = schema;
+  if (s.$ref && typeof s.$ref === "string") {
+    return resolveSchema(spec, resolveRef(spec, s.$ref));
+  }
+  const result = {};
+  for (const [key, value] of Object.entries(s)) {
+    if (value && typeof value === "object") {
+      result[key] = resolveSchema(spec, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+function extractEndpoints(spec, pathFilter) {
+  const paths = spec.paths;
+  if (!paths) return [];
+  const endpoints = [];
+  for (const [path, methods] of Object.entries(paths)) {
+    if (!pathFilter(path)) continue;
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!operation || typeof operation !== "object") continue;
+      const op = operation;
+      const responses = {};
+      const opResponses = op.responses;
+      if (opResponses) {
+        for (const [code, resp] of Object.entries(opResponses)) {
+          const r = resp;
+          const content = r?.content;
+          const json = content?.["application/json"];
+          if (json?.schema) {
+            responses[code] = {
+              description: r.description,
+              schema: resolveSchema(spec, json.schema)
+            };
+          } else {
+            responses[code] = { description: r?.description };
+          }
+        }
+      }
+      const endpoint = {
+        path,
+        method: method.toUpperCase(),
+        responses
+      };
+      if (op.description) endpoint.description = op.description;
+      if (op.parameters) endpoint.parameters = op.parameters;
+      if (op.requestBody) {
+        const body = op.requestBody;
+        const content = body.content;
+        const json = content?.["application/json"];
+        if (json?.schema) {
+          endpoint.requestBody = resolveSchema(spec, json.schema);
+        }
+      }
+      endpoints.push(endpoint);
+    }
+  }
+  return endpoints;
+}
+function formatEndpoint(ep) {
+  const lines = [];
+  lines.push(`## ${ep.method} ${ep.path}`);
+  if (ep.description) lines.push(`
+${ep.description}`);
+  if (ep.parameters && Array.isArray(ep.parameters) && ep.parameters.length > 0) {
+    lines.push("\n### Parameters\n");
+    for (const p of ep.parameters) {
+      const param = p;
+      lines.push(`- \`${param.name}\` (${param.in}): ${param.schema ? JSON.stringify(param.schema) : "unknown"}`);
+    }
+  }
+  if (ep.requestBody) {
+    lines.push("\n### Request Body\n");
+    lines.push("```json");
+    lines.push(JSON.stringify(ep.requestBody, null, 2));
+    lines.push("```");
+  }
+  for (const [code, resp] of Object.entries(ep.responses)) {
+    const r = resp;
+    lines.push(`
+### Response ${code}${r.description ? ` \u2014 ${r.description}` : ""}
+`);
+    if (r.schema) {
+      lines.push("```json");
+      lines.push(JSON.stringify(r.schema, null, 2));
+      lines.push("```");
+    }
+  }
+  return lines.join("\n");
+}
+function groupPathsByWidget(paths) {
+  const grouped = {};
+  for (const p of paths) {
+    const parts = p.split("/").filter(Boolean);
+    const group = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : parts[0] || "other";
+    if (!grouped[group]) grouped[group] = [];
+    grouped[group].push(p);
+  }
+  return grouped;
+}
+var isDirectExecution = process.argv[1]?.includes("query-spec");
+if (isDirectExecution) {
+  const args = process.argv.slice(2);
+  if (args.includes("--list")) {
+    const spec2 = loadSpec();
+    const grouped = groupPathsByWidget(Object.keys(spec2.paths ?? {}));
+    for (const [group, groupPaths] of Object.entries(grouped)) {
+      console.log(`
+${group}:`);
+      for (const p of groupPaths) console.log(`  ${p}`);
+    }
+    process.exit(0);
+  }
+  const widgetIdx = args.indexOf("--widget");
+  const pathIdx = args.indexOf("--path");
+  if (widgetIdx === -1 && pathIdx === -1) {
+    console.error("Usage: query-spec.ts --widget <name> | --path <path> | --list");
+    console.error("Widgets:", Object.keys(WIDGET_PREFIXES).join(", "));
+    process.exit(1);
+  }
+  const spec = loadSpec();
+  let filter;
+  if (widgetIdx !== -1) {
+    const widgetName = (args[widgetIdx + 1] || "").toLowerCase();
+    const prefix = WIDGET_PREFIXES[widgetName];
+    if (!prefix) {
+      console.error(`Unknown widget: ${args[widgetIdx + 1]}`);
+      console.error("Known widgets:", Object.keys(WIDGET_PREFIXES).join(", "));
+      process.exit(1);
+    }
+    filter = (path) => path.startsWith(prefix);
+  } else {
+    const pathPattern = args[pathIdx + 1] || "";
+    filter = (path) => path.includes(pathPattern);
+  }
+  const endpoints = extractEndpoints(spec, filter);
+  if (endpoints.length === 0) {
+    console.error("No matching endpoints found.");
+    process.exit(1);
+  }
+  console.log(`# Matched ${endpoints.length} endpoint(s)
+`);
+  for (const ep of endpoints) {
+    console.log(formatEndpoint(ep));
+    console.log("\n---\n");
+  }
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  WIDGET_PREFIXES,
+  extractEndpoints,
+  formatEndpoint,
+  groupPathsByWidget,
+  loadSpec,
+  resolveRef,
+  resolveSchema
+});

--- a/.claude/skills/workos-widgets/references/scripts/query-spec.ts
+++ b/.claude/skills/workos-widgets/references/scripts/query-spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Query the WorkOS Widgets OpenAPI spec for specific widget endpoints.
+ *
+ * Source file — build with: pnpm build:query-spec
+ * Runtime usage (via bundled .cjs):
+ *   node references/scripts/query-spec.cjs --widget UserProfile
+ *   node references/scripts/query-spec.cjs --widget UserManagement
+ *   node references/scripts/query-spec.cjs --widget admin-portal
+ *   node references/scripts/query-spec.cjs --path /_widgets/UserProfile/me
+ *   node references/scripts/query-spec.cjs --list
+ *
+ * Outputs matching endpoints with their request/response schemas (resolved $refs).
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { parse } from 'yaml';
+
+// Support both ESM (import.meta.url) and CJS (__dirname) for bundled output
+const _dir = typeof __dirname !== 'undefined' ? __dirname : dirname(new URL(import.meta.url).pathname);
+const SPEC_PATH = join(_dir, '../widgets-open-api-spec.yaml');
+
+export const WIDGET_PREFIXES: Record<string, string> = {
+  // Primary names (match SKILL.md widget slugs)
+  'user-management': '/_widgets/UserManagement',
+  'user-profile': '/_widgets/UserProfile',
+  'admin-portal-sso-connection': '/_widgets/admin-portal/sso-connections',
+  'admin-portal-domain-verification': '/_widgets/admin-portal/organization-domains',
+  // Alternate forms
+  usermanagement: '/_widgets/UserManagement',
+  userprofile: '/_widgets/UserProfile',
+  'admin-portal': '/_widgets/admin-portal',
+  adminportal: '/_widgets/admin-portal',
+  'sso-connection': '/_widgets/admin-portal/sso-connections',
+  'domain-verification': '/_widgets/admin-portal/organization-domains',
+  apikeys: '/_widgets/ApiKeys',
+  dataintegrations: '/_widgets/DataIntegrations',
+  'directory-sync': '/_widgets/directory-sync',
+  settings: '/_widgets/settings',
+};
+
+export function loadSpec(path?: string) {
+  return parse(readFileSync(path ?? SPEC_PATH, 'utf-8'));
+}
+
+export function resolveRef(spec: Record<string, unknown>, ref: string): unknown {
+  const parts = ref.replace('#/', '').split('/');
+  let current: unknown = spec;
+  for (const part of parts) {
+    if (current && typeof current === 'object') {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+export function resolveSchema(spec: Record<string, unknown>, schema: unknown): unknown {
+  if (!schema || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) {
+    return schema.map((item) => resolveSchema(spec, item));
+  }
+  const s = schema as Record<string, unknown>;
+  if (s.$ref && typeof s.$ref === 'string') {
+    return resolveSchema(spec, resolveRef(spec, s.$ref));
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(s)) {
+    if (value && typeof value === 'object') {
+      result[key] = resolveSchema(spec, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export interface EndpointInfo {
+  path: string;
+  method: string;
+  description?: string;
+  parameters?: unknown;
+  requestBody?: unknown;
+  responses: Record<string, unknown>;
+}
+
+export function extractEndpoints(spec: Record<string, unknown>, pathFilter: (path: string) => boolean): EndpointInfo[] {
+  const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+  if (!paths) return [];
+
+  const endpoints: EndpointInfo[] = [];
+  for (const [path, methods] of Object.entries(paths)) {
+    if (!pathFilter(path)) continue;
+    for (const [method, operation] of Object.entries(methods)) {
+      if (!operation || typeof operation !== 'object') continue;
+      const op = operation as Record<string, unknown>;
+
+      const responses: Record<string, unknown> = {};
+      const opResponses = op.responses as Record<string, unknown> | undefined;
+      if (opResponses) {
+        for (const [code, resp] of Object.entries(opResponses)) {
+          const r = resp as Record<string, unknown>;
+          const content = r?.content as Record<string, unknown> | undefined;
+          const json = content?.['application/json'] as Record<string, unknown> | undefined;
+          if (json?.schema) {
+            responses[code] = {
+              description: r.description,
+              schema: resolveSchema(spec, json.schema),
+            };
+          } else {
+            responses[code] = { description: r?.description };
+          }
+        }
+      }
+
+      const endpoint: EndpointInfo = {
+        path,
+        method: method.toUpperCase(),
+        responses,
+      };
+
+      if (op.description) endpoint.description = op.description as string;
+      if (op.parameters) endpoint.parameters = op.parameters;
+      if (op.requestBody) {
+        const body = op.requestBody as Record<string, unknown>;
+        const content = body.content as Record<string, unknown> | undefined;
+        const json = content?.['application/json'] as Record<string, unknown> | undefined;
+        if (json?.schema) {
+          endpoint.requestBody = resolveSchema(spec, json.schema);
+        }
+      }
+
+      endpoints.push(endpoint);
+    }
+  }
+  return endpoints;
+}
+
+export function formatEndpoint(ep: EndpointInfo): string {
+  const lines: string[] = [];
+  lines.push(`## ${ep.method} ${ep.path}`);
+  if (ep.description) lines.push(`\n${ep.description}`);
+
+  if (ep.parameters && Array.isArray(ep.parameters) && ep.parameters.length > 0) {
+    lines.push('\n### Parameters\n');
+    for (const p of ep.parameters) {
+      const param = p as Record<string, unknown>;
+      lines.push(`- \`${param.name}\` (${param.in}): ${param.schema ? JSON.stringify(param.schema) : 'unknown'}`);
+    }
+  }
+
+  if (ep.requestBody) {
+    lines.push('\n### Request Body\n');
+    lines.push('```json');
+    lines.push(JSON.stringify(ep.requestBody, null, 2));
+    lines.push('```');
+  }
+
+  for (const [code, resp] of Object.entries(ep.responses)) {
+    const r = resp as Record<string, unknown>;
+    lines.push(`\n### Response ${code}${r.description ? ` — ${r.description}` : ''}\n`);
+    if (r.schema) {
+      lines.push('```json');
+      lines.push(JSON.stringify(r.schema, null, 2));
+      lines.push('```');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function groupPathsByWidget(paths: string[]): Record<string, string[]> {
+  const grouped: Record<string, string[]> = {};
+  for (const p of paths) {
+    const parts = p.split('/').filter(Boolean);
+    const group = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : parts[0] || 'other';
+    if (!grouped[group]) grouped[group] = [];
+    grouped[group].push(p);
+  }
+  return grouped;
+}
+
+// --- CLI (only runs when executed directly) ---
+
+const isDirectExecution = process.argv[1]?.includes('query-spec');
+
+if (isDirectExecution) {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--list')) {
+    const spec = loadSpec();
+    const grouped = groupPathsByWidget(Object.keys(spec.paths ?? {}));
+    for (const [group, groupPaths] of Object.entries(grouped)) {
+      console.log(`\n${group}:`);
+      for (const p of groupPaths) console.log(`  ${p}`);
+    }
+    process.exit(0);
+  }
+
+  const widgetIdx = args.indexOf('--widget');
+  const pathIdx = args.indexOf('--path');
+
+  if (widgetIdx === -1 && pathIdx === -1) {
+    console.error('Usage: query-spec.ts --widget <name> | --path <path> | --list');
+    console.error('Widgets:', Object.keys(WIDGET_PREFIXES).join(', '));
+    process.exit(1);
+  }
+
+  const spec = loadSpec();
+  let filter: (path: string) => boolean;
+
+  if (widgetIdx !== -1) {
+    const widgetName = (args[widgetIdx + 1] || '').toLowerCase();
+    const prefix = WIDGET_PREFIXES[widgetName];
+    if (!prefix) {
+      console.error(`Unknown widget: ${args[widgetIdx + 1]}`);
+      console.error('Known widgets:', Object.keys(WIDGET_PREFIXES).join(', '));
+      process.exit(1);
+    }
+    filter = (path) => path.startsWith(prefix);
+  } else {
+    const pathPattern = args[pathIdx + 1] || '';
+    filter = (path) => path.includes(pathPattern);
+  }
+
+  const endpoints = extractEndpoints(spec, filter);
+
+  if (endpoints.length === 0) {
+    console.error('No matching endpoints found.');
+    process.exit(1);
+  }
+
+  console.log(`# Matched ${endpoints.length} endpoint(s)\n`);
+  for (const ep of endpoints) {
+    console.log(formatEndpoint(ep));
+    console.log('\n---\n');
+  }
+}

--- a/.claude/skills/workos-widgets/references/styling-and-components.md
+++ b/.claude/skills/workos-widgets/references/styling-and-components.md
@@ -1,0 +1,25 @@
+# Styling and Components
+
+## Objective
+
+Match widget UI to the host application's existing component and styling systems.
+
+## Do
+
+- Use detected styling approach (Tailwind, CSS, CSS Modules, SCSS, styled-components, Emotion).
+- Prefer existing shared UI components before introducing new primitives.
+- Keep naming and file placement aligned with existing conventions.
+- Add only minimal new styles required for widget UX.
+
+## Don't
+
+- Don't introduce a new styling system when one is already established; if in doubt, confirm with the user.
+- Don't break or modify existing styles outside widget integration scope.
+- Don't break established spacing/typography conventions.
+- Don't override existing component styles by passing `className` or `style` props to components that already have their own styling. Use `<Button>` as-is, never `<Button className="bg-red-500">`. If customization is needed, use the component's own API (e.g. `variant`, `size` props).
+
+## Component System Notes
+
+- shadcn: use existing shadcn components; add missing components through shadcn CLI only when required by widget behavior.
+- radix/base-ui/react-aria/ariakit/ark-ui: follow current primitive and composition conventions already used in the repo.
+- custom/none: implement simple, maintainable UI with the detected styling system and avoid overengineering.

--- a/.claude/skills/workos-widgets/references/token-strategies.md
+++ b/.claude/skills/workos-widgets/references/token-strategies.md
@@ -1,0 +1,65 @@
+# Token Strategies
+
+## Objective
+
+Provide `accessToken` to widget surfaces using the app's existing auth architecture.
+
+## Guidance
+
+- Prefer existing AuthKit/session flows when they are already established.
+- If backend token creation already exists, follow that pattern.
+- Keep token-related logic near current auth boundaries.
+- Pass token values explicitly into widget entry surfaces.
+- Send the widget token through the app's existing authenticated HTTP pattern when calling widget endpoints.
+- Use environment variables for credentials/config instead of hardcoded keys.
+- For endpoints that require elevated access, follow the elevation flow and handle elevated token usage separately from the regular widget token.
+
+## Widget Scope Reference
+
+Use the scope that matches the widget being implemented:
+
+| Widget                             | Required Scope                       |
+| ---------------------------------- | ------------------------------------ |
+| `user-management`                  | `widgets:users-table:manage`         |
+| `user-profile`                     | _(no permission scope required)_     |
+| `admin-portal-sso-connection`      | `widgets:sso:manage`                 |
+| `admin-portal-domain-verification` | `widgets:domain-verification:manage` |
+
+## JS/TS Authorization Tokens
+
+Widgets need an authorization token and JS/TS apps typically use one of two paths:
+
+1. If the app uses `authkit-js` or `authkit-react`, use the existing access token flow.
+2. If the app uses a backend WorkOS SDK, request a widget token with `workos.widgets.getToken(...)` and the scope for the selected widget (see Widget Scope Reference above).
+
+Widget tokens expire after one hour.
+
+```ts
+const workos = new WorkOS(process.env.WORKOS_API_KEY, {
+  clientId: process.env.WORKOS_CLIENT_ID,
+  // Use WORKOS_BASE_API_URL if set (e.g. for staging/local); falls back to default
+  ...(process.env.WORKOS_BASE_API_URL && { host: process.env.WORKOS_BASE_API_URL }),
+});
+
+const authToken = await workos.widgets.getToken({
+  userId: user.id,
+  organizationId,
+  scopes: ['<scope-for-this-widget>'], // see Widget Scope Reference above
+});
+```
+
+To generate a token successfully, the user needs a role with the required widget permissions. When token generation fails due to authorization, check role permissions in the WorkOS Dashboard roles configuration.
+
+New WorkOS accounts typically start with an Admin role that already has widget permissions. Existing accounts may need explicit role permission updates. Reference: [Roles and Permissions guide](https://workos.com/docs/authkit/roles-and-permissions).
+
+## Elevated Access Tokens
+
+Some operations require elevated access in addition to the normal widget token. Check the endpoint table in `fetching-apis.md` for the ⚠️ elevated marker **before calling it** — not on failure. If marked elevated, acquire the elevated token first.
+
+1. Use the `POST /_widgets/UserProfile/verify` endpoint to obtain an elevated access token.
+2. Use the returned token (`elevatedAccessToken`) in request header `x-elevated-access-token`.
+3. Treat elevated tokens as short-lived credentials (10 minutes) and scope usage to sensitive action paths only.
+
+## Example Direction
+
+When backend WorkOS SDK usage is present, use its existing token creation path and adapt it for the required widget scope.

--- a/.claude/skills/workos-widgets/references/widget-admin-portal-domain-verification.md
+++ b/.claude/skills/workos-widgets/references/widget-admin-portal-domain-verification.md
@@ -1,0 +1,15 @@
+# Widget: Admin Portal Domain Verification
+
+## Purpose
+
+The Admin Portal Domain Verification widget lets users verify domains through Admin Portal workflows.
+
+## Permission Requirement
+
+The acting user should have a role with `widgets:domain-verification:manage`.
+
+## Complete When
+
+- The widget lists domains with: domain value, added date/time, and verification status.
+- The widget supports actions to restart verification and remove domain.
+- The widget includes an "Add domain" action that links to Admin Portal domain management.

--- a/.claude/skills/workos-widgets/references/widget-admin-portal-sso-connection.md
+++ b/.claude/skills/workos-widgets/references/widget-admin-portal-sso-connection.md
@@ -1,0 +1,14 @@
+# Widget: Admin Portal SSO Connection
+
+## Purpose
+
+The Admin Portal SSO Connection widget lets users set up and manage SSO connections in Admin Portal.
+
+## Permission Requirement
+
+The acting user should have a role with `widgets:sso:manage`.
+
+## Complete When
+
+- The widget shows connection name and connection status.
+- The widget includes a "Manage connection" action that links to Admin Portal.

--- a/.claude/skills/workos-widgets/references/widget-user-management.md
+++ b/.claude/skills/workos-widgets/references/widget-user-management.md
@@ -1,0 +1,18 @@
+# Widget: User Management
+
+## Purpose
+
+The User Management widget lets organization admins manage members in an organization.
+
+## Permission Requirement
+
+The acting user should have a role with `widgets:users-table:manage`.
+
+## Complete When
+
+- The widget shows a paginated members table.
+- The table includes: avatar, name, email, role, last active time, and status when available.
+- Search is implemented server-side.
+- Role filtering is implemented server-side.
+- Per-user actions are available for editing role and deleting/removing user.
+- Admin invite flow is available for adding new users.

--- a/.claude/skills/workos-widgets/references/widget-user-profile.md
+++ b/.claude/skills/workos-widgets/references/widget-user-profile.md
@@ -1,0 +1,11 @@
+# Widget: User Profile
+
+## Purpose
+
+The User Profile widget lets end users view and manage their personal information.
+
+## Complete When
+
+- The widget displays profile picture, name, email, and connected accounts.
+- The widget includes an action to edit the user's name.
+- Profile updates reflect success/failure clearly in UI.

--- a/.claude/skills/workos-widgets/references/widgets-open-api-spec.yaml
+++ b/.claude/skills/workos-widgets/references/widgets-open-api-spec.yaml
@@ -1,0 +1,3374 @@
+openapi: 3.1.1
+paths:
+  /_widgets/ApiKeys/organization-api-keys:
+    post:
+      operationId: createOrganizationApiKey
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationApiKeyRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateOrganizationApiKeyResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                        field:
+                          type: string
+                      required:
+                        - code
+                        - field
+                required:
+                  - message
+                  - errors
+    get:
+      operationId: listOrganizationApiKeys
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: limit
+          required: false
+          in: query
+          schema:
+            type: number
+        - name: before
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: after
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: search
+          required: false
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOrganizationApiKeysResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/ApiKeys/permissions:
+    get:
+      operationId: listOrganizationApiKeyPermissions
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: search
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: limit
+          required: false
+          in: query
+          schema:
+            type: number
+        - name: before
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: after
+          required: false
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOrganizationApiKeyPermissionsResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/ApiKeys/{apiKeyId}:
+    delete:
+      operationId: deleteOrganizationApiKey
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: apiKeyId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/DataIntegrations/installations/{installationId}:
+    delete:
+      operationId: deleteDataInstallation
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: installationId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/DataIntegrations/mine:
+    get:
+      operationId: myDataIntegrations
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataIntegrationsResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/DataIntegrations/{dataIntegrationId}/authorization-status/{state}:
+    get:
+      operationId: getDataInstallationAuthorizationStatus
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: dataIntegrationId
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: state
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAuthorizationStatusResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/DataIntegrations/{slug}/authorize:
+    get:
+      operationId: getDataIntegrationAuthorizeUrl
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: slug
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: requireHandoff
+          required: false
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetDataIntegrationAuthorizeUrlResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/invite-user:
+    post:
+      operationId: inviteMember
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Sends an invitation email to a user to join the organization. If the
+        user does not have an account, they will be prompted to create one upon
+        accepting.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                firstName:
+                  type:
+                    - string
+                    - 'null'
+                lastName:
+                  type:
+                    - string
+                    - 'null'
+                roles:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - email
+                - roles
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/invites/{userId}:
+    delete:
+      operationId: revokeInvite
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Cancels a pending invitation for the specified user, preventing them
+        from joining the organization via that invite link.
+      parameters:
+        - name: userId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - id
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/invites/{userId}/resend:
+    post:
+      operationId: resendInvite
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Resends the pending invitation email to the specified user. Returns an
+        error if the invitation has already been accepted or has expired.
+      parameters:
+        - name: userId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type:
+                      - string
+                      - 'null'
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/members:
+    get:
+      operationId: members
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns a paginated list of members belonging to the organization.
+        Supports filtering by search term and role, and cursor-based pagination
+        via before/after parameters.
+      parameters:
+        - name: search
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: limit
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: before
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: after
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: role
+          required: false
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Member'
+                  list_metadata:
+                    $ref: '#/components/schemas/ListMetadata'
+                required:
+                  - data
+                  - list_metadata
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/members/{userId}:
+    delete:
+      operationId: removeMember
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Removes the specified user from the organization by revoking their
+        membership. The user account itself is not deleted.
+      parameters:
+        - name: userId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - id
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+    post:
+      operationId: updateMember
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Updates the specified member's organization membership, such as changing
+        their assigned role.
+      parameters:
+        - name: userId
+          required: true
+          in: path
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                roles:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - roles
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - id
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/organizations:
+    get:
+      operationId: organizations
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: Returns the list of organizations the authenticated user is a member of.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationsResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/roles:
+    get:
+      operationId: roles
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns the list of roles available in the organization that can be
+        assigned to members.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MemberRole'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserManagement/roles-and-config:
+    get:
+      operationId: rolesAndConfig
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns the list of roles available in the organization along with the
+        user management configuration, such as whether role assignment is
+        enabled.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RolesAndConfigResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/authentication-information:
+    get:
+      operationId: authenticationInformation
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns the authentication methods and MFA factors configured for the
+        authenticated user, including enrolled TOTP factors and passkeys.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationInformationResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/create-password:
+    post:
+      operationId: createPassword
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Sets a password for the authenticated user. Only available when the user
+        does not already have a password configured. Requires elevated access.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePasswordRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/create-totp-factor:
+    post:
+      operationId: createTotpFactor
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Initiates TOTP (authenticator app) enrollment for the authenticated user
+        by generating a new TOTP secret and QR code. Requires elevated access.
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTotpFactorResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/me:
+    get:
+      operationId: me
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns the profile information of the currently authenticated user,
+        including their name, email, and linked authentication factors.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Me'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+    post:
+      operationId: updateMe
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Updates the profile information of the currently authenticated user,
+        such as their first name, last name, or email address.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                locale:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Me'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/passkeys:
+    post:
+      operationId: registerPasskey
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Initiates passkey (WebAuthn) registration for the authenticated user by
+        returning the credential creation options. Requires elevated access.
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterPasskeyResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/passkeys/verify:
+    post:
+      operationId: verifyPasskey
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Completes passkey (WebAuthn) registration by verifying the credential
+        created by the authenticator. Requires elevated access.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyPasskeyRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/passkeys/{passkeyId}:
+    delete:
+      operationId: deletePasskey
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Removes the specified passkey from the authenticated user's account.
+        Requires elevated access.
+      parameters:
+        - name: passkeyId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/send-verification:
+    post:
+      operationId: sendVerification
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Sends a verification email to the authenticated user to confirm their
+        email address.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendVerificationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/sessions:
+    get:
+      operationId: sessions
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns all currently active sessions for the authenticated user,
+        including device and location information where available.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActiveSessionsResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/sessions/revoke-all:
+    delete:
+      operationId: revokeAllSessions
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Revokes all active sessions for the authenticated user except optionally
+        the current one, signing them out of all other devices.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeAllSessionsRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/sessions/revoke/{sessionId}:
+    delete:
+      operationId: revokeSession
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Revokes a specific active session by ID, signing the user out of that
+        particular device or browser.
+      parameters:
+        - name: sessionId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/totp-factors:
+    delete:
+      operationId: deleteTotpFactors
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Removes all TOTP factors enrolled for the authenticated user, disabling
+        authenticator app as a second factor. Requires elevated access.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/update-password:
+    post:
+      operationId: updatePassword
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Changes the password for the authenticated user. Requires the current
+        password to be supplied alongside the new password.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePasswordRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/verify:
+    post:
+      operationId: verify
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Verifies the email address of the authenticated user using the code sent
+        via the send-verification endpoint. On success, returns an elevated
+        access token that grants access to sensitive operations such as MFA
+        enrollment and passkey management.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/UserProfile/verify-totp-factor:
+    post:
+      operationId: verifyTotpFactor
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Completes TOTP enrollment by verifying the one-time code generated by
+        the authenticator app. Requires elevated access.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyTotpFactorRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                required:
+                  - success
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/admin-portal/generate-link:
+    post:
+      operationId: generateAdminPortalLink
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: intent
+          required: true
+          in: query
+          schema:
+            enum:
+              - domain_verification
+              - sso
+            type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  link:
+                    type: string
+                required:
+                  - link
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/admin-portal/organization-domains:
+    get:
+      operationId: listOrganizationDomains
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OrganizationDomain'
+                required:
+                  - data
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/admin-portal/organization-domains/{domainId}:
+    delete:
+      operationId: deleteOrganizationDomain
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: domainId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationDomain'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/admin-portal/organization-domains/{domainId}/reverify:
+    post:
+      operationId: reverifyOrganizationDomain
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: domainId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationDomain'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/admin-portal/sso-connections:
+    get:
+      operationId: listSsoConnections
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SsoConnection'
+  /_widgets/directory-sync/directories:
+    get:
+      operationId: listDirectories
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DirectoriesResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/directory-sync/directories/{directoryId}:
+    get:
+      operationId: getDirectory
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      parameters:
+        - name: directoryId
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Directory'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /_widgets/settings:
+    get:
+      operationId: settings
+      x-internal: false
+      x-api-client: widgets
+      summary: ''
+      description: >-
+        Returns the widget settings for the current environment, including
+        enabled authentication methods and branding configuration.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettingsResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+info:
+  title: WorkOS Widgets
+  description: WorkOS Widgets API
+  version: '1.0'
+  contact: {}
+tags: []
+servers:
+  - url: https://api.workos.com
+    description: Production
+  - url: https://api.workos-test.com
+    description: Staging
+components:
+  securitySchemes:
+    bearer:
+      scheme: bearer
+      bearerFormat: JWT
+      type: http
+  schemas:
+    MemberStatus:
+      type: string
+      enum:
+        - Active
+        - Invited
+        - InviteExpired
+        - InviteRevoked
+        - NoInvite
+    MemberActions:
+      type: array
+      items:
+        type: string
+        enum:
+          - edit-role
+          - resend-invite
+          - revoke-invite
+          - revoke-membership
+    Member:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        emailVerified:
+          type: boolean
+        profilePictureUrl:
+          type:
+            - string
+            - 'null'
+        firstName:
+          type:
+            - string
+            - 'null'
+        lastName:
+          type:
+            - string
+            - 'null'
+        createdAt:
+          format: date-time
+          type: string
+          description: An ISO 8601 timestamp.
+          example: '2026-01-15T12:00:00.000Z'
+        lastActivityAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        status:
+          $ref: '#/components/schemas/MemberStatus'
+        actions:
+          $ref: '#/components/schemas/MemberActions'
+        isLoggedInUser:
+          oneOf:
+            - type: boolean
+              const: true
+            - type: 'null'
+        roles:
+          oneOf:
+            - type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  slug:
+                    type: string
+                  description:
+                    type:
+                      - string
+                      - 'null'
+                required:
+                  - name
+                  - slug
+            - type: 'null'
+      required:
+        - id
+        - email
+        - emailVerified
+        - createdAt
+        - status
+        - actions
+    ListMetadata:
+      type: object
+      properties:
+        before:
+          type:
+            - string
+            - 'null'
+          description: >-
+            An object ID that defines your place in the list. When the ID is not
+            present, you are at the start of the list.
+          example: xxx_01HXYZ123456789ABCDEFGHIJ
+        after:
+          type:
+            - string
+            - 'null'
+          description: >-
+            An object ID that defines your place in the list. When the ID is not
+            present, you are at the end of the list.
+          example: xxx_01HXYZ987654321KJIHGFEDCBA
+      required:
+        - before
+        - after
+    MemberRole:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        default:
+          type: boolean
+        description:
+          type:
+            - string
+            - 'null'
+      required:
+        - name
+        - slug
+        - default
+    RolesAndConfigResponse:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemberRole'
+        multipleRolesEnabled:
+          type: boolean
+      required:
+        - roles
+        - multipleRolesEnabled
+    OrganizationInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        current:
+          type: boolean
+        favicon:
+          type:
+            - string
+            - 'null'
+      required:
+        - id
+        - name
+        - current
+    OrganizationsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationInfo'
+      required:
+        - data
+    OAuthProfile:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type:
+            - string
+            - 'null'
+        firstName:
+          type:
+            - string
+            - 'null'
+        lastName:
+          type:
+            - string
+            - 'null'
+        profilePictureUrl:
+          type:
+            - string
+            - 'null'
+        lastLoginAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+      required:
+        - id
+    Me:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        firstName:
+          type:
+            - string
+            - 'null'
+        lastName:
+          type:
+            - string
+            - 'null'
+        locale:
+          type:
+            - string
+            - 'null'
+        profilePictureUrl:
+          type:
+            - string
+            - 'null'
+        oauthProfiles:
+          oneOf:
+            - type: object
+              properties:
+                AppleOAuth:
+                  $ref: '#/components/schemas/OAuthProfile'
+                GithubOAuth:
+                  $ref: '#/components/schemas/OAuthProfile'
+                GoogleOAuth:
+                  $ref: '#/components/schemas/OAuthProfile'
+                MicrosoftOAuth:
+                  $ref: '#/components/schemas/OAuthProfile'
+            - type: 'null'
+      required:
+        - id
+        - email
+    CreateTotpFactorResponse:
+      type: object
+      properties:
+        authenticationFactor:
+          allOf:
+            - type: object
+              properties:
+                object:
+                  type: string
+                  enum:
+                    - authentication_factor
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - generic_otp
+                    - sms
+                    - totp
+                    - webauthn
+                user_id:
+                  type:
+                    - string
+                    - 'null'
+                sms:
+                  oneOf:
+                    - type: object
+                      properties:
+                        phone_number:
+                          type: string
+                      required:
+                        - phone_number
+                    - type: 'null'
+                totp:
+                  anyOf:
+                    - type: object
+                      properties:
+                        issuer:
+                          type: string
+                        user:
+                          type: string
+                        secret:
+                          type: string
+                        qr_code:
+                          type: string
+                        uri:
+                          type: string
+                      required:
+                        - issuer
+                        - user
+                        - secret
+                        - qr_code
+                        - uri
+                    - type: object
+                      properties:
+                        issuer:
+                          type: string
+                        user:
+                          type: string
+                      required:
+                        - issuer
+                        - user
+                    - type: 'null'
+              required:
+                - object
+                - id
+                - type
+            - type: object
+              properties:
+                created_at:
+                  type: string
+                  format: date-time
+                updated_at:
+                  type: string
+                  format: date-time
+              required:
+                - created_at
+                - updated_at
+        authenticationChallenge:
+          allOf:
+            - type: object
+              properties:
+                object:
+                  type: string
+                  enum:
+                    - authentication_challenge
+                id:
+                  type: string
+                expires_at:
+                  type:
+                    - string
+                    - 'null'
+                  format: date-time
+                code:
+                  type:
+                    - string
+                    - 'null'
+                authentication_factor_id:
+                  type: string
+              required:
+                - object
+                - id
+                - authentication_factor_id
+            - type: object
+              properties:
+                created_at:
+                  type: string
+                  format: date-time
+                updated_at:
+                  type: string
+                  format: date-time
+              required:
+                - created_at
+                - updated_at
+      required:
+        - authenticationFactor
+        - authenticationChallenge
+    VerifyTotpFactorRequest:
+      type: object
+      properties:
+        code:
+          type: string
+        authenticationChallengeId:
+          type: string
+      required:
+        - code
+        - authenticationChallengeId
+    AuthenticationInformationResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            verificationMethods:
+              type: object
+              properties:
+                Mfa:
+                  oneOf:
+                    - type: object
+                      properties:
+                        provider:
+                          type: string
+                          enum:
+                            - MFA
+                        isSetUp:
+                          type: boolean
+                        lastUsed:
+                          type:
+                            - string
+                            - 'null'
+                      required:
+                        - provider
+                        - isSetUp
+                    - type: 'null'
+                Password:
+                  oneOf:
+                    - type: object
+                      properties:
+                        provider:
+                          type: string
+                          enum:
+                            - Password
+                        isSetUp:
+                          type: boolean
+                        lastUsed:
+                          type:
+                            - string
+                            - 'null'
+                        isCurrentSession:
+                          type: boolean
+                      required:
+                        - provider
+                        - isSetUp
+                        - isCurrentSession
+                    - type: 'null'
+                Passkey:
+                  oneOf:
+                    - type: object
+                      properties:
+                        provider:
+                          type: string
+                          enum:
+                            - Passkey
+                        isSetUp:
+                          type: boolean
+                        lastUsed:
+                          type:
+                            - string
+                            - 'null'
+                        passKeys:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                            required:
+                              - id
+                        isCurrentSession:
+                          type: boolean
+                      required:
+                        - provider
+                        - isSetUp
+                        - passKeys
+                        - isCurrentSession
+                    - type: 'null'
+            passwordSettings:
+              type: object
+              properties:
+                isPasswordNumberRequired:
+                  type: boolean
+                isPasswordPwnedRequired:
+                  type: boolean
+                isPasswordSymbolRequired:
+                  type: boolean
+                isPasswordUppercaseRequired:
+                  type: boolean
+                passwordMinimumLength:
+                  type: number
+                passwordMinimumStrength:
+                  type: number
+              required:
+                - isPasswordNumberRequired
+                - isPasswordPwnedRequired
+                - isPasswordSymbolRequired
+                - isPasswordUppercaseRequired
+                - passwordMinimumLength
+                - passwordMinimumStrength
+          required:
+            - verificationMethods
+            - passwordSettings
+      required:
+        - data
+    CreatePasswordRequest:
+      type: object
+      properties:
+        password:
+          type: string
+      required:
+        - password
+    UpdatePasswordRequest:
+      type: object
+      properties:
+        newPassword:
+          type: string
+        currentPassword:
+          type: string
+      required:
+        - newPassword
+        - currentPassword
+    RevokeAllSessionsRequest:
+      type: object
+      properties:
+        currentSessionId:
+          type: string
+      required:
+        - currentSessionId
+    ActiveSession:
+      type: object
+      properties:
+        id:
+          type: string
+        userlandUserId:
+          type: string
+        ipAddress:
+          type:
+            - string
+            - 'null'
+        userAgent:
+          type:
+            - string
+            - 'null'
+        organizationId:
+          type:
+            - string
+            - 'null'
+        state:
+          type: object
+          properties:
+            tag:
+              type: string
+            expiresAt:
+              type:
+                - string
+                - 'null'
+              format: date-time
+          required:
+            - tag
+        currentLocation:
+          oneOf:
+            - type: object
+              properties:
+                cityName:
+                  type: string
+                countryISOCode:
+                  type: string
+              required:
+                - cityName
+                - countryISOCode
+            - type: 'null'
+        usedSsoAuth:
+          type: boolean
+        usedPasswordAuth:
+          type: boolean
+        usedPasskeyAuth:
+          type: boolean
+        usedAppleOauth:
+          type: boolean
+        usedBitbucketOauth:
+          type: boolean
+        usedGithubOauth:
+          type: boolean
+        usedGitLabOauth:
+          type: boolean
+        usedGoogleOauth:
+          type: boolean
+        usedLinkedInOauth:
+          type: boolean
+        usedImpersonation:
+          type: boolean
+        usedMicrosoftOauth:
+          type: boolean
+        usedSlackOauth:
+          type: boolean
+        usedXeroOauth:
+          type: boolean
+        usedMagicAuth:
+          type: boolean
+        impersonatorUserId:
+          type:
+            - string
+            - 'null'
+        impersonatorEmail:
+          type:
+            - string
+            - 'null'
+        impersonationReason:
+          type:
+            - string
+            - 'null'
+        lastActivityAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - userlandUserId
+        - state
+        - usedSsoAuth
+        - usedPasswordAuth
+        - usedPasskeyAuth
+        - usedAppleOauth
+        - usedBitbucketOauth
+        - usedGithubOauth
+        - usedGitLabOauth
+        - usedGoogleOauth
+        - usedLinkedInOauth
+        - usedImpersonation
+        - usedMicrosoftOauth
+        - usedSlackOauth
+        - usedXeroOauth
+        - usedMagicAuth
+        - createdAt
+        - updatedAt
+    ActiveSessionsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActiveSession'
+      required:
+        - data
+    SendVerificationResponse:
+      type: object
+      properties:
+        authenticationChallenge:
+          type: string
+        type:
+          type: string
+          enum:
+            - EmailVerification
+      required:
+        - authenticationChallenge
+        - type
+    VerifyRequest:
+      type: object
+      properties:
+        code:
+          type: string
+        authenticationChallengeId:
+          type: string
+      required:
+        - code
+        - authenticationChallengeId
+    VerifyResponse:
+      type: object
+      properties:
+        elevatedAccessToken:
+          type: string
+        expiresAt:
+          type: string
+      required:
+        - elevatedAccessToken
+        - expiresAt
+    RegisterPasskeyResponse:
+      type: object
+      properties:
+        challengeId:
+          type: string
+        options:
+          type: object
+      required:
+        - challengeId
+        - options
+    VerifyPasskeyRequest:
+      type: object
+      properties:
+        challengeId:
+          type: string
+        response:
+          type: object
+      required:
+        - challengeId
+        - response
+    SettingsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - settings
+        authkitOrigin:
+          type: string
+        logoDarkIconPath:
+          type:
+            - string
+            - 'null'
+        logoDarkPath:
+          type:
+            - string
+            - 'null'
+        logoLightIconPath:
+          type:
+            - string
+            - 'null'
+        logoLightPath:
+          type:
+            - string
+            - 'null'
+        teamName:
+          type: string
+      required:
+        - object
+        - authkitOrigin
+        - teamName
+    OrganizationDomainState:
+      type: string
+      enum:
+        - Failed
+        - LegacyVerified
+        - Pending
+        - Verified
+    DomainVerificationNameServer:
+      type: string
+      enum:
+        - AwsRoute53
+        - GoogleDomains
+        - CloudFlare
+        - GoDaddy
+        - Other
+    OrganizationDomain:
+      type: object
+      properties:
+        id:
+          type: string
+        domain:
+          type: string
+        state:
+          $ref: '#/components/schemas/OrganizationDomainState'
+        nameServer:
+          $ref: '#/components/schemas/DomainVerificationNameServer'
+        verificationPrefix:
+          type:
+            - string
+            - 'null'
+        verificationToken:
+          type:
+            - string
+            - 'null'
+        subdomain:
+          type:
+            - string
+            - 'null'
+        createdAt:
+          type: string
+      required:
+        - id
+        - domain
+        - state
+        - nameServer
+        - createdAt
+    X509CertificateJSON:
+      type: object
+      properties:
+        id:
+          type: string
+        value:
+          type: string
+        notBefore:
+          type:
+            - string
+            - 'null'
+        notAfter:
+          type:
+            - string
+            - 'null'
+        lastExpiryEventSentAt:
+          type:
+            - string
+            - 'null'
+      required:
+        - id
+        - value
+    SamlSessionState:
+      type: string
+      enum:
+        - Authorized
+        - Failed
+        - Started
+        - Successful
+        - Timedout
+    OidcSessionState:
+      type: string
+      enum:
+        - Started
+        - Authorized
+        - Successful
+        - Failed
+        - Terminated
+        - Timedout
+    SsoConnectionSessionJSON:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+        state:
+          anyOf:
+            - $ref: '#/components/schemas/SamlSessionState'
+            - $ref: '#/components/schemas/OidcSessionState'
+      required:
+        - id
+        - createdAt
+        - state
+    SsoConnection:
+      anyOf:
+        - type: object
+          properties:
+            id:
+              type: string
+            type:
+              type: string
+              enum:
+                - AdfsSaml
+                - Auth0Saml
+                - AzureSaml
+                - CasSaml
+                - ClassLinkSaml
+                - CloudflareSaml
+                - CyberArkSaml
+                - DuoSaml
+                - GenericSaml
+                - GoogleSaml
+                - JumpCloudSaml
+                - KeycloakSaml
+                - LastPassSaml
+                - MiniOrangeSaml
+                - NetIqSaml
+                - OktaSaml
+                - OneLoginSaml
+                - OracleSaml
+                - PingFederateSaml
+                - PingOneSaml
+                - RipplingSaml
+                - SalesforceSaml
+                - ShibbolethGenericSaml
+                - ShibbolethSaml
+                - SimpleSamlPhpSaml
+                - TestIdp
+                - VmWareSaml
+            name:
+              type: string
+            state:
+              type: string
+              enum:
+                - Inactive
+                - Validating
+                - Active
+                - Deleting
+            x509Certificates:
+              type: array
+              items:
+                $ref: '#/components/schemas/X509CertificateJSON'
+            latestExpiringCertificate:
+              oneOf:
+                - $ref: '#/components/schemas/X509CertificateJSON'
+                - type: 'null'
+            latestExpiredCertificate:
+              oneOf:
+                - $ref: '#/components/schemas/X509CertificateJSON'
+                - type: 'null'
+            createdAt:
+              type: string
+            providerTag:
+              type: string
+              enum:
+                - Saml
+            lastSession:
+              oneOf:
+                - $ref: '#/components/schemas/SsoConnectionSessionJSON'
+                - type: 'null'
+          required:
+            - id
+            - type
+            - name
+            - state
+            - x509Certificates
+            - createdAt
+            - providerTag
+        - allOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                name:
+                  type: string
+                state:
+                  type: string
+                  enum:
+                    - Inactive
+                    - Validating
+                    - Active
+                    - Deleting
+                type:
+                  type: string
+                  enum:
+                    - AdpOidc
+                    - Auth0Migration
+                    - CleverOidc
+                    - EntraIdOidc
+                    - GenericOidc
+                    - GoogleOidc
+                    - OktaOidc
+                    - LoginGovOidc
+                createdAt:
+                  type: string
+                providerTag:
+                  type: string
+                  enum:
+                    - OpenIdConnect
+                lastSession:
+                  oneOf:
+                    - $ref: '#/components/schemas/SsoConnectionSessionJSON'
+                    - type: 'null'
+              required:
+                - id
+                - name
+                - state
+                - type
+                - createdAt
+                - providerTag
+            - type: object
+              properties:
+                x509Certificates:
+                  type: 'null'
+                latestExpiringCertificate:
+                  type: 'null'
+                latestExpiredCertificate:
+                  type: 'null'
+    ListOrganizationApiKeysResponseData:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        obfuscatedValue:
+          type: string
+        createdAt:
+          type: string
+        lastUsedAt:
+          type:
+            - string
+            - 'null'
+        permissions:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - name
+        - obfuscatedValue
+        - createdAt
+        - permissions
+    ListOrganizationApiKeysResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListOrganizationApiKeysResponseData'
+        list_metadata:
+          type: object
+          properties:
+            before:
+              type: string
+            after:
+              type: string
+      required:
+        - data
+        - list_metadata
+    CreateOrganizationApiKeyRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - permissions
+    CreateOrganizationApiKeyResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        value:
+          type: string
+        obfuscatedValue:
+          type: string
+        createdAt:
+          type: string
+        name:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - value
+        - obfuscatedValue
+        - createdAt
+        - name
+        - permissions
+    ListOrganizationApiKeyPermission:
+      type: object
+      properties:
+        id:
+          type: string
+        slug:
+          type: string
+        name:
+          type: string
+        description:
+          type:
+            - string
+            - 'null'
+      required:
+        - id
+        - slug
+        - name
+    ListOrganizationApiKeyPermissionsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListOrganizationApiKeyPermission'
+        list_metadata:
+          type: object
+          properties:
+            before:
+              type: string
+            after:
+              type: string
+      required:
+        - data
+        - list_metadata
+    DataInstallation:
+      allOf:
+        - type: object
+          properties:
+            object:
+              anyOf:
+                - type: string
+                  enum:
+                    - data_installation
+                - type: string
+                  enum:
+                    - connected_account
+            id:
+              type: string
+            user_id:
+              type:
+                - string
+                - 'null'
+            organization_id:
+              type:
+                - string
+                - 'null'
+            scopes:
+              type: array
+              items:
+                type: string
+            state:
+              anyOf:
+                - type: string
+                  enum:
+                    - connected
+                - type: string
+                  enum:
+                    - needs_reauthorization
+            created_at:
+              type: string
+            updated_at:
+              type: string
+          required:
+            - object
+            - id
+            - scopes
+            - state
+            - created_at
+            - updated_at
+        - type: object
+          properties:
+            userlandUserId:
+              type:
+                - string
+                - 'null'
+            organizationId:
+              type:
+                - string
+                - 'null'
+            createdAt:
+              type: string
+            updatedAt:
+              type: string
+    DataIntegration:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - data_integration
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type:
+            - string
+            - 'null'
+        slug:
+          type: string
+        integrationType:
+          anyOf:
+            - type: string
+              enum:
+                - asana
+            - type: string
+              enum:
+                - box
+            - type: string
+              enum:
+                - cal-dot-com
+            - type: string
+              enum:
+                - calendly
+            - type: string
+              enum:
+                - confluence
+            - type: string
+              enum:
+                - dropbox
+            - type: string
+              enum:
+                - frame-io
+            - type: string
+              enum:
+                - front
+            - type: string
+              enum:
+                - github
+            - type: string
+              enum:
+                - gitlab
+            - type: string
+              enum:
+                - gmail
+            - type: string
+              enum:
+                - google
+            - type: string
+              enum:
+                - google-calendar
+            - type: string
+              enum:
+                - google-drive
+            - type: string
+              enum:
+                - helpscout
+            - type: string
+              enum:
+                - hubspot
+            - type: string
+              enum:
+                - intercom
+            - type: string
+              enum:
+                - jira
+            - type: string
+              enum:
+                - linear
+            - type: string
+              enum:
+                - microsoft
+            - type: string
+              enum:
+                - microsoft-onedrive
+            - type: string
+              enum:
+                - microsoft-onenote
+            - type: string
+              enum:
+                - microsoft-outlook
+            - type: string
+              enum:
+                - microsoft-outlook-calendar
+            - type: string
+              enum:
+                - microsoft-sharepoint
+            - type: string
+              enum:
+                - microsoft-teams
+            - type: string
+              enum:
+                - microsoft-todo
+            - type: string
+              enum:
+                - notion
+            - type: string
+              enum:
+                - prefect
+            - type: string
+              enum:
+                - pydantic-logfire
+            - type: string
+              enum:
+                - salesforce
+            - type: string
+              enum:
+                - sentry
+            - type: string
+              enum:
+                - slack
+            - type: string
+              enum:
+                - snowflake
+            - type: string
+              enum:
+                - stripe
+            - type: string
+              enum:
+                - xero
+            - type: string
+              enum:
+                - zendesk
+        ownership:
+          anyOf:
+            - type: string
+              enum:
+                - userland_user
+            - type: string
+              enum:
+                - organization
+        credentialsType:
+          anyOf:
+            - type: string
+              enum:
+                - shared
+            - type: string
+              enum:
+                - custom
+        scopes:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: 'null'
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+        installation:
+          oneOf:
+            - $ref: '#/components/schemas/DataInstallation'
+            - type: 'null'
+      required:
+        - object
+        - id
+        - name
+        - slug
+        - integrationType
+        - ownership
+        - credentialsType
+        - createdAt
+        - updatedAt
+    DataIntegrationsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataIntegration'
+      required:
+        - data
+    GetDataIntegrationAuthorizeUrlResponse:
+      allOf:
+        - type: object
+          properties:
+            url:
+              type: string
+            redirectToken:
+              type: string
+          required:
+            - url
+            - redirectToken
+        - type: object
+          properties:
+            handoffToken:
+              type: string
+    GetAuthorizationStatusResponse:
+      type: object
+      properties:
+        isConnecting:
+          type: boolean
+      required:
+        - isConnecting
+    DirectoryType:
+      type: string
+      enum:
+        - azure scim v2.0
+        - bamboohr
+        - breathe hr
+        - cezanne hr
+        - cyberark scim v2.0
+        - fourth hr
+        - generic scim v2.0
+        - gsuite directory
+        - gusto
+        - hibob
+        - jump cloud scim v2.0
+        - okta scim v2.0
+        - onelogin scim v2.0
+        - people hr
+        - personio
+        - pingfederate scim v2.0
+        - rippling
+        - rippling scim v2.0
+        - s3
+        - sailpoint scim v2.0
+        - sftp
+        - sftp workday
+        - workday
+    DirectoryState:
+      type: string
+      enum:
+        - requires_type
+        - linked
+        - validating
+        - invalid_credentials
+        - unlinked
+        - deleting
+    DirectoryUsersMetadata:
+      type: object
+      properties:
+        active:
+          type: number
+        inactive:
+          type: number
+      required:
+        - active
+        - inactive
+    DirectoryMetadata:
+      type: object
+      properties:
+        users:
+          $ref: '#/components/schemas/DirectoryUsersMetadata'
+        groups:
+          type: number
+      required:
+        - users
+        - groups
+    Directory:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/DirectoryType'
+        state:
+          $ref: '#/components/schemas/DirectoryState'
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/DirectoryMetadata'
+      required:
+        - id
+        - name
+        - type
+        - state
+        - createdAt
+        - updatedAt
+        - metadata
+    DirectoriesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Directory'
+        link:
+          type: string
+      required:
+        - data
+        - link

--- a/.claude/skills/workos/SKILL.md
+++ b/.claude/skills/workos/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: workos
+description: Use when the user asks for a WorkOS docs URL, term, or dashboard field (Sign-in endpoint, initiate_login_uri, Redirect URI, `WORKOS_*` env vars), or is implementing, debugging, or migrating WorkOS — AuthKit, SSO/SAML, Directory Sync, RBAC, FGA, MFA, Vault, Audit Logs, Admin Portal, Pipes (Connected Apps), Feature Flags, Radar (bot/fraud detection), webhooks, Custom Domains, or migrating from Auth0, Clerk, Cognito, Firebase, Supabase, Stytch, Descope, or Better Auth. Also triggers on @workos-inc/* imports.
+---
+
+# WorkOS Skill Router
+
+## How to Use
+
+**This file is a router, NOT the answer.** Before responding to the user:
+
+1. Match the request to a reference file using Rule 0 and the decision tree below.
+2. **You MUST Read the matched reference file with the Read tool before producing any answer, URL, or code.** If you have not Read a reference, you have not followed this skill.
+3. Follow the instructions inside the reference (it will tell you which live docs to fetch with WebFetch and which gotchas to avoid).
+
+**Exception**: Widget requests use the `workos-widgets` skill via the Skill tool — it has its own multi-framework orchestration.
+
+## Guardrails (apply to every response)
+
+These apply regardless of which routing rule fires. They exist because the most common failure mode of past WorkOS agent interactions has been plausibly-shaped fabrication of CLI commands and Dashboard paths.
+
+- **Never invent `workos` CLI commands.** If the user asks about CLI support or you're about to suggest a command, verify the command tree first. The authoritative source is `workos --help --json` — it emits the complete registered command tree. Do not assume a `create` subcommand exists because `list`/`get`/`delete` do. See `references/workos-management.md`.
+- **Never invent Dashboard click-paths.** Phrases like "Dashboard > Organizations > X > Roles > Map Groups" or `dashboard.workos.com/some/specific/path` should not appear unless you have verified them against a docs page you just fetched. The Dashboard UI reorganizes; docs pages are stable. Cite the docs URL and describe the destination conceptually ("the Authorization page", "the directory's settings") instead of committing to a click-path.
+- **When the user wants to do something not supported by the CLI, say so plainly.** Users are better served by "this isn't in the CLI; here's the docs URL for how to do it" than by a fabricated command that fails. See the "Not in the CLI" section of `references/workos-management.md`.
+- **Prefer docs URLs over prose when writing recipes.** If a reference file tells you to cite a specific docs URL, cite it literally; don't paraphrase the URL's slug.
+
+## Topic → Reference Map
+
+> Terminology lookups — "what is X", "docs URL for X" — are handled by **Rule 0** below, not this topic map. They route to `references/workos-terms.md`.
+
+### AuthKit Installation (Read `references/{name}.md`)
+
+| User wants to...                    | Read file                                     |
+| ----------------------------------- | --------------------------------------------- |
+| Install AuthKit in Next.js          | `references/workos-authkit-nextjs.md`         |
+| Install AuthKit in React SPA        | `references/workos-authkit-react.md`          |
+| Install AuthKit with React Router   | `references/workos-authkit-react-router.md`   |
+| Install AuthKit with TanStack Start | `references/workos-authkit-tanstack-start.md` |
+| Install AuthKit with SvelteKit      | `references/workos-authkit-sveltekit.md`      |
+| Install AuthKit in vanilla JS       | `references/workos-authkit-vanilla-js.md`     |
+| AuthKit architecture reference      | `references/workos-authkit-base.md`           |
+| Add WorkOS Widgets                  | Load `workos-widgets` skill via Skill tool    |
+
+### Backend SDK Installation (Read `references/{name}.md`)
+
+| User wants to...                   | Read file                          |
+| ---------------------------------- | ---------------------------------- |
+| Install AuthKit in Node.js backend | `references/workos-node.md`        |
+| Install AuthKit in Python          | `references/workos-python.md`      |
+| Install AuthKit in .NET            | `references/workos-dotnet.md`      |
+| Install AuthKit in Go              | `references/workos-go.md`          |
+| Install AuthKit in Ruby            | `references/workos-ruby.md`        |
+| Install AuthKit in PHP             | `references/workos-php.md`         |
+| Install AuthKit in PHP Laravel     | `references/workos-php-laravel.md` |
+| Install AuthKit in Kotlin          | `references/workos-kotlin.md`      |
+| Install AuthKit in Elixir          | `references/workos-elixir.md`      |
+
+### Features (Read `references/{name}.md`)
+
+| User wants to...                | Read file                             |
+| ------------------------------- | ------------------------------------- |
+| Configure Single Sign-On        | `references/workos-sso.md`            |
+| Set up Directory Sync           | `references/workos-directory-sync.md` |
+| Implement RBAC / roles          | `references/workos-rbac.md`           |
+| Encrypt data with Vault         | `references/workos-vault.md`          |
+| Handle WorkOS Events / webhooks | `references/workos-events.md`         |
+| Set up Audit Logs               | `references/workos-audit-logs.md`     |
+| Enable Admin Portal             | `references/workos-admin-portal.md`   |
+| Add Multi-Factor Auth           | `references/workos-mfa.md`            |
+| Configure email delivery        | `references/workos-email.md`          |
+| Set up Custom Domains           | `references/workos-custom-domains.md` |
+| Set up IdP integration          | `references/workos-integrations.md`   |
+| Implement FGA / fine-grained authz | `references/workos-fga.md`         |
+| Set up Pipes / Connected Apps   | `references/workos-pipes.md`          |
+| Configure Feature Flags         | `references/workos-feature-flags.md`  |
+| Set up Radar / fraud detection  | `references/workos-radar.md`          |
+
+### API References (Read `references/{name}.md`)
+
+Feature topic files above include endpoint tables for their respective APIs. Use these API-only references when no feature topic exists:
+
+| User wants to...           | Read file                               |
+| -------------------------- | --------------------------------------- |
+| AuthKit API Reference      | `references/workos-api-authkit.md`      |
+| Organization API Reference | `references/workos-api-organization.md` |
+
+### Migrations (Read `references/{name}.md`)
+
+| User wants to...                    | Read file                                             |
+| ----------------------------------- | ----------------------------------------------------- |
+| Migrate from Auth0                  | `references/workos-migrate-auth0.md`                  |
+| Migrate from AWS Cognito            | `references/workos-migrate-aws-cognito.md`            |
+| Migrate from Better Auth            | `references/workos-migrate-better-auth.md`            |
+| Migrate from Clerk                  | `references/workos-migrate-clerk.md`                  |
+| Migrate from Descope                | `references/workos-migrate-descope.md`                |
+| Migrate from Firebase               | `references/workos-migrate-firebase.md`               |
+| Migrate from Stytch                 | `references/workos-migrate-stytch.md`                 |
+| Migrate from Supabase Auth          | `references/workos-migrate-supabase-auth.md`          |
+| Migrate from the standalone SSO API | `references/workos-migrate-the-standalone-sso-api.md` |
+| Migrate from other services         | `references/workos-migrate-other-services.md`         |
+
+### Management & CLI Lifecycle (Read `references/{name}.md`)
+
+| User wants to...                         | Read file                          |
+| ---------------------------------------- | ---------------------------------- |
+| Manage WorkOS resources via CLI commands | `references/workos-management.md`  |
+| Upgrade the `workos` CLI to a newer version | `references/workos-cli-upgrade.md` |
+
+## Routing Decision Tree
+
+Apply these rules in order. First match wins.
+
+### 0. Terminology / Docs URL Lookup
+
+**Triggers**: Lookup-shaped phrasing — "what is X", "what does X mean", "docs URL for X", "where's the docs on X", "canonical link for X", "where do I configure X in the dashboard" — where X is a WorkOS-specific config field, endpoint, env var, or term. Examples: `initiate_login_uri`, "Sign-in endpoint", "Redirect URI", dashboard field names, `WORKOS_*` environment variables.
+
+**Do NOT fire Rule 0** for setup-shaped phrasing like "set up Vault", "enable Admin Portal", "configure MFA" — those route to Rule 3 (Feature-Specific).
+
+**Action**:
+
+1. Read `references/workos-terms.md` — a curated table mapping WorkOS terms to canonical docs URLs.
+2. If the term is in the table, use the summary to answer; WebFetch the listed URL only if the user wants more detail.
+3. If the term is NOT in the table, follow the "Still not here?" fallback at the bottom of that file. When you find the canonical URL, answer the user and suggest they open a PR to add a row.
+
+**For terminology lookups**, do NOT WebFetch `llms.txt` or guess `workos.com/docs/...` URLs before reading the terms file. (Rules 7 and 8 use `llms.txt` for different purposes — this prohibition is scoped to Rule 0 only.)
+
+**Why this wins**: Terminology lookups happen independent of feature/framework/migration context. They need to short-circuit routing, not fall through to "Vague or General" (Rule 7).
+
+---
+
+### 1. Migration Context
+
+**Triggers**: User mentions migrating FROM another provider (Auth0, Clerk, Cognito, Firebase, Supabase, Stytch, Descope, Better Auth, standalone SSO API).
+
+**Action**: Read `references/workos-migrate-[provider].md` where `[provider]` matches the source system. If provider is not in the table, read `references/workos-migrate-other-services.md`.
+
+**Why this wins**: Migration context overrides feature-specific routing because users need provider-specific data export and transformation steps.
+
+---
+
+### 2. API Reference Request
+
+**Triggers**: User explicitly asks about "API endpoints", "request format", "response schema", "API reference", or mentions inspecting HTTP details.
+
+**Action**: For features with topic files (SSO, Directory Sync, RBAC, Vault, Events, Audit Logs, Admin Portal), read the feature topic file — it includes an endpoint table. For AuthKit or Organization APIs, read `references/workos-api-[domain].md`.
+
+**Why this wins**: API references are low-level; feature topics are high-level but include endpoint tables for quick reference.
+
+---
+
+### 3. Feature-Specific Request
+
+**Triggers**: User mentions a specific WorkOS feature by name (SSO, MFA, Directory Sync, Audit Logs, Vault, RBAC, FGA, Admin Portal, Custom Domains, Events, Integrations, Email, Pipes, Feature Flags, Radar).
+
+**Action**: Read `references/workos-[feature].md` where `[feature]` is the lowercase slug (sso, mfa, directory-sync, audit-logs, vault, rbac, fga, admin-portal, custom-domains, events, integrations, email, pipes, feature-flags, radar).
+
+**Exception**: Widget requests load the `workos-widgets` skill via the Skill tool — it has its own orchestration.
+
+**Disambiguation**: If user mentions BOTH a feature and "API", route to the feature topic file (it includes endpoints). If they mention MULTIPLE features, route to the MOST SPECIFIC one first (e.g., "SSO with MFA" → route to SSO; user can request MFA separately). If user mentions "FGA" or "fine-grained authorization", route to `workos-fga` — NOT `workos-rbac`. RBAC is org-level roles; FGA is resource-scoped roles on top of RBAC.
+
+**Special case — IdP group → role mapping**: If the user asks about mapping Entra / Azure AD / Okta / Google Workspace / SCIM / directory / SSO groups to WorkOS roles (regardless of exact phrasing), read BOTH `workos-rbac.md` AND the source-specific reference:
+
+- Directory Sync / SCIM / Google Workspace groups → also read `workos-directory-sync.md`
+- SSO-only groups → also read `workos-sso.md`
+
+Both files now have a canonical recipe. Do not answer from memory or paraphrase dashboard menu paths — the docs don't commit to exact click-paths, so neither should you. This mapping is **not** a WorkOS CLI operation; if asked for a CLI command, state that it's not in the CLI and link the docs.
+
+---
+
+### 4. AuthKit Installation
+
+**Triggers**: User mentions authentication setup, login flow, sign-up, session management, or explicitly says "AuthKit" WITHOUT mentioning a specific feature like SSO or MFA.
+
+**Action**: Detect framework and language using the priority-ordered checks below. Read the corresponding reference file.
+
+**Disambiguation**:
+
+- If user says "SSO login via AuthKit", route to `workos-sso` (#3) — feature wins over framework.
+- If user says "React login with Google", route to AuthKit React (#4) — this is AuthKit-level auth, not SSO API.
+- If user is ALREADY using AuthKit and wants to add a feature (e.g., "add MFA to my AuthKit app"), route to the feature reference (#3), not back to AuthKit installation.
+
+#### Framework Detection Priority (AuthKit only)
+
+Check in this exact order. First match wins:
+
+```
+1. `@tanstack/start` in package.json dependencies
+   → Read: references/workos-authkit-tanstack-start.md
+
+2. `@sveltejs/kit` in package.json dependencies
+   → Read: references/workos-authkit-sveltekit.md
+
+3. `react-router` or `react-router-dom` in package.json dependencies
+   → Read: references/workos-authkit-react-router.md
+
+4. `next.config.js` OR `next.config.mjs` OR `next.config.ts` exists in project root
+   → Read: references/workos-authkit-nextjs.md
+
+5. (`vite.config.js` OR `vite.config.ts` exists) AND `react` in package.json dependencies
+   → Read: references/workos-authkit-react.md
+
+6. NONE of the above detected
+   → Read: references/workos-authkit-vanilla-js.md
+```
+
+#### Language Detection (Backend SDKs)
+
+If the project is NOT a JavaScript/TypeScript frontend framework, check:
+
+```
+1. `pyproject.toml` OR `requirements.txt` OR `setup.py` exists
+   → Read: references/workos-python.md
+
+2. `go.mod` exists
+   → Read: references/workos-go.md
+
+3. `Gemfile` exists OR `config/routes.rb` exists
+   → Read: references/workos-ruby.md
+
+4. `composer.json` exists AND `laravel/framework` in dependencies
+   → Read: references/workos-php-laravel.md
+
+5. `composer.json` exists (without Laravel)
+   → Read: references/workos-php.md
+
+6. `*.csproj` OR `*.sln` exists
+   → Read: references/workos-dotnet.md
+
+7. `build.gradle.kts` OR `build.gradle` exists
+   → Read: references/workos-kotlin.md
+
+8. `mix.exs` exists
+   → Read: references/workos-elixir.md
+
+9. `package.json` exists with `express` / `fastify` / `hono` / `koa` (backend JS)
+   → Read: references/workos-node.md
+```
+
+**Why this order**: TanStack, SvelteKit, and React Router are MORE specific than Next.js/Vite+React. A project can have both Next.js AND React Router; in that case, React Router wins because it's more specific. Vanilla JS is the fallback when no framework is detected. Backend languages are checked when no frontend framework is found.
+
+**Edge case — multiple frameworks detected**: If you detect conflicting signals (e.g., both `next.config.js` and `@tanstack/start`), ASK the user which one they want to use. Do NOT guess.
+
+**Edge case — framework unclear from context**: If the user says "add login" but you cannot scan files (remote repo, no access), ASK: "Which framework/language are you using?" Do NOT default without confirmation.
+
+---
+
+### 5. Integration Setup
+
+**Triggers**: User mentions connecting to external IdPs, configuring third-party integrations, or asks "how do I integrate with [provider]".
+
+**Action**: Read `references/workos-integrations.md`.
+
+**Why separate from SSO**: SSO covers the authentication flow; Integrations covers IdP configuration and connection setup. If user mentions BOTH ("set up Google SSO"), route to SSO (#3) — it will reference Integrations where needed.
+
+---
+
+### 6. Management / CLI Operations
+
+**Triggers**: User mentions managing WorkOS resources (organizations, users, roles, permissions), seeding data, or CLI management commands.
+
+**Action**: Read `references/workos-management.md`.
+
+**Sub-case — CLI upgrade**: If the user reports an outdated `workos` CLI (`workos --version` shows an old release, `unknown command` errors after following recent docs, or asks "how do I update the workos CLI?"), read `references/workos-cli-upgrade.md` instead. Do NOT guess the latest version — that file tells you to instruct the user to run `npm view workos version`.
+
+---
+
+### 7. Vague or General Request
+
+**Triggers**: User says "help with WorkOS", "WorkOS setup", "what can WorkOS do", or provides no feature-specific context.
+
+**Action**:
+
+1. WebFetch https://workos.com/docs/llms.txt
+2. Scan the index for the section that best matches the user's likely intent
+3. WebFetch the specific section URL
+4. Summarize capabilities and ASK the user what they want to accomplish
+
+**Do NOT guess a feature** — force disambiguation by showing options.
+
+---
+
+### 8. No Match / Ambiguous
+
+**Triggers**: None of the above rules match, OR the request is genuinely ambiguous.
+
+**Action**:
+
+1. WebFetch https://workos.com/docs/llms.txt
+2. Search the index for keywords from the user's request
+3. If you find a match, WebFetch that section URL and proceed
+4. If NO match, respond: "I couldn't find a WorkOS feature matching '[user's term]'. Could you clarify? For example: authentication, SSO, MFA, directory sync, audit logs, etc."
+
+---
+
+## Edge Cases
+
+### User mentions multiple features
+
+Route to the MOST SPECIFIC reference first. Example: "SSO with MFA and directory sync" → route to `workos-sso` first. After completing SSO setup, the user can request MFA and Directory Sync separately.
+
+### User mentions a feature + API reference
+
+Route to the feature topic file — it includes an endpoint table. Example: "SSO API endpoints" → `workos-sso.md`.
+
+### User wants to ADD a feature to an existing AuthKit setup
+
+Route to the feature reference (#3), not back to AuthKit installation. Example: "I'm using AuthKit in Next.js and want to add SSO" → `workos-sso.md`.
+
+### User mentions a provider but no feature
+
+Route to Integrations (#5). Example: "How do I connect Okta?" → `workos-integrations.md`.
+
+### User mentions a provider AND a feature
+
+Route to the feature reference (#3). Example: "Set up Okta SSO" → `workos-sso.md` (it will reference Integrations for Okta setup).
+
+### Unknown framework for AuthKit
+
+If you cannot detect framework and the user hasn't specified, ASK: "Which framework/language are you using?" Do NOT default without confirmation.
+
+### Framework conflicts (multiple frameworks detected)
+
+If detection finds conflicting signals (e.g., both Next.js and TanStack Start configs), ASK: "I see both [framework A] and [framework B]. Which one do you want to use for AuthKit?"
+
+### User provides no context at all
+
+Follow step #7 (Vague or General Request): fetch llms.txt, show options, and force disambiguation.

--- a/.claude/skills/workos/evals/evals.json
+++ b/.claude/skills/workos/evals/evals.json
@@ -1,0 +1,457 @@
+{
+  "skill_name": "workos",
+  "evals": [
+    {
+      "id": 0,
+      "name": "initiate-login-uri-lookup",
+      "prompt": "I'm configuring an OIDC-style integration and saw the term `initiate_login_uri` mentioned. I'm using WorkOS AuthKit. What exactly is this and where do I actually configure it? Give me the canonical docs URL so I can read more. Keep the answer tight.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Mentions Sign-in endpoint as the WorkOS-side term for this concept",
+          "kind": "content_contains_any",
+          "needles": ["Sign-in endpoint", "sign-in endpoint", "Sign-In endpoint"]
+        },
+        {
+          "text": "Points to Dashboard → Redirects as the config location",
+          "kind": "content_contains_all",
+          "needles": ["Dashboard", "Redirects"]
+        },
+        {
+          "text": "Cites an actual workos.com/docs URL (not llms.txt)",
+          "kind": "content_contains_any",
+          "needles": ["workos.com/docs/authkit", "workos.com/docs/sso", "workos.com/docs/reference"]
+        },
+        {
+          "text": "Does NOT invent a URL like /docs/initiate-login-uri",
+          "kind": "content_contains_none",
+          "needles": [
+            "/docs/initiate-login-uri",
+            "/docs/initiate_login_uri",
+            "/docs/oidc/initiate-login-uri",
+            "/docs/reference/initiate_login_uri"
+          ]
+        },
+        {
+          "text": "Does NOT use llms.txt as the primary source",
+          "kind": "content_contains_none",
+          "needles": ["fetch llms.txt", "fetched llms.txt", "from llms.txt"]
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "sign-in-endpoint-lookup",
+      "prompt": "I'm staring at the WorkOS Dashboard and I see a field called 'Sign-in endpoint' in the Redirects section. What IS this exactly — why does WorkOS need it if I'm already passing a Redirect URI? Link me to the canonical docs page.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Distinguishes Sign-in endpoint from Redirect URI",
+          "kind": "content_contains_all",
+          "needles": ["Sign-in endpoint", "Redirect URI"]
+        },
+        {
+          "text": "Explains the bookmark / password-reset use case",
+          "kind": "content_contains_any",
+          "needles": [
+            "bookmark",
+            "password reset",
+            "password-reset",
+            "did not originate",
+            "didn't originate",
+            "originate from your app"
+          ]
+        },
+        {
+          "text": "Cites a workos.com/docs URL",
+          "kind": "content_contains_any",
+          "needles": ["workos.com/docs/authkit", "workos.com/docs/reference"]
+        },
+        {
+          "text": "Does NOT invent /docs/sign-in-endpoint",
+          "kind": "content_contains_none",
+          "needles": ["/docs/sign-in-endpoint", "/docs/authkit/sign-in-endpoint", "/docs/reference/sign-in-endpoint"]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "cookie-password-lookup",
+      "prompt": "My WorkOS AuthKit app is throwing an error about `WORKOS_COOKIE_PASSWORD` being invalid. What is this env var, what are the requirements (length, format), how do I generate a valid one, and where are the official docs?",
+      "files": [],
+      "assertions": [
+        {
+          "text": "States the 32+ character requirement",
+          "kind": "content_contains_any",
+          "needles": ["32+ character", "32+ chars", "32 characters", "at least 32", "minimum 32", "32-character"]
+        },
+        {
+          "text": "Shows how to generate one with openssl",
+          "kind": "content_contains_all",
+          "needles": ["openssl", "rand"]
+        },
+        {
+          "text": "Mentions session cookie encryption / sealing",
+          "kind": "content_contains_any",
+          "needles": ["seal", "encrypt", "session cookie"]
+        },
+        { "text": "Cites a workos.com/docs URL", "kind": "content_contains_any", "needles": ["workos.com/docs"] }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "org-vs-connection-id",
+      "prompt": "For my SSO integration I see both Organization ID and Connection ID as options when generating an authorization URL. What's the actual difference, and which one should I pass to getAuthorizationUrl in typical multi-tenant B2B setup? Docs link please.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Recommends Organization ID for multi-tenant B2B",
+          "kind": "content_contains_any",
+          "needles": ["Organization ID", "organizationId", "organization_id"]
+        },
+        {
+          "text": "Explains what Connection ID is and when to use it",
+          "kind": "content_contains_any",
+          "needles": ["Connection ID", "connectionId", "connection_id"]
+        },
+        {
+          "text": "Explains why Organization ID is preferred (connection routing)",
+          "kind": "content_contains_any",
+          "needles": [
+            "group of users",
+            "preferred",
+            "typically",
+            "let the org",
+            "org can pick",
+            "active connection",
+            "specific connection"
+          ]
+        },
+        {
+          "text": "Cites a workos.com/docs URL",
+          "kind": "content_contains_any",
+          "needles": ["workos.com/docs/sso", "workos.com/docs/authkit", "workos.com/docs/reference"]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "entra-directory-group-to-role-mapping",
+      "prompt": "We use Entra ID (Azure AD) with WorkOS Directory Sync and I need to map our Entra groups to WorkOS roles — for example the 'Engineering' Entra group should get the 'developer' role. How do I set this up? Docs link too.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Identifies Directory Sync as the source (not SSO)",
+          "kind": "content_contains_any",
+          "needles": ["Directory Sync", "directory sync", "SCIM"]
+        },
+        {
+          "text": "Cites the Directory Sync IdP role assignment docs URL",
+          "kind": "content_contains_any",
+          "needles": ["workos.com/docs/directory-sync/identity-provider-role-assignment"]
+        },
+        {
+          "text": "Says roles must be configured first",
+          "kind": "content_contains_any",
+          "needles": [
+            "Configure roles first",
+            "configure roles first",
+            "roles are configured",
+            "Once roles are configured",
+            "create the role",
+            "create the roles",
+            "roles first"
+          ]
+        },
+        {
+          "text": "Mentions Admin Portal or WorkOS Dashboard as the config surface",
+          "kind": "content_contains_any",
+          "needles": ["Admin Portal", "WorkOS Dashboard", "WorkOS dashboard", "dashboard.workos.com"]
+        },
+        {
+          "text": "Does NOT invent a workos CLI command for this operation",
+          "kind": "content_contains_none",
+          "needles": [
+            "workos roles map",
+            "workos role-mapping",
+            "workos rbac map",
+            "workos directory roles",
+            "workos directory-sync map",
+            "workos groups map",
+            "workos map-group"
+          ]
+        },
+        {
+          "text": "Does NOT invent a specific click-path in the Dashboard",
+          "kind": "content_contains_none",
+          "needles": [
+            "Dashboard > Organizations > ",
+            "Dashboard → Organizations →",
+            "Organizations tab > Roles tab > Map Groups",
+            "Organizations → Roles → Map"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "where-in-dashboard-group-role-mapping",
+      "prompt": "Where in the WorkOS Dashboard do I configure the mapping from directory groups to roles? Point me at the exact page. If there's an official docs page for this give me the URL.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Cites the canonical docs URL",
+          "kind": "content_contains_any",
+          "needles": [
+            "workos.com/docs/directory-sync/identity-provider-role-assignment",
+            "workos.com/docs/rbac/idp-role-assignment",
+            "workos.com/docs/rbac/integration"
+          ]
+        },
+        {
+          "text": "Mentions Admin Portal as where the mapping happens, or the directory page",
+          "kind": "content_contains_any",
+          "needles": ["Admin Portal", "directory page", "Authorization page", "Authorization"]
+        },
+        {
+          "text": "Does NOT fabricate a dashboard.workos.com/... deep link",
+          "kind": "content_contains_none",
+          "needles": [
+            "dashboard.workos.com/organizations/",
+            "dashboard.workos.com/directory/",
+            "dashboard.workos.com/rbac",
+            "dashboard.workos.com/roles/",
+            "dashboard.workos.com/group-mappings"
+          ]
+        },
+        {
+          "text": "Does NOT invent a specific click-path in the Dashboard",
+          "kind": "content_contains_none",
+          "needles": [
+            "Dashboard > Organizations > ",
+            "Dashboard → Organizations →",
+            "Click Organizations, then Roles, then Map Groups",
+            "Organizations → Roles → Map"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "cli-group-role-mapping-not-supported",
+      "prompt": "Is there a `workos` CLI command to map Directory Sync groups to WorkOS roles? I'd rather script this than click through the dashboard.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "States that the WorkOS CLI does NOT support this operation",
+          "kind": "content_contains_any",
+          "needles": [
+            "not in the CLI",
+            "not supported in the CLI",
+            "not a CLI",
+            "not configurable via the CLI",
+            "CLI does not support",
+            "no CLI command",
+            "no workos CLI command",
+            "the WorkOS CLI doesn't",
+            "the WorkOS CLI does not"
+          ]
+        },
+        {
+          "text": "Points to the Dashboard / Admin Portal / docs as the correct place",
+          "kind": "content_contains_any",
+          "needles": [
+            "Admin Portal",
+            "WorkOS Dashboard",
+            "WorkOS dashboard",
+            "workos.com/docs/directory-sync/identity-provider-role-assignment",
+            "workos.com/docs/rbac/idp-role-assignment"
+          ]
+        },
+        {
+          "text": "Does NOT invent a workos CLI command for this operation",
+          "kind": "content_contains_none",
+          "needles": [
+            "workos roles map",
+            "workos role-mapping",
+            "workos rbac map",
+            "workos directory roles",
+            "workos directory-sync map",
+            "workos groups map",
+            "workos map-group",
+            "workos group-mapping"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "name": "api-role-assignment-overridden-by-idp",
+      "prompt": "I called `updateOrganizationMembership` to set a user's role to 'admin' and it worked, but next time they log in the role flips back to 'developer'. What's happening and how do I fix it?",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Identifies IdP role assignment precedence as the cause",
+          "kind": "content_contains_any",
+          "needles": [
+            "IdP role assignment",
+            "IdP mapping",
+            "identity provider role assignment",
+            "directory group role assignment",
+            "SSO group role assignment",
+            "takes precedence",
+            "take precedence",
+            "override"
+          ]
+        },
+        {
+          "text": "Points user to change the mapping at the IdP / directory / Admin Portal instead",
+          "kind": "content_contains_any",
+          "needles": ["Admin Portal", "directory", "directory group", "IdP", "identity provider", "mapping"]
+        },
+        {
+          "text": "Cites the canonical docs URL for precedence",
+          "kind": "content_contains_any",
+          "needles": [
+            "workos.com/docs/rbac/integration",
+            "workos.com/docs/rbac/idp-role-assignment",
+            "workos.com/docs/directory-sync/identity-provider-role-assignment"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "name": "sso-connection-create-not-in-cli",
+      "prompt": "How do I create a new SSO connection for one of my organizations using the `workos` CLI? Give me the exact command.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "States connection creation is NOT in the CLI",
+          "kind": "content_contains_any",
+          "needles": [
+            "not in the CLI",
+            "not supported in the CLI",
+            "CLI doesn't support",
+            "CLI does not support",
+            "no CLI command",
+            "cannot be created from the CLI"
+          ]
+        },
+        {
+          "text": "Points at portal generate-link OR the Admin Portal / Dashboard as the right place",
+          "kind": "content_contains_any",
+          "needles": ["portal generate-link", "Admin Portal", "WorkOS Dashboard", "WorkOS dashboard"]
+        },
+        {
+          "text": "Does NOT invent a creation command",
+          "kind": "content_contains_none",
+          "needles": [
+            "workos connection create",
+            "workos sso create",
+            "workos sso connection create",
+            "workos connections create"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "name": "directory-connection-create-not-in-cli",
+      "prompt": "I need to create a new Directory Sync connection for my organization. What's the workos CLI command for that?",
+      "files": [],
+      "assertions": [
+        {
+          "text": "States connection creation is NOT in the CLI",
+          "kind": "content_contains_any",
+          "needles": [
+            "not in the CLI",
+            "not supported in the CLI",
+            "CLI doesn't support",
+            "CLI does not support",
+            "no CLI command",
+            "cannot be created from the CLI"
+          ]
+        },
+        {
+          "text": "Points at portal generate-link OR the Admin Portal / Dashboard as the right place",
+          "kind": "content_contains_any",
+          "needles": ["portal generate-link", "Admin Portal", "WorkOS Dashboard", "WorkOS dashboard", "dsync"]
+        },
+        {
+          "text": "Does NOT invent a creation command",
+          "kind": "content_contains_none",
+          "needles": [
+            "workos directory create",
+            "workos directory-sync create",
+            "workos dsync create",
+            "workos directories create"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "name": "cli-surface-area-verification",
+      "prompt": "Before you answer: I want to know whether the `workos` CLI has a command to update a user's role assignment rules. If yes give me the command; if no, tell me how you verified it's not there.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "References workos --help --json as the verification source",
+          "kind": "content_contains_any",
+          "needles": ["workos --help --json", "--help --json", "help --json"]
+        },
+        {
+          "text": "Does NOT fabricate a role-rule command",
+          "kind": "content_contains_none",
+          "needles": ["workos role-rule", "workos role-rules", "workos role assignment-rule", "workos role rule"]
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "name": "cli-upgrade-recommendation",
+      "prompt": "I just ran `workos --version` and it printed 0.10.0. The docs reference a command that errors with `unknown command` when I run it. What do I do — I want the upgrade command and a way to confirm what the latest version actually is.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Tells the user to check the latest version via npm view rather than guessing",
+          "kind": "content_contains_any",
+          "needles": ["npm view workos version", "npm view workos", "npm view workos dist-tags"]
+        },
+        {
+          "text": "Provides at least one concrete upgrade command using @latest (npm/pnpm or npx)",
+          "kind": "content_contains_any",
+          "needles": [
+            "npm install -g workos@latest",
+            "pnpm add -g workos@latest",
+            "npx workos@latest",
+            "pnpm dlx workos"
+          ]
+        },
+        {
+          "text": "Does NOT pin to a fabricated version number (signals the agent invented 'the latest')",
+          "kind": "content_contains_none",
+          "needles": [
+            "workos@0.11",
+            "workos@0.12",
+            "workos@0.13",
+            "workos@0.14",
+            "workos@1.0",
+            "latest is 0.11",
+            "latest is 0.12",
+            "latest is 0.13",
+            "latest is 0.14",
+            "latest version is 0.1",
+            "latest version is 1.0",
+            "current latest: 0.",
+            "currently 0.11",
+            "currently 0.12",
+            "currently 0.13",
+            "currently 0.14"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/workos/references/workos-admin-portal.md
+++ b/.claude/skills/workos/references/workos-admin-portal.md
@@ -1,0 +1,30 @@
+# WorkOS Admin Portal
+
+## Docs
+
+- https://workos.com/docs/admin-portal/index
+- https://workos.com/docs/admin-portal/example-apps
+- https://workos.com/docs/admin-portal/custom-branding
+- https://workos.com/docs/reference/admin-portal
+- https://workos.com/docs/reference/admin-portal/portal-link
+- https://workos.com/docs/reference/admin-portal/portal-link/generate
+- https://workos.com/docs/reference/admin-portal/provider-icons
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Portal links are single-use and time-limited. Visiting an expired or already-used link returns 404. Must generate a new link each time.
+- Do NOT email portal links directly from your backend. Links are exposed in email logs. Instead, store the link and have your app's settings page redirect to it.
+- The `intent` parameter determines which configuration screens appear. It cannot be changed after link generation — must generate a new link for a different intent.
+- Only one active portal link exists per organization at a time. Revoke the old one before generating a new one.
+- Domain verification may be required before SSO activation. Some configurations need DNS TXT records or email verification first.
+- API key must start with `sk_` (secret key). Using `pk_` (publishable key) returns "Unauthorized."
+
+## Endpoints
+
+| Endpoint                | Description                           |
+| ----------------------- | ------------------------------------- |
+| `/admin-portal`         | admin-portal                          |
+| `/portal-link`          | admin-portal - portal-link            |
+| `/portal-link/generate` | admin-portal - portal-link - generate |
+| `/provider-icons`       | admin-portal - provider-icons         |

--- a/.claude/skills/workos/references/workos-api-authkit.md
+++ b/.claude/skills/workos/references/workos-api-authkit.md
@@ -1,0 +1,104 @@
+# WorkOS AuthKit API Reference
+
+## Docs
+
+- https://workos.com/docs/reference/authkit
+- https://workos.com/docs/reference/authkit/api-keys
+- https://workos.com/docs/reference/authkit/api-keys/create-for-organization
+- https://workos.com/docs/reference/authkit/api-keys/delete
+- https://workos.com/docs/reference/authkit/api-keys/list-for-organization
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+(none yet — add as discovered)
+
+## Endpoints
+
+| Endpoint                                                            | Description                                                                      |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `/authkit`                                                          | authkit                                                                          |
+| `/api-keys`                                                         | authkit - api-keys                                                               |
+| `/api-keys/create-for-organization`                                 | authkit - api-keys - create-for-organization                                     |
+| `/api-keys/delete`                                                  | authkit - api-keys - delete                                                      |
+| `/api-keys/list-for-organization`                                   | authkit - api-keys - list-for-organization                                       |
+| `/api-keys/validate`                                                | Validate an API key and retrieve associated metadata.                            |
+| `/authentication`                                                   | authkit - authentication                                                         |
+| `/authentication-errors`                                            | authkit - authentication-errors                                                  |
+| `/authentication-errors/email-verification-required-error`          | authkit - authentication-errors - email-verification-required-error              |
+| `/authentication-errors/mfa-challenge-error`                        | authkit - authentication-errors - mfa-challenge-error                            |
+| `/authentication-errors/mfa-enrollment-error`                       | authkit - authentication-errors - mfa-enrollment-error                           |
+| `/authentication-errors/organization-authentication-required-error` | authkit - authentication-errors - organization-authentication-required-error     |
+| `/authentication-errors/organization-selection-error`               | authkit - authentication-errors - organization-selection-error                   |
+| `/authentication-errors/sso-required-error`                         | authkit - authentication-errors - sso-required-error                             |
+| `/authentication/code`                                              | authkit - authentication - code                                                  |
+| `/authentication/email-verification`                                | authkit - authentication - email-verification                                    |
+| `/authentication/get-authorization-url`                             | authkit - authentication - get-authorization-url                                 |
+| `/authentication/get-authorization-url/error-codes`                 | authkit - authentication - get-authorization-url - error-codes                   |
+| `/authentication/get-authorization-url/pkce`                        | authkit - authentication - get-authorization-url - pkce                          |
+| `/authentication/get-authorization-url/redirect-uri`                | authkit - authentication - get-authorization-url - redirect-uri                  |
+| `/authentication/magic-auth`                                        | authkit - authentication - magic-auth                                            |
+| `/authentication/organization-selection`                            | authkit - authentication - organization-selection                                |
+| `/authentication/password`                                          | authkit - authentication - password                                              |
+| `/authentication/refresh-and-seal-session-data`                     | authkit - authentication - refresh-and-seal-session-data                         |
+| `/authentication/refresh-token`                                     | authkit - authentication - refresh-token                                         |
+| `/authentication/session-cookie`                                    | authkit - authentication - session-cookie                                        |
+| `/authentication/totp`                                              | authkit - authentication - totp                                                  |
+| `/cli-auth`                                                         | authkit - cli-auth                                                               |
+| `/cli-auth/device-authorization`                                    | Initiate the CLI Auth flow by obtaining a device code and verification URLs.     |
+| `/cli-auth/device-code`                                             | Exchange a device code for access and refresh tokens during the CLI Auth flow.   |
+| `/cli-auth/error-codes`                                             | authkit - cli-auth - error-codes                                                 |
+| `/email-verification`                                               | authkit - email-verification                                                     |
+| `/email-verification/get`                                           | authkit - email-verification - get                                               |
+| `/identity`                                                         | authkit - identity                                                               |
+| `/identity/list`                                                    | authkit - identity - list                                                        |
+| `/invitation`                                                       | authkit - invitation                                                             |
+| `/invitation/accept`                                                | authkit - invitation - accept                                                    |
+| `/invitation/find-by-token`                                         | authkit - invitation - find-by-token                                             |
+| `/invitation/get`                                                   | authkit - invitation - get                                                       |
+| `/invitation/list`                                                  | authkit - invitation - list                                                      |
+| `/invitation/resend`                                                | authkit - invitation - resend                                                    |
+| `/invitation/revoke`                                                | authkit - invitation - revoke                                                    |
+| `/invitation/send`                                                  | authkit - invitation - send                                                      |
+| `/logout`                                                           | authkit - logout                                                                 |
+| `/logout/get-logout-url`                                            | authkit - logout - get-logout-url                                                |
+| `/logout/get-logout-url-from-session-cookie`                        | authkit - logout - get-logout-url-from-session-cookie                            |
+| `/magic-auth`                                                       | authkit - magic-auth                                                             |
+| `/magic-auth/create`                                                | authkit - magic-auth - create                                                    |
+| `/magic-auth/get`                                                   | authkit - magic-auth - get                                                       |
+| `/mfa`                                                              | Enroll users in multi-factor authentication for an additional layer of security. |
+| `/mfa/authentication-challenge`                                     | authkit - mfa - authentication-challenge                                         |
+| `/mfa/authentication-factor`                                        | authkit - mfa - authentication-factor                                            |
+| `/mfa/enroll-auth-factor`                                           | authkit - mfa - enroll-auth-factor                                               |
+| `/mfa/list-auth-factors`                                            | authkit - mfa - list-auth-factors                                                |
+| `/organization-membership`                                          | authkit - organization-membership                                                |
+| `/organization-membership/create`                                   | authkit - organization-membership - create                                       |
+| `/organization-membership/deactivate`                               | authkit - organization-membership - deactivate                                   |
+| `/organization-membership/delete`                                   | authkit - organization-membership - delete                                       |
+| `/organization-membership/get`                                      | authkit - organization-membership - get                                          |
+| `/organization-membership/list`                                     | authkit - organization-membership - list                                         |
+| `/organization-membership/reactivate`                               | authkit - organization-membership - reactivate                                   |
+| `/organization-membership/update`                                   | authkit - organization-membership - update                                       |
+| `/password-reset`                                                   | authkit - password-reset                                                         |
+| `/password-reset/create`                                            | authkit - password-reset - create                                                |
+| `/password-reset/get`                                               | authkit - password-reset - get                                                   |
+| `/password-reset/reset-password`                                    | authkit - password-reset - reset-password                                        |
+| `/session`                                                          | authkit - session                                                                |
+| `/session-helpers`                                                  | session-helpers                                                                  |
+| `/session-helpers/authenticate`                                     | authkit - session-helpers - authenticate                                         |
+| `/session-helpers/get-logout-url`                                   | authkit - session-helpers - get-logout-url                                       |
+| `/session-helpers/load-sealed-session`                              | authkit - session-helpers - load-sealed-session                                  |
+| `/session-helpers/refresh`                                          | authkit - session-helpers - refresh                                              |
+| `/session-tokens`                                                   | authkit - session-tokens                                                         |
+| `/session-tokens/access-token`                                      | authkit - session-tokens - access-token                                          |
+| `/session-tokens/jwks`                                              | authkit - session-tokens - jwks                                                  |
+| `/session-tokens/refresh-token`                                     | authkit - session-tokens - refresh-token                                         |
+| `/session/list`                                                     | authkit - session - list                                                         |
+| `/session/revoke`                                                   | authkit - session - revoke                                                       |
+| `/user`                                                             | authkit - user                                                                   |
+| `/user/create`                                                      | authkit - user - create                                                          |
+| `/user/delete`                                                      | authkit - user - delete                                                          |
+| `/user/get`                                                         | authkit - user - get                                                             |
+| `/user/get-by-external-id`                                          | authkit - user - get-by-external-id                                              |
+| `/user/list`                                                        | authkit - user - list                                                            |
+| `/user/update`                                                      | authkit - user - update                                                          |

--- a/.claude/skills/workos/references/workos-api-organization.md
+++ b/.claude/skills/workos/references/workos-api-organization.md
@@ -1,0 +1,26 @@
+# WorkOS Organizations API Reference
+
+## Docs
+
+- https://workos.com/docs/reference/organization
+- https://workos.com/docs/reference/organization/create
+- https://workos.com/docs/reference/organization/delete
+- https://workos.com/docs/reference/organization/get
+- https://workos.com/docs/reference/organization/get-by-external-id
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+(none yet — add as discovered)
+
+## Endpoints
+
+| Endpoint              | Description                       |
+| --------------------- | --------------------------------- |
+| `/organization`       | organization                      |
+| `/create`             | organization - create             |
+| `/delete`             | organization - delete             |
+| `/get`                | organization - get                |
+| `/get-by-external-id` | organization - get-by-external-id |
+| `/list`               | organization - list               |
+| `/update`             | organization - update             |

--- a/.claude/skills/workos/references/workos-audit-logs.md
+++ b/.claude/skills/workos/references/workos-audit-logs.md
@@ -1,0 +1,43 @@
+# WorkOS Audit Logs
+
+## Docs
+
+- https://workos.com/docs/audit-logs/metadata-schema
+- https://workos.com/docs/audit-logs/log-streams
+- https://workos.com/docs/audit-logs/index
+- https://workos.com/docs/audit-logs/exporting-events
+- https://workos.com/docs/audit-logs/editing-events
+- https://workos.com/docs/audit-logs/admin-portal
+- https://workos.com/docs/reference/audit-logs
+- https://workos.com/docs/reference/audit-logs/configuration
+- https://workos.com/docs/reference/audit-logs/event
+- https://workos.com/docs/reference/audit-logs/event/create
+- https://workos.com/docs/reference/audit-logs/export
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Event type naming MUST follow `{group}.{object}.{action}` convention (e.g., `user.account.created`). Flat names like `shareCreated` are rejected.
+- Metadata limits: 50 keys max per metadata object, 40 chars per key name, 500 chars per value. Exceeding silently truncates or fails.
+- Log Streams to customer SIEMs via HTTP POST require IP allowlisting. WorkOS US egress IPs: `3.217.146.166`, `23.21.184.92`, `34.204.154.149`, `44.213.245.178`, `44.215.236.82`, `50.16.203.9`. EU region uses different IPs — check docs.
+- If metadata schema validation is enabled in the Dashboard, events that don't match the JSON Schema are rejected. Disable temporarily if blocking deployment.
+- Log Stream must show "Active" status in Dashboard to deliver events. Credential or network issues silently stop delivery without failing the event creation call.
+
+## Endpoints
+
+| Endpoint               | Description                        |
+| ---------------------- | ---------------------------------- |
+| `/audit-logs`          | audit-logs                         |
+| `/configuration`       | audit-logs - configuration         |
+| `/event`               | audit-logs - event                 |
+| `/event/create`        | audit-logs - event - create        |
+| `/export`              | audit-logs - export                |
+| `/export/create`       | audit-logs - export - create       |
+| `/export/get`          | audit-logs - export - get          |
+| `/retention`           | audit-logs - retention             |
+| `/retention/get`       | audit-logs - retention - get       |
+| `/retention/set`       | audit-logs - retention - set       |
+| `/schema`              | audit-logs - schema                |
+| `/schema/create`       | audit-logs - schema - create       |
+| `/schema/list`         | audit-logs - schema - list         |
+| `/schema/list-actions` | audit-logs - schema - list-actions |

--- a/.claude/skills/workos/references/workos-authkit-base.md
+++ b/.claude/skills/workos/references/workos-authkit-base.md
@@ -1,0 +1,131 @@
+# WorkOS AuthKit Base Template
+
+## First Action: Fetch README
+
+Before any implementation, fetch the framework-specific README:
+
+```
+WebFetch: {sdk-package-name} README from npmjs.com or GitHub
+```
+
+README is the source of truth for: install commands, imports, API usage, code patterns.
+
+## Task Structure (Required)
+
+| Phase | Task      | Blocked By         | Purpose                           |
+| ----- | --------- | ------------------ | --------------------------------- |
+| 1     | preflight | -                  | Verify env vars, detect framework |
+| 2     | install   | preflight          | Install SDK package               |
+| 3     | callback  | install            | Create OAuth callback route       |
+| 4     | provider  | install            | Setup auth context/middleware     |
+| 5     | ui        | callback, provider | Add sign-in/out UI                |
+| 6     | verify    | ui                 | Build confirmation                |
+
+## Server-Side Auth Flow
+
+For Rails, Flask, Sinatra, Express, or any other server-rendered app, keep this order explicit:
+
+This is the runtime login sequence inside the `callback` and `provider` implementation phases above; it does not replace the task order table.
+
+1. Configure the WorkOS SDK with `WORKOS_API_KEY` and `WORKOS_CLIENT_ID`.
+2. Generate the authorization URL for login with the AuthKit provider and `redirect_uri`.
+3. Redirect the user to that authorization URL.
+4. Handle the callback route by exchanging `code` with the SDK.
+5. Store the returned user profile in the app session.
+6. Implement logout by clearing the app session and redirecting the user.
+
+## Decision Trees
+
+### Package Manager Detection
+
+```
+pnpm-lock.yaml? → pnpm
+yarn.lock? → yarn
+bun.lockb? → bun
+else → npm
+```
+
+### Provider vs Middleware
+
+```
+Client-side framework? → AuthKitProvider wraps app
+Server-side framework? → Middleware handles sessions
+Hybrid (Next.js)? → Both may be needed
+```
+
+### Callback Route Location
+
+Extract path from `WORKOS_REDIRECT_URI` → create route at that exact path.
+
+## Environment Variables
+
+| Variable                 | Purpose                        | When Required |
+| ------------------------ | ------------------------------ | ------------- |
+| `WORKOS_API_KEY`         | Server authentication          | Server SDKs   |
+| `WORKOS_CLIENT_ID`       | Client identification          | All SDKs      |
+| `WORKOS_REDIRECT_URI`    | OAuth callback URL             | Server SDKs   |
+| `WORKOS_COOKIE_PASSWORD` | Session encryption (32+ chars) | Server SDKs   |
+
+Note: Some frameworks use prefixed variants (e.g., `NEXT_PUBLIC_*`). Check README.
+
+## Verification Checklists
+
+### After Install
+
+- [ ] SDK package installed in node_modules
+- [ ] No install errors in output
+
+### After Callback Route
+
+- [ ] Route file exists at path matching `WORKOS_REDIRECT_URI`
+- [ ] Imports SDK callback handler (not custom OAuth)
+
+### After Provider/Middleware
+
+- [ ] Provider wraps entire app (client-side)
+- [ ] Middleware configured in correct location (server-side)
+
+### After UI
+
+- [ ] Home page shows conditional auth state
+- [ ] Uses SDK functions for sign-in/out URLs
+
+### Final Verification
+
+- [ ] Build completes with exit code 0
+- [ ] No import resolution errors
+
+## Error Recovery
+
+### Module not found
+
+- [ ] Verify install completed successfully
+- [ ] Verify SDK exists in node_modules
+- [ ] Re-run install if missing
+
+### Build import errors
+
+- [ ] Delete `node_modules`, reinstall
+- [ ] Verify package.json has SDK dependency
+
+### Invalid redirect URI
+
+- [ ] Compare route path to `WORKOS_REDIRECT_URI`
+- [ ] Paths must match exactly
+
+### Cookie password error
+
+- [ ] Verify `WORKOS_COOKIE_PASSWORD` is 32+ characters
+- [ ] Generate new: `openssl rand -base64 32`
+
+### Auth state not persisting
+
+- [ ] Verify provider wraps entire app
+- [ ] Check middleware is in correct location
+
+## Critical Rules
+
+1. **Install SDK before writing imports** - never create import statements for uninstalled packages
+2. **Use SDK functions** - never construct OAuth URLs manually
+3. **Follow README patterns** - SDK APIs change between versions
+4. **Extract callback path from env** - don't hardcode `/auth/callback`

--- a/.claude/skills/workos/references/workos-authkit-nextjs.md
+++ b/.claude/skills/workos/references/workos-authkit-nextjs.md
@@ -1,0 +1,332 @@
+# WorkOS AuthKit for Next.js
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/authkit-nextjs/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `next.config.js` or `next.config.mjs` exists
+- Confirm `package.json` contains `"next"` dependency
+
+### Environment Variables
+
+Check `.env.local` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `NEXT_PUBLIC_WORKOS_REDIRECT_URI` - valid callback URL
+- `WORKOS_COOKIE_PASSWORD` - 32+ characters
+
+## Step 3: Install SDK
+
+Detect package manager, install SDK package from README.
+
+**Verify:** SDK package exists in node_modules before continuing.
+
+## Step 4: Locate the app/ directory (BLOCKING)
+
+**STOP. Do this before creating any files.**
+
+Determine where the `app/` directory lives:
+
+```bash
+# Check for src/app/ first, then root app/
+ls src/app/ 2>/dev/null && echo "APP_DIR=src" || (ls app/ 2>/dev/null && echo "APP_DIR=root")
+```
+
+Set `APP_DIR` for all subsequent steps. All middleware/proxy files MUST be created in `APP_DIR`:
+
+- If `APP_DIR=src` → create files in `src/` (e.g., `src/proxy.ts`)
+- If `APP_DIR=root` → create files at project root (e.g., `proxy.ts`)
+
+Next.js only discovers middleware/proxy files in the parent directory of `app/`. A file at the wrong level is **silently ignored** — no error, just doesn't run.
+
+## Step 5: Version Detection (Decision Tree)
+
+Read Next.js version from `package.json`:
+
+```
+Next.js version?
+  |
+  +-- 16+ --> Create {APP_DIR}/proxy.ts
+  |
+  +-- 15   --> Create {APP_DIR}/middleware.ts (cookies() is async)
+  |
+  +-- 13-14 --> Create {APP_DIR}/middleware.ts (cookies() is sync)
+```
+
+**Next.js 16+ proxy.ts:** `proxy.ts` is the preferred convention. `middleware.ts` still works but shows a deprecation warning. Next.js 16 throws **error E900** if both files exist at the same level.
+
+**Next.js 15+ async note:** All route handlers and middleware accessing cookies must be async and properly await cookie operations. This is a breaking change from Next.js 14.
+
+Middleware/proxy code: See README for `authkitMiddleware()` export pattern.
+
+### Existing Middleware (IMPORTANT)
+
+If `middleware.ts` already exists with custom logic (rate limiting, logging, headers, etc.), use the **`authkit()` composable function** instead of `authkitMiddleware`.
+
+**Pattern for composing with existing middleware:**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { authkit, handleAuthkitHeaders } from '@workos-inc/authkit-nextjs';
+
+export default async function middleware(request: NextRequest) {
+  // 1. Get auth session and headers from AuthKit
+  const { session, headers, authorizationUrl } = await authkit(request);
+  const { pathname } = request.nextUrl;
+
+  // 2. === YOUR EXISTING MIDDLEWARE LOGIC ===
+  // Rate limiting, logging, custom headers, etc.
+  const rateLimitResult = checkRateLimit(request);
+  if (!rateLimitResult.allowed) {
+    return new NextResponse('Too Many Requests', { status: 429 });
+  }
+
+  // 3. Protect routes - redirect to auth if needed
+  if (pathname.startsWith('/dashboard') && !session.user && authorizationUrl) {
+    return handleAuthkitHeaders(request, headers, { redirect: authorizationUrl });
+  }
+
+  // 4. Continue with AuthKit headers properly handled
+  return handleAuthkitHeaders(request, headers);
+}
+```
+
+**Key functions:**
+
+- `authkit(request)` - Returns `{ session, headers, authorizationUrl }` for composition
+- `handleAuthkitHeaders(request, headers, options?)` - Ensures AuthKit headers pass through correctly
+- For rewrites, use `partitionAuthkitHeaders()` and `applyResponseHeaders()` (see README)
+
+**Critical:** Always return via `handleAuthkitHeaders()` to ensure `withAuth()` works in pages.
+
+## Step 6: Create Callback Route
+
+Parse `NEXT_PUBLIC_WORKOS_REDIRECT_URI` to determine route path:
+
+```
+URI path          --> Route location (use APP_DIR from Step 4)
+/auth/callback    --> {APP_DIR}/app/auth/callback/route.ts
+/callback         --> {APP_DIR}/app/callback/route.ts
+```
+
+Use `handleAuth()` from SDK. Do not write custom OAuth logic.
+
+**CRITICAL for Next.js 15+:** The route handler MUST be async and properly await handleAuth():
+
+```typescript
+// CORRECT - Next.js 15+ requires async route handlers
+export const GET = handleAuth();
+
+// If handleAuth returns a function, ensure it's awaited in request context
+```
+
+Check README for exact usage. If build fails with "cookies outside request scope", the handler is likely missing async/await.
+
+## Step 7: Provider Setup (REQUIRED)
+
+**CRITICAL:** You MUST wrap the app in `AuthKitProvider` in `app/layout.tsx`.
+
+This is required for:
+
+- Client-side auth state via `useAuth()` hook
+- Consistent auth UX across client/server boundaries
+- Proper migration from Auth0 (which uses client-side auth)
+
+```tsx
+// app/layout.tsx
+import { AuthKitProvider } from '@workos-inc/authkit-nextjs/components';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthKitProvider>{children}</AuthKitProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+**Do NOT skip this step** even if using server-side auth patterns elsewhere.
+
+## Step 8: UI Integration
+
+Use **server helpers only for read-only auth checks** in Server Components. Use **client helpers for interactive auth UI** like shared nav/header buttons.
+
+### Server Components (safe)
+
+Use `withAuth()` / `getUser()` in `app/page.tsx`, `app/dashboard/page.tsx`, layouts, and route handlers to read auth state.
+
+**Do not** call `getSignInUrl()` / `getSignUpUrl()` during Server Component render. Those helpers set PKCE cookies via `cookies()` and will throw in Next.js 15+/16.
+
+### Shared nav/header auth UI (preferred)
+
+If you need a reusable `nav-auth.tsx` / header auth button, make it a **client component** and use `useAuth()` from the same client entrypoint as `AuthKitProvider` (check README for the exact import path for your SDK version).
+
+Use `refreshAuth({ ensureSignedIn: true })` from a click handler to start sign-in instead of computing a sign-in URL during render.
+
+```tsx
+'use client';
+// Check README for exact import path for your SDK version
+import { useAuth } from '@workos-inc/authkit-nextjs/components';
+
+export function NavAuth() {
+  const { user, isLoading, refreshAuth } = useAuth();
+
+  if (isLoading) return null;
+
+  if (user) {
+    return <a href="/dashboard">Dashboard</a>;
+  }
+
+  return (
+    <button type="button" onClick={() => void refreshAuth({ ensureSignedIn: true })}>
+      Sign in
+    </button>
+  );
+}
+```
+
+### If you need a server-generated sign-in URL
+
+Call `getSignInUrl()` **only** inside a Server Action or Route Handler. It is the safe wrapper for AuthKit sign-in/sign-up flows.
+
+### Critical auth URL gotchas
+
+- **Never** call `getSignInUrl()` / `getSignUpUrl()` inside a Server Component render (`page.tsx`, `layout.tsx`, async `nav-auth.tsx`, etc.).
+- **Never** use raw `getAuthorizationUrl()` for AuthKit UI flows. It returns an object like `{ url, sealedState }`, **not** a URL string.
+- If you bypass `getSignInUrl()`, the PKCE cookie is never set (`sealedState` is discarded), which causes `OAuth state mismatch` on the callback.
+- If you pass the raw `getAuthorizationUrl()` result to `window.location.href`, the browser will navigate to `/[object Object]`.
+- For server-side redirects, use `getSignInUrl()` in a Server Action / Route Handler. For client-side nav buttons, use `refreshAuth({ ensureSignedIn: true })`.
+
+**Note:** The SDK renamed `getUser` to `withAuth` in newer versions. Use whichever function the installed SDK version exports — do NOT rename existing working imports.
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check middleware/proxy exists (one should match)
+ls proxy.ts middleware.ts src/proxy.ts src/middleware.ts 2>/dev/null
+
+# 2. CRITICAL: Check AuthKitProvider is in layout (REQUIRED)
+grep "AuthKitProvider" app/layout.tsx || echo "FAIL: AuthKitProvider missing from layout"
+
+# 3. Check callback route exists
+find app -name "route.ts" -path "*/callback/*"
+
+# 4. Audit for raw getAuthorizationUrl usage — always unsafe in app sign-in/sign-up flows
+rg -n "getAuthorizationUrl|window\.location\.href\s*=\s*auth\.signInUrl" app src/app src 2>/dev/null || true
+
+# 5. Audit getSignInUrl() usage — safe in Server Actions/Route Handlers, unsafe in page/layout/component render
+rg -n "getSignInUrl\(" app src/app 2>/dev/null || true
+
+# 6. Build succeeds
+npm run build
+```
+
+**If check #2 fails:** Go back to Step 6 and add AuthKitProvider. This is not optional.
+
+**Manual verification before marking complete:**
+
+1. Click **Sign in** and confirm the browser goes to a real WorkOS URL — **not** `/[object Object]`
+2. Complete auth and confirm callback succeeds without `OAuth state mismatch`
+3. If `rg` finds `getSignInUrl(` in `page.tsx`, `layout.tsx`, or async server-rendered nav components, move that logic to a client component, Server Action, or Route Handler
+4. If `rg` finds `getAuthorizationUrl` in sign-in/sign-up code paths, replace it with `getSignInUrl()` / `getSignUpUrl()`
+
+## Error Recovery
+
+### "cookies was called outside a request scope" (Next.js 15+)
+
+**Most common cause:** Route handler not properly async or missing await.
+
+Fix for callback route:
+
+1. Check that `handleAuth()` is exported directly: `export const GET = handleAuth();`
+2. If using custom wrapper, ensure it's `async` and awaits any cookie operations
+3. Verify authkit-nextjs SDK version supports Next.js 15+ (check README for compatibility)
+4. **Never** call `cookies()` at module level - only inside request handlers
+
+This error causes OAuth codes to expire ("invalid_grant"), so fix the handler first.
+
+### "Cookies can only be modified in a Server Action or Route Handler"
+
+**Cause:** `getSignInUrl()` or `getSignUpUrl()` called directly in a Server Component. These functions set a PKCE cookie internally and must run in a Server Action or Route Handler.
+
+**Fix:**
+
+1. Move the `getSignInUrl()` call to a Server Action
+2. Or create a Route Handler that redirects to the sign-in URL
+3. Or convert the shared auth UI to a client component and call `refreshAuth({ ensureSignedIn: true })`
+4. Do NOT call `getSignInUrl()` at the top level of a page component
+
+### `GET /[object%20Object]` or `window.location.href = "[object Object]"`
+
+**Cause:** Code used raw `getAuthorizationUrl()` output as `signInUrl`. That helper returns `{ url, sealedState }`, not a string.
+
+**Fix:**
+
+1. Replace raw `getAuthorizationUrl()` usage with `getSignInUrl()` (or `getSignUpUrl()`)
+2. If you must inspect the lower-level helper, extract `.url` and preserve `sealedState` — but prefer the AuthKit wrapper
+3. Verify the provider/browser redirect receives a real string URL before assigning `window.location.href`
+
+### "OAuth state mismatch"
+
+**Cause:** The code bypassed `getSignInUrl()` and discarded `sealedState`, so the PKCE state cookie was never set.
+
+**Fix:**
+
+1. Use `getSignInUrl()` in a Server Action or Route Handler so AuthKit sets the PKCE cookie
+2. For client-side sign-in buttons, use `refreshAuth({ ensureSignedIn: true })`
+3. Do not hand-roll the sign-in action with raw `getAuthorizationUrl()` unless you also persist `sealedState` exactly as the SDK expects
+
+### "middleware.ts not found"
+
+- Check: File at project root or `src/`, not inside `app/`
+- Check: Filename matches Next.js version (proxy.ts for 16+, middleware.ts for 13-15)
+
+### "Both middleware file and proxy file are detected" (Next.js 16+)
+
+- Next.js 16 throws error E900 if both `middleware.ts` and `proxy.ts` exist
+- Delete `middleware.ts` and use only `proxy.ts`
+- If `middleware.ts` has custom logic, migrate it into `proxy.ts`
+
+### "withAuth route not covered by middleware" but middleware/proxy file exists
+
+- **Most common cause:** File is at the wrong level. Next.js only discovers middleware/proxy files in the parent directory of `app/`. For `src/app/` projects, the file must be in `src/`, not at the project root.
+- Check: Is `app/` at `src/app/`? Then middleware/proxy must be at `src/middleware.ts` or `src/proxy.ts`
+- Check: Matcher config must include the route path being accessed
+
+### "Cannot use getUser in client component"
+
+- Check: Component has no `'use client'` directive, or
+- Check: Move auth logic to server component/API route
+
+### "Module not found" for SDK import
+
+- Check: SDK installed before writing imports
+- Check: SDK package directory exists in node_modules
+
+### "withAuth route not covered by middleware"
+
+- Check: Middleware/proxy file exists at correct location
+- Check: Matcher config includes the route path
+
+### Build fails after AuthKitProvider
+
+- Check: Import path matches what README specifies (root export vs `/components` subpath)
+- Check: No client/server boundary violations
+
+### NEXT*PUBLIC* prefix issues
+
+- Client components need `NEXT_PUBLIC_*` prefix
+- Server components use plain env var names

--- a/.claude/skills/workos/references/workos-authkit-react-router.md
+++ b/.claude/skills/workos/references/workos-authkit-react-router.md
@@ -1,0 +1,112 @@
+# WorkOS AuthKit for React Router
+
+## Decision Tree
+
+```
+1. Fetch README (BLOCKING)
+2. Detect router mode
+3. Follow README for that mode
+4. Verify with checklist below
+```
+
+## Phase 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP - Do not write any code until this completes.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/authkit-react-router/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, **follow the README**.
+
+## Phase 2: Detect Router Mode
+
+| Mode           | Detection Signal                | Key Indicator             |
+| -------------- | ------------------------------- | ------------------------- |
+| v7 Framework   | `react-router.config.ts` exists | Routes in `app/routes/`   |
+| v7 Data        | `createBrowserRouter` in source | Loaders in route config   |
+| v7 Declarative | `<BrowserRouter>` component     | Routes as JSX, no loaders |
+| v6             | package.json version `"6.x"`    | Similar to v7 Declarative |
+
+**Detection order:**
+
+1. Check for `react-router.config.ts` (Framework mode)
+2. Grep for `createBrowserRouter` (Data mode)
+3. Check package.json version (v6 vs v7)
+4. Default to Declarative if v7 with `<BrowserRouter>`
+
+## Phase 3: Follow README
+
+Based on detected mode, apply the corresponding README section. The README contains current API signatures and code patterns.
+
+## Critical Distinctions
+
+### authLoader vs authkitLoader
+
+| Function        | Purpose                   | Where to use           |
+| --------------- | ------------------------- | ---------------------- |
+| `authLoader`    | OAuth callback handler    | Callback route ONLY    |
+| `authkitLoader` | Fetch user data in routes | Any route needing auth |
+
+**Common mistake:** Using `authkitLoader` for callback route. Use `authLoader()`.
+
+### Root Route Requirement
+
+Auth loader MUST be on root route for child routes to access auth context.
+
+**Wrong:** Auth loader only on `/dashboard`
+**Right:** Auth loader on `/` (root), children inherit context
+
+## Environment Variables
+
+Required in `.env` or `.env.local`:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `WORKOS_REDIRECT_URI` - full URL (e.g., `http://localhost:3000/auth/callback`)
+- `WORKOS_COOKIE_PASSWORD` - 32+ chars (server modes only)
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check SDK installed
+ls node_modules/@workos-inc/authkit-react-router 2>/dev/null || echo "FAIL: SDK not installed"
+
+# 2. Check callback route exists and matches WORKOS_REDIRECT_URI
+grep -r "authLoader\|handleCallbackRoute" src/ app/ 2>/dev/null
+
+# 3. Check auth loader/provider on root route
+grep -r "authkitLoader\|AuthKitProvider" src/ app/ 2>/dev/null
+
+# 4. Build succeeds
+npm run build
+```
+
+**If check #2 fails:** Callback route path must match WORKOS_REDIRECT_URI exactly. Use authLoader (not authkitLoader) for the callback route.
+
+## Error Recovery
+
+### "loader is not a function"
+
+**Cause:** Using loader pattern in Declarative/v6 mode
+**Fix:** Declarative/v6 modes use `AuthKitProvider` + `useAuth` hook, not loaders
+
+### Auth state not available in child routes
+
+**Cause:** Auth loader missing from root route
+**Fix:** Add `authkitLoader` (or `AuthKitProvider`) to root route so children inherit context
+
+### useAuth returns undefined
+
+**Cause:** Missing `AuthKitProvider` wrapper
+**Fix:** Wrap app with `AuthKitProvider` (required for Declarative/v6 modes)
+
+### Callback route 404
+
+**Cause:** Route path mismatch with `WORKOS_REDIRECT_URI`
+**Fix:** Extract exact path from env var, create route at that path
+
+### "Module not found" for SDK
+
+**Cause:** SDK not installed
+**Fix:** Install SDK, wait for completion, verify `node_modules` before writing imports

--- a/.claude/skills/workos/references/workos-authkit-react.md
+++ b/.claude/skills/workos/references/workos-authkit-react.md
@@ -1,0 +1,95 @@
+# WorkOS AuthKit for React (SPA)
+
+## Decision Tree
+
+```
+START
+  │
+  ├─► Fetch README (BLOCKING)
+  │   raw.githubusercontent.com/workos/authkit-react/main/README.md
+  │   README is source of truth. Stop if fetch fails.
+  │
+  ├─► Detect Build Tool
+  │   ├─ vite.config.ts exists? → Vite
+  │   └─ otherwise → Create React App
+  │
+  ├─► Set Env Var Prefix
+  │   ├─ Vite → VITE_WORKOS_CLIENT_ID
+  │   └─ CRA  → REACT_APP_WORKOS_CLIENT_ID
+  │
+  └─► Implement per README
+```
+
+## Critical: Build Tool Detection
+
+| Marker File               | Build Tool | Env Prefix   | Access Pattern            |
+| ------------------------- | ---------- | ------------ | ------------------------- |
+| `vite.config.ts`          | Vite       | `VITE_`      | `import.meta.env.VITE_*`  |
+| `craco.config.js` or none | CRA        | `REACT_APP_` | `process.env.REACT_APP_*` |
+
+**Wrong prefix = undefined values at runtime.** This is the #1 integration failure.
+
+## Key Clarification: No Callback Route
+
+The React SDK handles OAuth callbacks **internally** via AuthKitProvider.
+
+- No server-side callback route needed
+- SDK intercepts redirect URI client-side
+- Token exchange happens automatically
+
+Just ensure redirect URI env var matches WorkOS Dashboard exactly.
+
+## Required Environment Variables
+
+```
+{PREFIX}WORKOS_CLIENT_ID=client_...
+{PREFIX}WORKOS_REDIRECT_URI=http://localhost:5173/callback
+```
+
+No `WORKOS_API_KEY` needed. Client-side only SDK.
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check env var prefix matches build tool
+grep -E "VITE_WORKOS_CLIENT_ID|REACT_APP_WORKOS_CLIENT_ID" .env .env.local 2>/dev/null
+
+# 2. Check AuthKitProvider wraps app root
+grep "AuthKitProvider" src/main.tsx src/index.tsx 2>/dev/null || echo "FAIL: AuthKitProvider missing"
+
+# 3. Check no server framework present (wrong skill if found)
+grep -E '"next"|"react-router"' package.json && echo "WARN: Server framework detected"
+
+# 4. Build succeeds
+pnpm build
+```
+
+**If check #2 fails:** AuthKitProvider must wrap the app root in main.tsx/index.tsx. This is required for useAuth() to work.
+
+## Error Recovery
+
+### "clientId is required"
+
+**Cause:** Env var inaccessible (wrong prefix)
+
+Check: Does prefix match build tool? Vite needs `VITE_`, CRA needs `REACT_APP_`.
+
+### Auth state lost on refresh
+
+**Cause:** Token persistence issue
+
+Check: Browser dev tools → Application → Local Storage. SDK stores tokens here automatically.
+
+### useAuth returns undefined
+
+**Cause:** Component outside provider tree
+
+Check: Entry file (`main.tsx` or `index.tsx`) wraps `<App />` in `<AuthKitProvider>`.
+
+### Callback redirect fails
+
+**Cause:** URI mismatch
+
+Check: Env var redirect URI exactly matches WorkOS Dashboard → Redirects configuration.

--- a/.claude/skills/workos/references/workos-authkit-sveltekit.md
+++ b/.claude/skills/workos/references/workos-authkit-sveltekit.md
@@ -1,0 +1,203 @@
+# WorkOS AuthKit for SvelteKit
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/authkit-sveltekit/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `svelte.config.js` (or `svelte.config.ts`) exists
+- Confirm `package.json` contains `@sveltejs/kit` dependency
+- Confirm `src/routes/` directory exists
+
+### Environment Variables
+
+Check `.env` or `.env.local` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `WORKOS_REDIRECT_URI` - valid callback URL
+- `WORKOS_COOKIE_PASSWORD` - 32+ characters
+
+SvelteKit uses `$env/static/private` and `$env/dynamic/private` natively. The agent should write env vars to `.env` (SvelteKit's default) or `.env.local`.
+
+## Step 2b: Partial Install Recovery
+
+Before installing the SDK, check if a previous AuthKit attempt already exists:
+
+1. Check if `@workos/authkit-sveltekit` is already in `package.json`
+2. Check for incomplete setup signals:
+   - `src/hooks.server.ts` has commented-out `authkitHandle` import or exports a passthrough handle
+   - `src/routes/+layout.server.ts` has TODO comments about loading the session
+   - No callback `+server.ts` route exists in `src/routes/`
+   - No `WORKOS_COOKIE_PASSWORD` in `.env`
+3. If partial install detected:
+   - Do NOT reinstall the SDK (it's already there)
+   - Read existing files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - The most common gap is the missing callback route — create it
+   - Wire up `authkitHandle` in hooks.server.ts properly (use `sequence()` if other hooks exist)
+   - Complete the layout load function
+   - Ensure `WORKOS_COOKIE_PASSWORD` is set in `.env`
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+package.json has 'lucia'?              → Lucia v3 session auth
+package.json has '@auth0/auth0-spa-js'? → Auth0 SPA auth
+package.json has '@auth/sveltekit'?    → Auth.js SvelteKit
+src/hooks.server.ts handles cookies?   → Custom session middleware
+```
+
+If existing auth detected (Lucia is most common in SvelteKit):
+
+- Do NOT remove or disable the existing auth system
+- Use `sequence()` from `@sveltejs/kit/hooks` to compose handles:
+
+  ```typescript
+  import { sequence } from '@sveltejs/kit/hooks';
+  import { authkitHandle } from '@workos/authkit-sveltekit';
+
+  // Keep existing handle, compose with AuthKit
+  export const handle = sequence(authkitHandle, existingHandle);
+  ```
+
+- AuthKit handle should come FIRST in `sequence()` so it runs before other middleware
+- Create separate WorkOS routes if `/login` or `/callback` are already taken (e.g., use `/auth/callback`)
+- Ensure existing auth routes, form actions, and session cookies continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS AuthKit later
+
+## Step 3: Install SDK
+
+Detect package manager, install SDK package from README.
+
+```
+pnpm-lock.yaml? → pnpm add @workos/authkit-sveltekit
+yarn.lock? → yarn add @workos/authkit-sveltekit
+bun.lockb? → bun add @workos/authkit-sveltekit
+else → npm install @workos/authkit-sveltekit
+```
+
+**Verify:** SDK package exists in node_modules before continuing.
+
+## Step 4: Configure Server Hooks
+
+SvelteKit uses `src/hooks.server.ts` for server-side middleware. This is where the AuthKit handler is registered.
+
+Create or update `src/hooks.server.ts` with the authkit handle function from the README.
+
+### Existing Hooks (IMPORTANT)
+
+If `src/hooks.server.ts` already exists with custom logic, use SvelteKit's `sequence()` helper to compose hooks:
+
+```typescript
+import { sequence } from '@sveltejs/kit/hooks';
+import { authkitHandle } from '@workos/authkit-sveltekit'; // Check README for exact export
+
+export const handle = sequence(authkitHandle, yourExistingHandle);
+```
+
+Check README for the exact export name and usage pattern.
+
+## Step 5: Create Callback Route
+
+Parse `WORKOS_REDIRECT_URI` to determine route path:
+
+```
+URI path          --> Route location
+/callback         --> src/routes/callback/+server.ts
+/auth/callback    --> src/routes/auth/callback/+server.ts
+```
+
+Use the SDK's callback handler from the README. Do not write custom OAuth logic.
+
+**Critical:** SvelteKit uses `+server.ts` for API routes, not `+page.server.ts`.
+
+## Step 6: Layout Setup
+
+Update `src/routes/+layout.server.ts` to load the auth session and pass it to all pages.
+
+Check README for the exact pattern — typically a `load` function that returns the user session from locals.
+
+```typescript
+// src/routes/+layout.server.ts
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async (event) => {
+  // Check README for exact API — session is typically on event.locals
+  return {
+    user: event.locals.user, // or similar from README
+  };
+};
+```
+
+## Step 7: UI Integration
+
+Add auth UI to `src/routes/+page.svelte` using the session data from the layout.
+
+- Show user info when authenticated
+- Show sign-in link/button when not authenticated
+- Add sign-out functionality
+
+Check README for sign-in URL generation and sign-out patterns.
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check hooks.server.ts exists and has authkit
+grep -i "workos\|authkit" src/hooks.server.ts || echo "FAIL: authkit missing from hooks.server.ts"
+
+# 2. Check callback route exists
+find src/routes -name "+server.ts" -path "*/callback/*"
+
+# 3. Check layout loads auth session
+grep -i "user\|auth\|session" src/routes/+layout.server.ts || echo "FAIL: auth session missing from layout"
+
+# 4. Build succeeds
+pnpm build || npm run build
+```
+
+## Error Recovery
+
+### "Cannot find module '@workos/authkit-sveltekit'"
+
+- Check: SDK installed before writing imports
+- Check: SDK package directory exists in node_modules
+- Re-run install if missing
+
+### hooks.server.ts not taking effect
+
+- Check: File is at `src/hooks.server.ts`, not `src/hooks.ts` or elsewhere
+- Check: Named export is `handle` (SvelteKit requirement)
+- Check: If using `sequence()`, all handles are properly composed
+
+### Callback route not found (404)
+
+- Check: File uses `+server.ts` (not `+page.server.ts`)
+- Check: Route path matches `WORKOS_REDIRECT_URI` path exactly
+- Check: Exports `GET` handler (SvelteKit convention)
+
+### "locals" type errors
+
+- Check: App.Locals interface is augmented in `src/app.d.ts`
+- Check README for TypeScript setup instructions
+
+### Cookie password error
+
+- Verify `WORKOS_COOKIE_PASSWORD` is 32+ characters
+- Generate new: `openssl rand -base64 32`
+
+### Auth state not available in pages
+
+- Check: `+layout.server.ts` load function returns user data
+- Check: Pages access data via `export let data` (Svelte 4) or `$page.data` (Svelte 5)

--- a/.claude/skills/workos/references/workos-authkit-tanstack-start.md
+++ b/.claude/skills/workos/references/workos-authkit-tanstack-start.md
@@ -1,0 +1,309 @@
+# WorkOS AuthKit for TanStack Start
+
+## Decision Tree
+
+```
+1. Fetch README (BLOCKING)
+   ├── Extract package name from install command
+   └── README is source of truth for ALL code patterns
+
+2. Detect directory structure
+   ├── src/ (TanStack Start v1.132+, default)
+   └── app/ (legacy vinxi-based projects)
+
+3. Follow README install/setup exactly
+   └── Do not invent commands or patterns
+```
+
+## Fetch SDK Documentation (BLOCKING)
+
+**STOP - Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/authkit-tanstack-start/main/README.md`
+
+From README, extract:
+
+1. Package name: `@workos/authkit-tanstack-react-start`
+2. Use that exact name for all imports
+
+**README overrides this skill if conflict.**
+
+## Pre-Flight Checklist
+
+- [ ] README fetched and package name extracted
+- [ ] `@tanstack/start` or `@tanstack/react-start` in package.json
+- [ ] Identify directory structure: `src/` (modern) or `app/` (legacy)
+- [ ] Environment variables set (see below)
+
+## Directory Structure Detection
+
+**Modern TanStack Start (v1.132+)** uses `src/`:
+
+```
+src/
+├── start.ts              # Middleware config (CRITICAL)
+├── router.tsx            # Router setup
+├── routes/
+│   ├── __root.tsx        # Root layout
+│   ├── api.auth.callback.tsx  # OAuth callback (flat route)
+│   └── ...
+```
+
+**Legacy (vinxi-based)** uses `app/`:
+
+```
+app/
+├── start.ts or router.tsx
+├── routes/
+│   └── api/auth/callback.tsx  # OAuth callback (nested route)
+```
+
+**Detection:**
+
+```bash
+ls src/routes 2>/dev/null && echo "Modern (src/)" || echo "Legacy (app/)"
+```
+
+## Environment Variables
+
+| Variable                 | Format       | Required |
+| ------------------------ | ------------ | -------- |
+| `WORKOS_API_KEY`         | `sk_...`     | Yes      |
+| `WORKOS_CLIENT_ID`       | `client_...` | Yes      |
+| `WORKOS_REDIRECT_URI`    | Full URL     | Yes      |
+| `WORKOS_COOKIE_PASSWORD` | 32+ chars    | Yes      |
+
+Generate password if missing: `openssl rand -base64 32`
+
+Default redirect URI: `http://localhost:3000/api/auth/callback`
+
+## Middleware Configuration (CRITICAL)
+
+**authkitMiddleware MUST be configured or auth will fail silently.**
+
+**WARNING: Do NOT add middleware to `createRouter()` in `router.tsx` or `app.tsx`. That is TanStack Router (client-side only). Server middleware belongs in `start.ts` using `requestMiddleware`.**
+
+### If `start.ts` already exists
+
+Read the existing file first. Add `authkitMiddleware` to the existing `requestMiddleware` array (or create the array if missing). Preserve the existing export style. Do not rewrite the file from scratch.
+
+### If `start.ts` does not exist
+
+Create `src/start.ts` (or `app/start.ts` for legacy) using `createStart`:
+
+```typescript
+import { createStart } from '@tanstack/react-start';
+import { authkitMiddleware } from '@workos/authkit-tanstack-react-start';
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [authkitMiddleware()],
+}));
+```
+
+**Two things matter here:**
+
+1. **Named export `startInstance`** — the build plugin generates `import type { startInstance }` from this file. A `default` export will cause a build error.
+2. **`createStart` takes a function** returning the options object, not the options directly. `createStart({ ... })` will fail.
+
+**WARNING: Do NOT add middleware to `createRouter()` in `router.tsx` or `app.tsx`. That is TanStack Router (client-side only). Server middleware belongs in `start.ts` using `requestMiddleware`.**
+
+## Callback Route (CRITICAL)
+
+Path must match `WORKOS_REDIRECT_URI`. For `/api/auth/callback`:
+
+**Modern (flat routes):** `src/routes/api.auth.callback.tsx`
+**Legacy (nested routes):** `app/routes/api/auth/callback.tsx`
+
+```typescript
+import { createFileRoute } from '@tanstack/react-router';
+import { handleCallbackRoute } from '@workos/authkit-tanstack-react-start';
+
+export const Route = createFileRoute('/api/auth/callback')({
+  server: {
+    handlers: {
+      GET: handleCallbackRoute(),
+    },
+  },
+});
+```
+
+**Key points:**
+
+- Use `handleCallbackRoute()` - do not write custom OAuth logic
+- Route path string must match the URI path exactly
+- This is a server-only route (no component needed)
+
+## Protected Routes
+
+Use `getAuth()` in route loaders to check authentication:
+
+```typescript
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { getAuth, getSignInUrl } from '@workos/authkit-tanstack-react-start';
+
+export const Route = createFileRoute('/dashboard')({
+  loader: async () => {
+    const { user } = await getAuth();
+    if (!user) {
+      const signInUrl = await getSignInUrl();
+      throw redirect({ href: signInUrl });
+    }
+    return { user };
+  },
+  component: Dashboard,
+});
+```
+
+## Sign Out Route
+
+```typescript
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { signOut } from '@workos/authkit-tanstack-react-start';
+
+export const Route = createFileRoute('/signout')({
+  loader: async () => {
+    await signOut();
+    throw redirect({ href: '/' });
+  },
+});
+```
+
+## Client-Side Hooks (Optional)
+
+Only needed if you want reactive auth state in components.
+
+**1. Add AuthKitProvider to root:**
+
+```typescript
+// src/routes/__root.tsx
+import { AuthKitProvider } from '@workos/authkit-tanstack-react-start/client';
+
+function RootComponent() {
+  return (
+    <AuthKitProvider>
+      <Outlet />
+    </AuthKitProvider>
+  );
+}
+```
+
+**2. Use hooks in components:**
+
+```typescript
+import { useAuth } from '@workos/authkit-tanstack-react-start/client';
+
+function Profile() {
+  const { user, isLoading } = useAuth();
+  // ...
+}
+```
+
+**Note:** Server-side `getAuth()` is preferred for most use cases.
+
+## Finalize (REQUIRED before declaring success)
+
+After creating/editing all files, run these steps in order. Skipping them is the most common cause of build failures.
+
+### 1. Regenerate the route tree
+
+Adding new route files (callback, signout, etc.) makes the existing `routeTree.gen.ts` stale. The build will fail with type errors about missing routes until it is regenerated.
+
+```bash
+pnpm build 2>/dev/null || npx tsr generate
+```
+
+The build itself triggers route tree regeneration. If it fails for other reasons, use `tsr generate` directly.
+
+### 2. Ensure Vite type declarations exist
+
+TanStack Start projects import CSS with `import styles from './styles.css?url'`. Without Vite's type declarations, TypeScript will error on these imports. Check if `src/vite-env.d.ts` (or `app/vite-env.d.ts`) exists — if not, create it now (before attempting the build):
+
+```typescript
+/// <reference types="vite/client" />
+```
+
+### 3. Verify the build
+
+```bash
+pnpm build
+```
+
+Do not skip this step. If the build fails, fix the errors before finishing. Common causes:
+
+- Stale route tree → re-run step 1
+- Missing Vite types → re-run step 2
+- Wrong import paths → check package name is `@workos/authkit-tanstack-react-start`
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check authkitMiddleware is configured
+grep -r "authkitMiddleware" src/ app/ 2>/dev/null || echo "FAIL: Middleware not configured"
+
+# 2. Check callback route exists
+find src/routes app/routes -name "*callback*" 2>/dev/null
+
+# 3. Check environment variables
+grep -c "WORKOS_" .env 2>/dev/null || echo "FAIL: No env vars found"
+
+# 4. Build succeeds
+pnpm build
+```
+
+**If check #1 fails:** authkitMiddleware must be in src/start.ts (or app/start.ts for legacy) requestMiddleware array. Auth will fail silently without it.
+
+## Error Recovery
+
+### "AuthKit middleware is not configured"
+
+**Cause:** `authkitMiddleware()` not in start.ts
+**Fix:** Create/update `src/start.ts` with middleware config
+**Verify:** `grep -r "authkitMiddleware" src/`
+
+### "Module not found" for SDK
+
+**Cause:** Wrong package name or not installed
+**Fix:** `pnpm add @workos/authkit-tanstack-react-start`
+**Verify:** `ls node_modules/@workos/authkit-tanstack-react-start`
+
+### Callback 404
+
+**Cause:** Route file path doesn't match WORKOS_REDIRECT_URI
+**Fix:**
+
+- URI `/api/auth/callback` → file `src/routes/api.auth.callback.tsx` (flat) or `app/routes/api/auth/callback.tsx` (nested)
+- Route path string in `createFileRoute()` must match exactly
+
+### getAuth returns undefined user
+
+**Cause:** Middleware not configured or not running
+**Fix:** Ensure `authkitMiddleware()` is in start.ts requestMiddleware array
+
+### "Cookie password too short"
+
+**Cause:** WORKOS_COOKIE_PASSWORD < 32 chars
+**Fix:** `openssl rand -base64 32`, update .env
+
+### Build fails with route type errors
+
+**Cause:** Route tree not regenerated after adding routes
+**Fix:** `pnpm dev` to regenerate `routeTree.gen.ts`
+
+## SDK Exports Reference
+
+**Server (main export):**
+
+- `authkitMiddleware()` - Request middleware
+- `handleCallbackRoute()` - OAuth callback handler
+- `getAuth()` - Get current session
+- `signOut()` - Sign out user
+- `getSignInUrl()` / `getSignUpUrl()` - Auth URLs
+- `switchToOrganization()` - Change org context
+
+**Client (`/client` subpath):**
+
+- `AuthKitProvider` - Context provider
+- `useAuth()` - Auth state hook
+- `useAccessToken()` - Token management

--- a/.claude/skills/workos/references/workos-authkit-vanilla-js.md
+++ b/.claude/skills/workos/references/workos-authkit-vanilla-js.md
@@ -1,0 +1,87 @@
+# WorkOS AuthKit for Vanilla JavaScript
+
+## Decision Tree
+
+### Step 1: Fetch README (BLOCKING)
+
+WebFetch: `https://raw.githubusercontent.com/workos/authkit-js/main/README.md`
+
+**README is source of truth.** If this skill conflicts, follow README.
+
+### Step 2: Detect Project Type
+
+```
+Has package.json with build tool (Vite, webpack, Parcel)?
+  YES -> Bundled project (npm install)
+  NO  -> CDN/Static project (script tag)
+```
+
+### Step 3: Follow README Installation
+
+- **Bundled**: Use package manager install from README
+- **CDN**: Use unpkg script tag from README
+
+### Step 4: Implement Per README
+
+Follow README examples for:
+
+- Client initialization
+- Sign in/out handlers
+- User state management
+
+## Critical API Quirk
+
+`createClient()` is **async** - returns a Promise, not a client directly.
+
+```javascript
+// CORRECT
+const authkit = await createClient(clientId);
+```
+
+## Verification Checklist (ALL MUST PASS)
+
+Run these commands to confirm integration. **Do not mark complete until all pass:**
+
+```bash
+# 1. Check SDK is available (bundled or CDN)
+grep -r "createClient\|WorkOS" src/ *.html 2>/dev/null || echo "FAIL: SDK not found"
+
+# 2. Check createClient uses await
+grep -rn "await createClient" src/ *.js *.html 2>/dev/null || echo "FAIL: createClient must be awaited"
+
+# 3. Check sign-in is on user gesture (click handler)
+grep -rn "signIn\|sign_in" src/ *.js *.html 2>/dev/null
+
+# 4. Build succeeds (bundled projects only)
+pnpm build 2>/dev/null || echo "CDN project — verify manually in browser"
+```
+
+**If check #2 fails:** createClient() is async and must be awaited. Using it without await returns a Promise, not a client.
+
+## Environment Variables
+
+**Bundled projects only:**
+
+- Vite: `VITE_WORKOS_CLIENT_ID`
+- Webpack: `REACT_APP_WORKOS_CLIENT_ID` or custom
+- No `WORKOS_API_KEY` needed (client-side SDK)
+
+## Error Recovery
+
+| Error                            | Cause               | Fix                                                    |
+| -------------------------------- | ------------------- | ------------------------------------------------------ |
+| `WorkOS is not defined`          | CDN not loaded      | Add script to `<head>` before your code                |
+| `createClient is not a function` | Wrong import        | npm: check import path; CDN: use `WorkOS.createClient` |
+| `clientId is required`           | Undefined env var   | Check env prefix matches build tool                    |
+| CORS errors                      | `file://` protocol  | Use local dev server (`npx serve`)                     |
+| Popup blocked                    | Not user gesture    | Call `signIn()` only from click handler                |
+| Auth state lost                  | Token not persisted | Check localStorage in dev tools                        |
+
+## Task Flow
+
+1. **preflight**: Fetch README, detect project type, verify env vars
+2. **install**: Add SDK per project type
+3. **callback**: SDK handles internally (no server route needed)
+4. **provider**: Initialize client with `await createClient()`
+5. **ui**: Add auth buttons and state display
+6. **verify**: Build (if bundled), check console

--- a/.claude/skills/workos/references/workos-cli-upgrade.md
+++ b/.claude/skills/workos/references/workos-cli-upgrade.md
@@ -1,0 +1,42 @@
+# WorkOS CLI Upgrades
+
+## Docs
+
+- npm package: https://www.npmjs.com/package/workos
+- Releases / changelog: https://github.com/workos/cli/releases
+
+If this file conflicts with fetched docs, follow the docs.
+
+Use this when the user is running an outdated `workos` CLI and you need to recommend an upgrade. Symptoms include `unknown command`, missing flags shown in newer docs, or the user explicitly asking how to update the CLI.
+
+## Detecting an outdated CLI
+
+- Confirm the user's running version with `workos --version`.
+- Confirm the latest published version with `npm view workos version` (or `npm view workos dist-tags`). **Do NOT guess.** The latest version moves frequently and any number you reproduce from memory is almost certainly stale.
+- If running version < latest, recommend the upgrade command for the user's package manager (table below).
+- If you cannot determine how the user installed the CLI, recommend `npx workos@latest <command>` as a no-install fallback so they can unblock immediately.
+
+## Upgrade commands by package manager
+
+| Package manager | One-shot upgrade               | No-install alternative |
+| --------------- | ------------------------------ | ---------------------- |
+| npm             | `npm install -g workos@latest` | `npx workos@latest`    |
+| pnpm            | `pnpm add -g workos@latest`    | `pnpm dlx workos`      |
+
+The CLI is published to npm. If the user is on a different package manager, suggest the `npx workos@latest` no-install form so they can unblock immediately.
+
+After upgrading, have the user re-run `workos --version` to confirm the new version is on PATH (a stale shim from a different package manager can shadow the upgrade — `workos doctor` flags this in newer CLI versions).
+
+## What NOT to do
+
+- **Do NOT guess the "latest" version.** Always tell the user to run `npm view workos version`. A fabricated version pin (`workos@0.13.0` when the real latest is `0.14.2`) leaves the user pinned to a stale install with no obvious symptom.
+- **Do NOT recommend `npm uninstall -g workos && npm install -g workos`** as a default upgrade path. `workos@latest` reinstalls in place. Suggest uninstall-then-reinstall only if the user reports a corrupted install or a binary-shadow warning from `workos doctor`.
+- **Do NOT pin to a specific version** unless the user explicitly asks (e.g. "I need to stay on 0.12.x for CI"). Default to `@latest`.
+- **Do NOT mix package managers.** If the user installed via npm, recommend the npm upgrade command — a `pnpm add -g` on top of a global npm install can leave two `workos` binaries on PATH. When unsure which one they used, prefer the no-install `npx workos@latest` form.
+- **Do NOT recommend Homebrew, asdf, or other version managers.** The CLI is published to npm only. If the user mentions a non-npm install, treat it as out-of-scope and point them to the npm package URL above.
+
+## Gotchas
+
+- **Global install on Node managed by `nvm` / `fnm` / `volta`**: each Node version has its own global prefix. Switching Node versions can make `workos` "disappear" until the user reinstalls under the new Node. The fix is to reinstall, not to chase the missing binary.
+- **`npx` cache**: `npx workos@latest` may serve a cached older version on the first invocation after a release. Re-running once usually picks up the new tarball.
+- **Corporate proxies / private registries**: if `npm view workos version` errors, the user may be on a private registry that mirrors npm. Have them check `npm config get registry`; recommendations above assume the public npm registry.

--- a/.claude/skills/workos/references/workos-custom-domains.md
+++ b/.claude/skills/workos/references/workos-custom-domains.md
@@ -1,0 +1,21 @@
+# WorkOS Custom Domains
+
+## Docs
+
+- https://workos.com/docs/custom-domains/index
+- https://workos.com/docs/custom-domains/email
+- https://workos.com/docs/custom-domains/authkit
+- https://workos.com/docs/custom-domains/auth-api
+- https://workos.com/docs/custom-domains/admin-portal
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Custom domains are production-environment only. Staging environments always use `workos.dev` and cannot be customized.
+- AuthKit custom domains require updating ALL callback URLs in production code, environment variables (`WORKOS_REDIRECT_URI`), and OAuth app registration in the WorkOS Dashboard. Missing any one causes "Invalid redirect_uri" errors.
+- DNS verification can take 24-48 hours. Do not proceed with code changes until Dashboard shows "Verified" status.
+- SSL is auto-provisioned after DNS verification but is a separate status. Dashboard must show both "Verified" and "SSL Active" before the domain is usable.
+- Email and Admin Portal custom domains require no code changes — WorkOS handles them backend-only. Only AuthKit domains need code updates.
+- When migrating AuthKit to a custom domain, add the new callback URI alongside the old one in Dashboard. Remove the old `workos.com` callback only after confirming the custom domain works.
+- Cookie domain must be set to `.yourapp.com` (with leading dot) for subdomain compatibility. Incorrect cookie domain causes silent auth failures where login redirects back to `workos.com`.
+- Emails still sent from `workos.dev` usually means the staging environment is selected or the email domain is not yet verified. Check the environment toggle (top-right in Dashboard).

--- a/.claude/skills/workos/references/workos-directory-sync.md
+++ b/.claude/skills/workos/references/workos-directory-sync.md
@@ -1,0 +1,51 @@
+# WorkOS Directory Sync
+
+## Docs
+
+- https://workos.com/docs/directory-sync/quick-start
+- https://workos.com/docs/directory-sync/understanding-events
+- https://workos.com/docs/directory-sync/handle-inactive-users
+- https://workos.com/docs/directory-sync/attributes
+- https://workos.com/docs/directory-sync/identity-provider-role-assignment
+- https://workos.com/docs/rbac/integration
+  If this file conflicts with fetched docs, follow the docs.
+
+## Mapping directory groups to WorkOS roles
+
+This is one of the most common customer asks. Full recipe lives in `workos-rbac.md` under "IdP group → role mapping"; Directory Sync specifics:
+
+- SCIM/Google Workspace directory groups are the source of truth. Per docs: "SCIM is generally the preferred option due to its real-time synchronization capabilities."
+- Roles propagate in real time: "Roles are granted to directory users in real-time, when we receive updates to their group memberships."
+- IdP role assignment overrides API and Dashboard role assignments. Per docs: "IdP role assignment will always take precedence over roles assigned via API or the WorkOS Dashboard." Do not recommend `updateOrganizationMembership` as a workaround when a Directory Sync mapping exists — it will silently revert on the next sync.
+- Mappings are configured in the Admin Portal during directory setup, or on the directory page of the WorkOS Dashboard. Do **not** invent specific menu paths beyond that — the docs do not commit to exact click-paths.
+- Not configurable via the WorkOS CLI. If asked, say so explicitly and link to https://workos.com/docs/directory-sync/identity-provider-role-assignment.
+
+## Gotchas
+
+- dsync.deleted sends ONE event for the whole directory — it does NOT send individual dsync.user.deleted or dsync.group.deleted events. You must cascade-delete all users and groups by directory_id yourself.
+- Use email as stable user identity, NOT the WorkOS directory*user*\* ID — the ID changes if a user is recreated in the IdP. Upsert by email.
+- Return 200 from webhook handler IMMEDIATELY (WorkOS times out at 10s) — process events asynchronously after acknowledging
+- Webhooks are NOT mandatory — the Events API (workos.events.listEvents) is a fully supported pull-based alternative for batch processing
+- Webhook signature verification must use the RAW request body, not parsed JSON — parsing first breaks the signature
+- Use dsync.\* wildcard for Events API filter, not just "dsync" — bare string returns nothing
+- Events API after param must be within 30-day retention window
+- User state "inactive" is far more common than "deleted" — most IdPs deactivate users rather than deleting them. Handle dsync.user.updated with state=inactive as a deprovisioning event.
+- Webhook handler pattern: call workos.webhooks.verifyEvent() with raw body + workos-signature header + secret, THEN return 200, THEN process event in async handler. Order matters.
+- Ruby webhook trap: use request.raw_post for signature verification, NOT request.body — Rails parses body into params which breaks the signature. Disable JSON parsing for the webhook endpoint (use ActionController::API or skip_before_action).
+- Use upsert pattern (ON CONFLICT / upsert) for all webhook handlers — events can be delivered more than once. dsync.user.created should upsert, not insert.
+
+## Endpoints
+
+| Endpoint                | Description                |
+| ----------------------- | -------------------------- |
+| `/directory-sync`       | Directory Sync overview    |
+| `/directory`            | Directory management       |
+| `/directory-group`      | Directory group operations |
+| `/directory-group/get`  | Get a directory group      |
+| `/directory-group/list` | List directory groups      |
+| `/directory-user`       | Directory user operations  |
+| `/directory-user/get`   | Get a directory user       |
+| `/directory-user/list`  | List directory users       |
+| `/directory/delete`     | Delete a directory         |
+| `/directory/get`        | Get a directory            |
+| `/directory/list`       | List directories           |

--- a/.claude/skills/workos/references/workos-dotnet.md
+++ b/.claude/skills/workos/references/workos-dotnet.md
@@ -1,0 +1,158 @@
+# WorkOS AuthKit for .NET (ASP.NET Core)
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-dotnet/main/README.md`
+
+The README is the source of truth for SDK API usage. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm a `*.csproj` file exists in the project root
+- Detect project style:
+  - **Minimal API** (modern): `Program.cs` with `WebApplication.CreateBuilder()` — .NET 6+
+  - **Startup pattern** (older): `Startup.cs` with `ConfigureServices()` / `Configure()` — .NET 5 and earlier
+
+This detection determines WHERE to register WorkOS services and middleware.
+
+### Environment Variables
+
+Check `appsettings.Development.json` for:
+
+- `WORKOS_API_KEY` — starts with `sk_`
+- `WORKOS_CLIENT_ID` — starts with `client_`
+
+## Step 3: Install SDK
+
+```bash
+dotnet add package WorkOS.net
+```
+
+**Verify:** Check the `*.csproj` file contains a `<PackageReference Include="WorkOS.net"` entry.
+
+If `dotnet` CLI is not available, stop and inform the user to install the .NET SDK.
+
+## Step 4: Configure WorkOS Client
+
+### Minimal API Pattern (Program.cs)
+
+Add WorkOS configuration to `Program.cs`:
+
+1. Read WorkOS settings from `IConfiguration`
+2. Register the WorkOS client in the DI container
+3. The WorkOS client needs API key for initialization
+
+```csharp
+// In Program.cs, after builder creation:
+var workosApiKey = builder.Configuration["WorkOS:ApiKey"];
+var workosClientId = builder.Configuration["WorkOS:ClientId"];
+```
+
+### Startup Pattern (Startup.cs)
+
+Add to `ConfigureServices()`:
+
+1. Read WorkOS settings from `IConfiguration`
+2. Register services
+
+Choose the pattern that matches the detected project structure.
+
+## Step 5: Create Authentication Endpoints
+
+Create auth endpoints following the WorkOS AuthKit pattern. Use minimal API `app.MapGet()` for minimal API projects, or a Controller for Startup-pattern projects.
+
+### Required Endpoints
+
+**GET /auth/login** — Redirect to WorkOS AuthKit:
+
+- Use the WorkOS SDK to generate an authorization URL
+- Include `clientId`, `redirectUri`, and `provider: "authkit"` parameters
+- Redirect the user to the authorization URL
+
+**GET /auth/callback** — Handle OAuth callback:
+
+- Extract `code` from query parameters
+- Exchange authorization code for user profile using the WorkOS SDK
+- Store user info in session or cookie
+- Redirect to home page
+
+**GET /auth/logout** — Clear session:
+
+- Clear the authentication session/cookie
+- Redirect to home page
+
+### Session Management
+
+Use ASP.NET Core's built-in session or cookie authentication:
+
+```csharp
+// Enable session middleware in Program.cs
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession();
+// ...
+app.UseSession();
+```
+
+## Step 6: Environment Setup
+
+Configure `appsettings.Development.json` with WorkOS credentials:
+
+```json
+{
+  "WorkOS": {
+    "ApiKey": "<WORKOS_API_KEY value>",
+    "ClientId": "<WORKOS_CLIENT_ID value>",
+    "RedirectUri": "http://localhost:5000/auth/callback"
+  }
+}
+```
+
+Use the actual credential values provided in the environment context.
+
+**Important:** Do NOT put secrets in `appsettings.json` (committed to git). Use `appsettings.Development.json` (gitignored) or `dotnet user-secrets`.
+
+## Step 7: Verification
+
+Run these checks — **do not mark complete until all pass:**
+
+```bash
+# 1. Check WorkOS.net is in csproj
+grep -i "WorkOS" *.csproj
+
+# 2. Check auth endpoints exist
+grep -r "auth/login\|auth/callback\|auth/logout" *.cs
+
+# 3. Build succeeds
+dotnet build
+```
+
+**If build fails:** Read the error output carefully. Common issues:
+
+- Missing `using` statements for WorkOS namespaces
+- Incorrect DI registration order
+- Missing session/cookie middleware registration
+
+## Error Recovery
+
+### "dotnet: command not found"
+
+- .NET SDK is not installed. Inform the user to install from https://dotnet.microsoft.com/download
+
+### NuGet restore failures
+
+- Check internet connectivity
+- Try `dotnet restore` explicitly before `dotnet build`
+
+### "No project file found"
+
+- Ensure you're in the correct directory with a `*.csproj` file
+
+### Build errors after integration
+
+- Check that all `using` statements are correct
+- Verify DI registration order (services before middleware)
+- Ensure `app.UseSession()` is called before mapping auth endpoints

--- a/.claude/skills/workos/references/workos-elixir.md
+++ b/.claude/skills/workos/references/workos-elixir.md
@@ -1,0 +1,226 @@
+# WorkOS AuthKit for Elixir (Phoenix)
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-elixir/main/README.md`
+
+The README is the source of truth for SDK API usage. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `mix.exs` exists
+- Read `mix.exs` to extract the app name (look for `app: :my_app` in `project/0`)
+- Confirm `lib/{app}_web/router.ex` exists (Phoenix project marker)
+- Confirm `config/runtime.exs` exists
+
+### Determine App Name
+
+The app name from `mix.exs` determines all file paths. For example, if `app: :my_app`:
+
+- Web module: `lib/my_app_web/`
+- Router: `lib/my_app_web/router.ex`
+- Controllers: `lib/my_app_web/controllers/`
+
+### Environment Variables
+
+Check `.env.local` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `:workos` is already in `mix.exs` dependencies
+2. Check for incomplete auth code — AuthController exists but has TODO stubs, 501 responses, or missing callback/sign_out functions
+3. If partial install detected:
+   - Do NOT re-add the SDK dependency (it's already there)
+   - Do NOT re-run `mix deps.get` if deps are already fetched
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps (controller methods, routes)
+   - Preserve any working code — only fix what's broken
+   - Check for missing `/auth/callback` route (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+mix.exs has ':ueberauth'?                          → Ueberauth auth
+mix.exs has ':pow'?                                → Pow auth
+mix.exs has ':guardian'?                           → Guardian JWT auth
+mix.exs has ':phx_gen_auth'?                       → Phoenix generated auth
+config/*.exs has 'Ueberauth' config?               → Ueberauth configured
+router.ex has '/:provider' wildcard auth routes?   → Ueberauth routes
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If Ueberauth is configured, be careful of `/:provider` wildcard routes — use a specific scope like `/auth/workos` to avoid conflicts
+- Reuse existing session infrastructure if compatible
+- Create separate route paths for WorkOS auth
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+Add the `workos` package to `mix.exs` dependencies:
+
+```elixir
+defp deps do
+  [
+    # ... existing deps
+    {:workos, "~> 1.0"}
+  ]
+end
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+**Verify:** Check that `mix deps.get` completed successfully (exit code 0).
+
+## Step 4: Configure WorkOS
+
+Add WorkOS configuration to `config/runtime.exs`:
+
+```elixir
+config :workos,
+  api_key: System.get_env("WORKOS_API_KEY"),
+  client_id: System.get_env("WORKOS_CLIENT_ID")
+```
+
+This ensures credentials are loaded from environment variables at runtime, not compiled into the release.
+
+## Step 5: Create Auth Controller
+
+### Prerequisite: Verify `{AppName}Web` module exists
+
+The controller uses `use {AppName}Web, :controller`. Confirm `lib/{app}_web.ex` exists and defines the `:controller` macro. If it doesn't exist (minimal Phoenix projects may lack it), create it:
+
+```elixir
+defmodule {AppName}Web do
+  def controller do
+    quote do
+      use Phoenix.Controller, formats: [:html, :json]
+      import Plug.Conn
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end
+```
+
+### Create controller
+
+Create `lib/{app}_web/controllers/auth_controller.ex`:
+
+```elixir
+defmodule {AppName}Web.AuthController do
+  use {AppName}Web, :controller
+
+  def sign_in(conn, _params) do
+    client_id = Application.get_env(:workos, :client_id)
+    redirect_uri = "http://localhost:4000/auth/callback"
+
+    authorization_url = WorkOS.UserManagement.get_authorization_url(%{
+      provider: "authkit",
+      client_id: client_id,
+      redirect_uri: redirect_uri
+    })
+
+    case authorization_url do
+      {:ok, url} -> redirect(conn, external: url)
+      {:error, reason} -> conn |> put_status(500) |> text("Auth error: #{inspect(reason)}")
+    end
+  end
+
+  def callback(conn, %{"code" => code}) do
+    client_id = Application.get_env(:workos, :client_id)
+
+    case WorkOS.UserManagement.authenticate_with_code(%{
+      code: code,
+      client_id: client_id
+    }) do
+      {:ok, auth_response} ->
+        conn
+        |> put_session(:user, auth_response.user)
+        |> redirect(to: "/")
+
+      {:error, reason} ->
+        conn |> put_status(401) |> text("Authentication failed: #{inspect(reason)}")
+    end
+  end
+
+  def sign_out(conn, _params) do
+    conn
+    |> clear_session()
+    |> redirect(to: "/")
+  end
+end
+```
+
+**IMPORTANT:** Adapt the module name and API calls based on the README. The WorkOS Elixir SDK API may differ from the pseudocode above. Always follow the README for exact function names, parameter shapes, and return types.
+
+## Step 6: Add Routes
+
+Add auth routes to `lib/{app}_web/router.ex`. Add these routes inside or outside the existing pipeline scope as appropriate:
+
+```elixir
+scope "/auth", {AppName}Web do
+  pipe_through :browser
+
+  get "/sign-in", AuthController, :sign_in
+  get "/callback", AuthController, :callback
+  post "/sign-out", AuthController, :sign_out
+end
+```
+
+## Step 7: Verification
+
+Run the following to confirm the integration compiles:
+
+```bash
+mix compile
+```
+
+**If compilation fails:**
+
+1. Read the error message carefully
+2. Check that the WorkOS SDK module names match what's in the README
+3. Verify the app name is consistent across all files
+4. Fix the issue and re-run `mix compile`
+
+## Error Recovery
+
+### "could not compile dependency :workos"
+
+- Check Elixir version compatibility (1.15+ recommended)
+- Try `mix deps.clean workos && mix deps.get`
+
+### "module WorkOS.UserManagement is not available"
+
+- The SDK API may use different module paths — re-read the README
+- Check if the SDK uses `WorkOS.SSO` or another module instead
+
+### "undefined function" in controller
+
+- Verify `use {AppName}Web, :controller` is correct
+- Check that the SDK functions match the README exactly
+
+### Route conflicts
+
+- Check existing routes in router.ex for `/auth` prefix conflicts
+- Adjust the scope path if needed (e.g., `/workos-auth`)

--- a/.claude/skills/workos/references/workos-email.md
+++ b/.claude/skills/workos/references/workos-email.md
@@ -1,0 +1,16 @@
+# WorkOS Email Delivery
+
+## Docs
+
+- https://workos.com/docs/email
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- WorkOS sends auth emails automatically (Magic Auth, invitations, password resets). This feature is about configuring the sender domain, not writing email-sending code.
+- Do NOT manually configure SPF/DKIM TXT records. WorkOS uses SendGrid's automated security via CNAMEs. Adding custom SPF/DKIM records will break authentication.
+- You must set up actual inboxes for `welcome@<your-domain>` and `access@<your-domain>`. Email providers check if sender addresses are real — no inbox means higher spam score.
+- Spam trigger words in your team name or organization names (e.g., "FREE", "WINNER", "URGENT") damage deliverability even with perfect DNS config.
+- Only send invitations when a user explicitly requests access. Bulk inviting from marketing lists violates anti-spam laws and destroys domain reputation.
+- DNS propagation for CNAME records can take 24-48 hours. Do not assume failure before that window.
+- "Domain already in use" error means the domain is configured in another WorkOS account — must remove from old account first.

--- a/.claude/skills/workos/references/workos-events.md
+++ b/.claude/skills/workos/references/workos-events.md
@@ -1,0 +1,30 @@
+# WorkOS Events
+
+## Docs
+
+- https://workos.com/docs/events/index
+- https://workos.com/docs/events/observability/datadog
+- https://workos.com/docs/events/data-syncing/webhooks
+- https://workos.com/docs/events/data-syncing/index
+- https://workos.com/docs/events/data-syncing/events-api
+- https://workos.com/docs/events/data-syncing/data-reconciliation
+- https://workos.com/docs/reference/events
+- https://workos.com/docs/reference/events/list
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Do not implement both webhooks and Events API polling simultaneously — this causes duplicate event processing.
+- Webhook endpoints must return 200 OK within 5 seconds. Acknowledge immediately, process asynchronously.
+- Verify webhook signature before processing using the raw request body. JSON-parsing the body before verification breaks the signature check.
+- `WORKOS_WEBHOOK_SECRET` is shown only once when registering the endpoint. Save it immediately.
+- WorkOS may retry webhook deliveries. All event processing must be idempotent — deduplicate using `event.id`, not webhook delivery ID.
+- For Events API polling, `last_event_id` must be stored persistently. If lost, you must backfill via date-range queries.
+- Do NOT backfill by replaying webhooks. Webhook signatures expire. Always use the Events API for historical data.
+
+## Endpoints
+
+| Endpoint  | Description   |
+| --------- | ------------- |
+| `/events` | events        |
+| `/list`   | events - list |

--- a/.claude/skills/workos/references/workos-feature-flags.md
+++ b/.claude/skills/workos/references/workos-feature-flags.md
@@ -1,0 +1,30 @@
+# WorkOS Feature Flags
+
+## Docs
+
+- https://workos.com/docs/feature-flags
+- https://workos.com/docs/feature-flags/sdk-integration
+- https://workos.com/docs/feature-flags/slack-notifications
+- https://workos.com/docs/reference/feature-flags
+- https://workos.com/docs/reference/feature-flags/flag
+- https://workos.com/docs/reference/feature-flags/targeting
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Feature flags are delivered via the `feature_flags` claim in the access token — NOT via a separate API call. You must read them from the session.
+- Read the `feature_flags` claim from the session/access token. Some frameworks expose convenience helpers like `session.getFeatureFlag()`, but there is no standalone `workos.featureFlags.get()` API method. Claude tends to invent one.
+- Flags have three targeting states: None (off for all), Some (targeted orgs/users), All (on for everyone). There is no percentage rollout — it's discrete targeting.
+- Flag evaluation requires a valid session with `feature_flags` claim. If using `loadSealedSession()`, the claim is included automatically.
+- To refresh flag values mid-session, call `session.refresh()` — stale tokens carry stale flag state.
+- Flags are scoped per environment (sandbox vs production). A flag enabled in sandbox is NOT automatically enabled in production.
+- Separate **runtime evaluation** from **management**. At runtime, flag values arrive in the `feature_flags` access-token claim — do not call the API per request. For management, the API does expose write methods: `enableFeatureFlag(slug)`, `disableFeatureFlag(slug)`, `addFlagTarget({ slug, resourceId })`, `removeFlagTarget({ slug, resourceId })` (Node SDK). Flag definitions themselves (creation, slug, default state) are still Dashboard-only.
+- Slack notifications for flag changes are opt-in and configured per flag in the Dashboard.
+- In Next.js with `@workos-inc/authkit-nextjs`, server components access flags via `const { featureFlags } = await withAuth();` — the `featureFlags` field is the deserialized form of the `feature_flags` JWT claim. Prefer this over reaching for `loadSealedSession()` from `@workos-inc/node`; the AuthKit helper is the documented path and handles session loading for you.
+
+## Endpoints
+
+| Endpoint     | Description                  |
+| ------------ | ---------------------------- |
+| `/flag`      | Feature flag management      |
+| `/targeting` | Flag targeting configuration |

--- a/.claude/skills/workos/references/workos-fga.md
+++ b/.claude/skills/workos/references/workos-fga.md
@@ -1,0 +1,52 @@
+# WorkOS Fine-Grained Authorization (FGA)
+
+## Docs
+
+- https://workos.com/docs/fga
+- https://workos.com/docs/fga/quick-start
+- https://workos.com/docs/fga/resource-types
+- https://workos.com/docs/fga/resources
+- https://workos.com/docs/fga/roles-and-permissions
+- https://workos.com/docs/fga/assignments
+- https://workos.com/docs/fga/access-checks
+- https://workos.com/docs/fga/resource-discovery
+- https://workos.com/docs/fga/authkit-integration
+- https://workos.com/docs/fga/standalone-integration
+- https://workos.com/docs/fga/high-cardinality-entities
+- https://workos.com/docs/reference/fga
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- FGA extends RBAC — it is NOT a replacement. Org-level roles from RBAC still apply. FGA adds resource-scoped roles on top.
+- **SDK namespace is `workos.authorization.*`, NOT `workos.fga.*`.** The product is called FGA but every SDK method lives under `authorization`: `check`, `assignRole`, `removeRoleAssignment`, `listResources`, `createResource`, etc. Claude consistently invents `workos.fga.check`, `workos.fga.assignRole`, `workos.warrants.check` (legacy Warrant API, removed). Always use `workos.authorization.*`.
+- Resource types are configured ONLY in the Dashboard, not via API. Slugs are immutable after creation — choose carefully.
+- Access checks use `organizationMembershipId`, NOT `userId`. Fetch membership first via `listOrganizationMemberships()`.
+- Permissions use `{resource_type}:{action}` format (e.g., `project:edit`). Claude tends to invent flat permission names like `editProject`.
+- Hierarchy max depth is 5 levels, max 10 child types per resource type, max 50 resource types per environment.
+- First org-level role creation on a resource type makes that org independent — it stops inheriting environment-level roles. Same behavior as RBAC.
+- `resourceExternalId` (your app's ID) and `resourceTypeSlug` can be used instead of WorkOS `resource_id` in all API calls — prefer external IDs to avoid storing WorkOS IDs.
+- Deleting a resource fails by default if it has children or role assignments. Pass cascade option to force.
+- Access checks evaluate three levels automatically (direct assignment, inherited from parent, org-scoped role) — do NOT manually check each level.
+- For org-wide permissions, check JWT claims instead of calling the API — saves a round trip. Reserve API calls for resource-specific checks.
+
+## Endpoints
+
+| Endpoint                        | Description                              |
+| ------------------------------- | ---------------------------------------- |
+| `/fga`                          | FGA overview                             |
+| `/resource`                     | Resource management                      |
+| `/resource/create`              | Create a resource                        |
+| `/resource/get`                 | Get resource by ID                       |
+| `/resource/get-by-external-id`  | Get resource by external ID              |
+| `/resource/list`                | List resources                           |
+| `/resource/update`              | Update a resource                        |
+| `/resource/delete`              | Delete a resource                        |
+| `/role-assignment`              | Role assignment management               |
+| `/role-assignment/assign`       | Assign role on a resource                |
+| `/role-assignment/list`         | List role assignments for membership     |
+| `/role-assignment/remove`       | Remove role assignment                   |
+| `/access-check`                 | Access check                             |
+| `/access-check/check`           | Check if membership has permission       |
+| `/access-check/list-resources`  | List resources membership can access     |
+| `/access-check/list-members`    | List memberships with access to resource |

--- a/.claude/skills/workos/references/workos-go.md
+++ b/.claude/skills/workos/references/workos-go.md
@@ -1,0 +1,221 @@
+# WorkOS AuthKit for Go
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-go/main/README.md`
+
+The README is the source of truth for SDK API usage. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `go.mod` exists in the project root
+- Confirm Go module is initialized (module path declared in `go.mod`)
+
+### Environment Variables
+
+Check `.env` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `WORKOS_REDIRECT_URI` - valid callback URL (e.g., `http://localhost:8080/auth/callback`)
+
+### Framework Detection
+
+Read `go.mod` to detect web framework:
+
+```
+go.mod contains github.com/gin-gonic/gin?
+  |
+  +-- Yes --> Use Gin router patterns
+  |
+  +-- No  --> Use stdlib net/http patterns
+```
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `github.com/workos/workos-go` is already in `go.mod`
+2. Check for incomplete auth code — files that import WorkOS packages but have non-functional handlers (TODO comments, 501 responses, empty handler bodies)
+3. If partial install detected:
+   - Do NOT re-run `go get` (the module is already there)
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - Preserve any working code — only fix what's broken
+   - If `usermanagement.SetAPIKey()` is already called in `init()`, don't call it again
+   - Always run `go mod tidy` after changes to keep `go.sum` consistent
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+*.go files have 'jwt' or 'JWT'?             → Custom JWT auth
+*.go files have 'oauth2'?                   → OAuth2 middleware
+*.go files have 'authMiddleware'?            → Custom auth middleware
+go.mod has 'golang.org/x/oauth2'?           → OAuth2 package
+go.mod has 'github.com/coreos/go-oidc'?     → OIDC auth
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/auth/login` is taken)
+- Match handler signatures to the detected framework (Gin `*gin.Context` vs stdlib `http.ResponseWriter, *http.Request`)
+- Ensure existing auth middleware continues to work on its routes
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+Run:
+
+```bash
+go get github.com/workos/workos-go/v4
+```
+
+**Verify:** Check that `go.mod` now contains `github.com/workos/workos-go/v4`. Both `go.mod` and `go.sum` will be modified — this is expected.
+
+## Step 4: Configure Authentication
+
+### 4a: Create Auth Handler File
+
+Create an auth handler file. Respect existing project structure:
+
+- If `internal/` directory exists, create `internal/auth/handlers.go`
+- If `handlers/` directory exists, create `handlers/auth.go`
+- Otherwise, create `auth/handlers.go`
+
+The file must:
+
+- Declare a package matching the directory name
+- Import `github.com/workos/workos-go/v4` packages as needed
+- Read env vars with `os.Getenv("WORKOS_API_KEY")`, `os.Getenv("WORKOS_CLIENT_ID")`, `os.Getenv("WORKOS_REDIRECT_URI")`
+
+### 4b: Implement Handlers
+
+Implement these three handlers following the redirect-based auth flow from the README:
+
+**Login handler** (`/auth/login`):
+
+- Get the authorization URL from WorkOS using `usermanagement.GetAuthorizationURL()`
+- Set `Provider` to the string `"authkit"` (it's a plain string, not a constant)
+- Include `ClientID` and `RedirectURI` from env vars
+- Redirect the user to the returned URL
+
+**Callback handler** (`/auth/callback`):
+
+- Extract the `code` query parameter from the redirect
+- Call `usermanagement.AuthenticateWithCode()` with the code and `ClientID`
+- Store user info in session/cookie (or return as JSON for API-first apps)
+- Redirect to homepage or return user data
+
+**Logout handler** (`/auth/logout`):
+
+- Clear session data
+- Redirect to homepage
+
+**CRITICAL:** Use idiomatic Go error handling throughout:
+
+```go
+result, err := someFunction()
+if err != nil {
+    http.Error(w, "Error message", http.StatusInternalServerError)
+    return
+}
+```
+
+### 4c: Wire Handlers into Router
+
+#### If using Gin:
+
+```go
+r := gin.Default()
+r.GET("/auth/login", handleLogin)
+r.GET("/auth/callback", handleCallback)
+r.GET("/auth/logout", handleLogout)
+```
+
+#### If using stdlib net/http:
+
+```go
+http.HandleFunc("/auth/login", handleLogin)
+http.HandleFunc("/auth/callback", handleCallback)
+http.HandleFunc("/auth/logout", handleLogout)
+```
+
+Wire these routes into the existing router setup in `main.go` or wherever routes are defined. Do NOT replace existing routes — add alongside them.
+
+### 4d: Initialize WorkOS Client
+
+In the appropriate init location (package-level `init()` or `main()`), initialize the WorkOS client:
+
+```go
+import "github.com/workos/workos-go/v4/pkg/usermanagement"
+
+func init() {
+    usermanagement.SetAPIKey(os.Getenv("WORKOS_API_KEY"))
+}
+```
+
+Follow the README for the exact initialization pattern — it may differ from above.
+
+## Step 5: Environment Setup
+
+The `.env` file should already contain the required variables (written by the installer). Verify it contains:
+
+```
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+WORKOS_REDIRECT_URI=http://localhost:8080/auth/callback
+```
+
+**Note for production:** Go does not have a built-in .env convention. In production, set real OS environment variables. The `.env` file is for development only. If using a `.env` loader like `github.com/joho/godotenv`, the agent may install it and add `godotenv.Load()` to `main()`.
+
+## Step 6: Verification
+
+Run these commands. **Do not mark complete until all pass:**
+
+```bash
+# 1. Go module is tidy
+go mod tidy
+
+# 2. Build succeeds
+go build ./...
+
+# 3. Vet passes (catches common mistakes)
+go vet ./...
+```
+
+If build fails:
+
+- Check import paths match the SDK version in `go.mod`
+- Ensure all new files have correct package declarations
+- Run `go mod tidy` to resolve dependency issues
+
+## Error Recovery
+
+### "cannot find module providing package github.com/workos/workos-go/v4/..."
+
+- Run `go mod tidy` to sync dependencies
+- Check that `go get` completed successfully
+- Verify the import path matches exactly (v4 suffix required)
+
+### "undefined: usermanagement.SetAPIKey" or similar
+
+- SDK API may have changed — refer to the fetched README
+- Check the correct subpackage import path
+
+### Build fails with type errors
+
+- Ensure handler function signatures match the framework (Gin uses `*gin.Context`, stdlib uses `http.ResponseWriter, *http.Request`)
+- Check that error return values are handled
+
+### "package X is not in std"
+
+- Run `go mod tidy` after adding new imports
+- Ensure `go get` was run before writing import statements

--- a/.claude/skills/workos/references/workos-integrations.md
+++ b/.claude/skills/workos/references/workos-integrations.md
@@ -1,0 +1,253 @@
+---
+name: workos-integrations
+description: Set up identity provider integrations with WorkOS. Covers SSO, SCIM, and OAuth for 40+ providers.
+---
+
+<!-- generated:sha256:cd3ef709325d -->
+
+# WorkOS Integrations
+
+## Step 1: Identify the Provider
+
+Ask the user which identity provider they need to integrate. Then find it in the table below.
+
+## Provider Lookup
+
+| Provider               | Type       | Doc URL                                                  |
+| ---------------------- | ---------- | -------------------------------------------------------- |
+| Access People HR       | General    | workos.com/docs/integrations/access-people-hr            |
+| ADP                    | OIDC       | workos.com/docs/integrations/adp-oidc                    |
+| Apple                  | General    | workos.com/docs/integrations/apple                       |
+| Auth0                  | SAML       | workos.com/docs/integrations/auth0-saml                  |
+| Auth0                  | Enterprise | workos.com/docs/integrations/auth0-enterprise-connection |
+| Auth0                  | Directory  | workos.com/docs/integrations/auth0-directory-sync        |
+| AWS Cognito            | General    | workos.com/docs/integrations/aws-cognito                 |
+| Bamboohr               | General    | workos.com/docs/integrations/bamboohr                    |
+| Breathe HR             | General    | workos.com/docs/integrations/breathe-hr                  |
+| Bubble                 | General    | workos.com/docs/integrations/bubble                      |
+| CAS                    | SAML       | workos.com/docs/integrations/cas-saml                    |
+| Cezanne HR             | General    | workos.com/docs/integrations/cezanne                     |
+| Classlink              | SAML       | workos.com/docs/integrations/classlink-saml              |
+| Clever                 | OIDC       | workos.com/docs/integrations/clever-oidc                 |
+| Cloudflare             | SAML       | workos.com/docs/integrations/cloudflare-saml             |
+| Cyberark               | SCIM       | workos.com/docs/integrations/cyberark-scim               |
+| Cyberark               | SAML       | workos.com/docs/integrations/cyberark-saml               |
+| Duo                    | SAML       | workos.com/docs/integrations/duo-saml                    |
+| Entra ID (Azure AD)    | SCIM       | workos.com/docs/integrations/entra-id-scim               |
+| Entra ID (Azure AD)    | SAML       | workos.com/docs/integrations/entra-id-saml               |
+| Entra ID (Azure AD)    | OIDC       | workos.com/docs/integrations/entra-id-oidc               |
+| Firebase               | General    | workos.com/docs/integrations/firebase                    |
+| Fourth                 | General    | workos.com/docs/integrations/fourth                      |
+| Github                 | OAuth      | workos.com/docs/integrations/github-oauth                |
+| Gitlab                 | OAuth      | workos.com/docs/integrations/gitlab-oauth                |
+| Google Workspace       | SAML       | workos.com/docs/integrations/google-saml                 |
+| Google Workspace       | OIDC       | workos.com/docs/integrations/google-oidc                 |
+| Google Workspace       | OAuth      | workos.com/docs/integrations/google-oauth                |
+| Google Workspace       | Directory  | workos.com/docs/integrations/google-directory-sync       |
+| Hibob                  | General    | workos.com/docs/integrations/hibob                       |
+| Intuit                 | OAuth      | workos.com/docs/integrations/intuit-oauth                |
+| Jumpcloud              | SCIM       | workos.com/docs/integrations/jumpcloud-scim              |
+| Jumpcloud              | SAML       | workos.com/docs/integrations/jumpcloud-saml              |
+| Keycloak               | SAML       | workos.com/docs/integrations/keycloak-saml               |
+| Lastpass               | SAML       | workos.com/docs/integrations/lastpass-saml               |
+| Linkedin               | OAuth      | workos.com/docs/integrations/linkedin-oauth              |
+| Login.gov              | OIDC       | workos.com/docs/integrations/login-gov-oidc              |
+| Microsoft              | OAuth      | workos.com/docs/integrations/microsoft-oauth             |
+| Microsoft AD FS        | SAML       | workos.com/docs/integrations/microsoft-ad-fs-saml        |
+| Miniorange             | SAML       | workos.com/docs/integrations/miniorange-saml             |
+| NetIQ                  | SAML       | workos.com/docs/integrations/net-iq-saml                 |
+| NextAuth.js            | General    | workos.com/docs/integrations/next-auth                   |
+| Oidc                   | General    | workos.com/docs/integrations/oidc                        |
+| Okta                   | SCIM       | workos.com/docs/integrations/okta-scim                   |
+| Okta                   | SAML       | workos.com/docs/integrations/okta-saml                   |
+| Okta                   | OIDC       | workos.com/docs/integrations/okta-oidc                   |
+| Onelogin               | SCIM       | workos.com/docs/integrations/onelogin-scim               |
+| Onelogin               | SAML       | workos.com/docs/integrations/onelogin-saml               |
+| Oracle                 | SAML       | workos.com/docs/integrations/oracle-saml                 |
+| Pingfederate           | SCIM       | workos.com/docs/integrations/pingfederate-scim           |
+| Pingfederate           | SAML       | workos.com/docs/integrations/pingfederate-saml           |
+| Pingone                | SAML       | workos.com/docs/integrations/pingone-saml                |
+| React Native Expo      | General    | workos.com/docs/integrations/react-native-expo           |
+| Rippling               | SCIM       | workos.com/docs/integrations/rippling-scim               |
+| Rippling               | SAML       | workos.com/docs/integrations/rippling-saml               |
+| Sailpoint              | SCIM       | workos.com/docs/integrations/sailpoint-scim              |
+| Salesforce             | SAML       | workos.com/docs/integrations/salesforce-saml             |
+| Salesforce             | OAuth      | workos.com/docs/integrations/salesforce-oauth            |
+| Saml                   | General    | workos.com/docs/integrations/saml                        |
+| Scim                   | General    | workos.com/docs/integrations/scim                        |
+| Sftp                   | General    | workos.com/docs/integrations/sftp                        |
+| Shibboleth Generic     | SAML       | workos.com/docs/integrations/shibboleth-generic-saml     |
+| Shibboleth Unsolicited | SAML       | workos.com/docs/integrations/shibboleth-unsolicited-saml |
+| SimpleSAMLphp          | General    | workos.com/docs/integrations/simple-saml-php             |
+| Slack                  | OAuth      | workos.com/docs/integrations/slack-oauth                 |
+| Supabase + AuthKit     | General    | workos.com/docs/integrations/supabase-authkit            |
+| Supabase + WorkOS SSO  | General    | workos.com/docs/integrations/supabase-sso                |
+| Vercel                 | OAuth      | workos.com/docs/integrations/vercel-oauth                |
+| Vmware                 | SAML       | workos.com/docs/integrations/vmware-saml                 |
+| Workday                | General    | workos.com/docs/integrations/workday                     |
+| Xero                   | OAuth      | workos.com/docs/integrations/xero-oauth                  |
+
+## Step 2: Set Up the Connection
+
+**WebFetch** the provider-specific doc URL from the table above, then follow the protocol for the connection type.
+
+### SAML SSO Setup
+
+1. In WorkOS Dashboard, navigate to **Organizations > [Org] > Authentication**
+2. Click **Add Connection** and select SAML
+3. Copy these values from the connection detail page:
+   - **ACS URL** (Assertion Consumer Service) — paste into IdP's SSO config
+   - **SP Entity ID** — paste into IdP's audience/entity field
+4. In the IdP admin console, create a new SAML application:
+   a. Set the ACS URL and SP Entity ID from step 3
+   b. Configure attribute mapping: `id` → NameID, `email` → email, `firstName` → first name, `lastName` → last name
+   c. Download or copy the **IdP Metadata URL** (or download the metadata XML file)
+5. Back in WorkOS Dashboard, upload the IdP metadata (URL or XML file)
+6. Connection state transitions: **Draft → Validating → Active**
+   - If it stays in Draft, see Troubleshooting below
+
+### SCIM Directory Sync Setup
+
+1. In WorkOS Dashboard, navigate to **Organizations > [Org] > Directory Sync**
+2. Click **Add Directory** and select the provider
+3. Copy these values from the directory detail page:
+   - **SCIM Endpoint URL** (e.g., `https://api.workos.com/directories/<DIR_ID>/scim/v2`)
+   - **SCIM Bearer Token** — treat as a secret, never log or commit
+4. In the IdP admin console, configure SCIM provisioning:
+   a. Set the SCIM Base URL to the endpoint from step 3
+   b. Set Authentication to **Bearer Token** and paste the token
+   c. Enable provisioning actions: Create Users, Update User Attributes, Deactivate Users
+   d. Map user attributes: `userName` → email, `name.givenName` → first name, `name.familyName` → last name
+5. Run a test push/sync from the IdP to verify users appear in WorkOS
+6. Directory state transitions: **Inactive → Validating → Linked**
+
+### OAuth Social Login Setup
+
+1. In the OAuth provider's developer console, create a new OAuth application
+2. Set the **Redirect URI** to the value from WorkOS Dashboard:
+   - Format: `https://auth.workos.com/sso/oauth/callback/<CONNECTION_ID>`
+3. Copy the **Client ID** and **Client Secret** from the provider
+4. In WorkOS Dashboard, navigate to **Authentication > Social Login**
+5. Select the provider and paste the Client ID and Client Secret
+6. Configure scopes (typically: `openid`, `profile`, `email`)
+7. Test by initiating a login flow through your application
+
+## Step 3: Verify the Integration
+
+```bash
+# Check connection status via WorkOS API
+curl -s -H "Authorization: Bearer $WORKOS_API_KEY" \
+  https://api.workos.com/connections | jq '.data[] | {id, name, state}'
+
+# Verify SSO connection is active
+curl -s -H "Authorization: Bearer $WORKOS_API_KEY" \
+  https://api.workos.com/connections | jq '.data[] | select(.state == "active") | .name'
+
+# Check directory sync connections
+curl -s -H "Authorization: Bearer $WORKOS_API_KEY" \
+  https://api.workos.com/directories | jq '.data[] | {id, name, state}'
+```
+
+Checklist:
+
+- [ ] Connection appears in WorkOS Dashboard with "Active" (SSO) or "Linked" (directory) state
+- [ ] Test SSO login succeeds with a test user
+- [ ] User profile attributes map correctly (email, first name, last name, groups)
+- [ ] (If SCIM) Directory sync shows users from provider
+- [ ] (If OAuth) Social login redirects correctly and returns user profile
+
+## Integration Type Decision Tree
+
+```
+What type of integration?
+  |
+  +-- SSO (user login)
+  |     |
+  |     +-- Provider supports SAML? → Use SAML connection (preferred for enterprise)
+  |     +-- Provider supports OIDC only? → Use OIDC connection
+  |     +-- Provider supports both? → Prefer SAML (wider enterprise support, more attributes)
+  |
+  +-- Directory Sync (user provisioning)
+  |     |
+  |     +-- Provider supports SCIM? → Use SCIM connection
+  |     +-- No SCIM but has API? → Check if WorkOS has a native directory for this provider
+  |     +-- No directory support? → Consider SFTP-based import or manual sync
+  |
+  +-- OAuth (social login)
+        |
+        +-- Find provider in OAuth section of table above
+        +-- Follow OAuth setup steps in Step 2
+```
+
+## Troubleshooting Decision Tree
+
+```
+Connection not working?
+  |
+  +-- Connection stuck in "Draft"
+  |     |
+  |     +-- Did you upload IdP metadata? → Upload XML or enter metadata URL in Dashboard
+  |     +-- Metadata uploaded but still Draft? → Check metadata is valid XML, not HTML login page
+  |     +-- Using metadata URL? → Verify URL is publicly reachable (not behind firewall)
+  |
+  +-- Connection stuck in "Validating"
+  |     |
+  |     +-- IdP metadata certificate expired? → Upload new cert or fresh metadata
+  |     +-- ACS URL contains typo? → Re-copy from Dashboard, paste exactly
+  |     +-- SP Entity ID mismatch? → Ensure IdP audience matches WorkOS SP Entity ID exactly
+  |
+  +-- SAML assertion errors
+  |     |
+  |     +-- "Recipient mismatch" → ACS URL in IdP config does not match WorkOS; re-copy it
+  |     +-- "Audience mismatch" → SP Entity ID in IdP does not match; re-copy it
+  |     +-- "Signature invalid" → IdP metadata/certificate is stale; re-upload current metadata
+  |     +-- "Response expired" → Clock skew between IdP and SP; verify NTP sync on IdP server
+  |     +-- "NameID missing" → IdP not sending NameID; add NameID mapping in IdP attribute config
+  |
+  +-- SCIM sync failing
+  |     |
+  |     +-- 401 Unauthorized → Bearer token is wrong or expired; regenerate in Dashboard
+  |     +-- 404 Not Found → SCIM endpoint URL is wrong; re-copy from Dashboard
+  |     +-- Users sync but no attributes → Check attribute mapping in IdP; must map userName, name.*
+  |     +-- Users created but not updated → Ensure "Update User Attributes" is enabled in IdP provisioning
+  |     +-- Deactivated users still active → Enable "Deactivate Users" in IdP provisioning settings
+  |
+  +-- OAuth redirect errors
+  |     |
+  |     +-- "redirect_uri_mismatch" → Redirect URI in provider console doesn't match WorkOS; copy exact URI
+  |     +-- "invalid_client" → Client ID or Secret is wrong; re-copy from provider console
+  |     +-- "access_denied" → User denied consent, or OAuth app not approved; check provider app status
+  |     +-- Scopes error → Remove unsupported scopes; start with openid, profile, email
+  |
+  +-- "Organization not found"
+        |
+        +-- No org exists → Create organization in Dashboard first
+        +-- Org exists but connection not linked → Link connection to organization in Dashboard
+        +-- Domain not verified → Verify domain under Organizations > Domains (required for SSO)
+```
+
+## Error Recovery Reference
+
+| Problem                          | Root Cause                                      | Fix                                                                               |
+| -------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| Connection stuck in "Draft"      | IdP metadata not uploaded or invalid            | Upload valid IdP metadata XML or enter a reachable metadata URL in Dashboard      |
+| Connection stuck in "Validating" | Certificate expired or ACS/Entity ID mismatch   | Re-upload fresh metadata; verify ACS URL and SP Entity ID match exactly           |
+| SAML "Recipient mismatch"        | ACS URL in IdP does not match WorkOS value      | Copy the exact ACS URL from the connection's details in the WorkOS Dashboard      |
+| SAML "Audience mismatch"         | SP Entity ID in IdP does not match WorkOS       | Copy exact SP Entity ID from Dashboard; paste into IdP audience/entity field      |
+| SAML "Signature invalid"         | IdP certificate rotated but WorkOS has old cert | Re-download IdP metadata and re-upload to WorkOS Dashboard                        |
+| SAML "Response expired"          | Clock skew between IdP server and WorkOS        | Sync IdP server time via NTP; most assertions allow 5-minute skew                 |
+| SCIM 401 Unauthorized            | Bearer token is expired or was regenerated      | Copy the current bearer token from the directory's SCIM settings in the Dashboard |
+| SCIM 404 Not Found               | Endpoint URL has wrong directory ID or path     | Re-copy full SCIM endpoint URL from Dashboard                                     |
+| SCIM sync no attributes          | Attribute mapping missing in IdP                | Map userName, name.givenName, name.familyName in IdP SCIM config                  |
+| SCIM users not deactivated       | Deprovisioning not enabled                      | Enable "Deactivate Users" in IdP provisioning settings                            |
+| OAuth "redirect_uri_mismatch"    | Redirect URI in provider console is different   | Paste exact redirect URI from WorkOS Dashboard into provider OAuth app            |
+| OAuth "invalid_client"           | Client ID or Secret is wrong                    | Re-copy Client ID and Secret from provider developer console                      |
+| "Organization not found"         | Connection not linked to an organization        | Create org in Dashboard, then link the connection to it                           |
+| "Domain not verified"            | SSO requires a verified domain                  | Add and verify the organization's domain in the Dashboard                         |
+
+## Related Skills
+
+- **workos-sso**: General SSO implementation and configuration
+- **workos-directory-sync**: Directory Sync setup and management
+- **workos-domain-verification**: Domain verification required for SSO
+- **workos-admin-portal**: Let customers configure their own connections

--- a/.claude/skills/workos/references/workos-kotlin.md
+++ b/.claude/skills/workos/references/workos-kotlin.md
@@ -1,0 +1,190 @@
+# WorkOS AuthKit for Kotlin (Spring Boot)
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-kotlin/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `build.gradle.kts` exists (Kotlin DSL) or `build.gradle` (Groovy DSL)
+- Confirm Spring Boot plugin is present (`org.springframework.boot`)
+- Detect Gradle wrapper: check if `./gradlew` exists
+
+### Gradle Wrapper
+
+```bash
+# If gradlew exists, ensure it's executable
+if [ -f ./gradlew ]; then chmod +x ./gradlew; fi
+```
+
+Use `./gradlew` if wrapper exists, otherwise fall back to `gradle`.
+
+### Environment Variables
+
+Check `application.properties` or `application.yml` for:
+
+- `workos.api-key` or `WORKOS_API_KEY`
+- `workos.client-id` or `WORKOS_CLIENT_ID`
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `workos-kotlin` is already in `build.gradle.kts` dependencies
+2. Check for incomplete auth code — WorkOS imported/instantiated but no controller with login/callback endpoints
+3. If partial install detected:
+   - Do NOT re-add the SDK dependency (it's already there)
+   - Read existing source files to understand what's done vs missing
+   - Complete the integration by filling gaps (controller, config bean, routes)
+   - Preserve any working code — only fix what's broken
+   - Check for a missing `/auth/callback` endpoint (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+build.gradle.kts has 'spring-boot-starter-security'?  → Spring Security
+*.kt files have 'SecurityFilterChain'?                → Security filter config
+*.kt files have 'formLogin'?                          → Form-based auth
+*.kt files have 'oauth2Login'?                        → OAuth2 auth
+*.kt files have 'httpBasic'?                          → Basic auth
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If Spring Security is configured, ensure WorkOS auth routes are permitted through the security filter chain (add `.requestMatchers("/auth/workos/**").permitAll()`)
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/login` is taken)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+Add the WorkOS Kotlin SDK dependency to `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.workos:workos-kotlin:4.18.1")
+    // ... existing dependencies
+}
+```
+
+Check the README for the latest version number — use the version from the README if it differs from above.
+
+**JVM target**: Ensure `jvmTarget` in `build.gradle.kts` matches the JDK on the system. Check with `java -version`. Common values: `"17"`, `"21"`. If `kotlin { jvmToolchain(...) }` is set, ensure it matches too.
+
+**Verify:** Run `./gradlew dependencies` or `gradle dependencies` to confirm the dependency resolves.
+
+## Step 4: Configure Authentication
+
+### 4a: Application Properties
+
+Add WorkOS configuration to `src/main/resources/application.properties`:
+
+```properties
+workos.api-key=${WORKOS_API_KEY}
+workos.client-id=${WORKOS_CLIENT_ID}
+workos.redirect-uri=http://localhost:8080/auth/callback
+```
+
+Or if the project uses `application.yml`, add the equivalent YAML.
+
+### 4b: Create WorkOS Configuration Bean
+
+Create a configuration class that initializes the WorkOS client:
+
+```kotlin
+@Configuration
+class WorkOSConfig {
+    @Value("\${workos.api-key}")
+    lateinit var apiKey: String
+
+    @Bean
+    fun workos(): WorkOS = WorkOS(apiKey)
+}
+```
+
+Adapt based on the SDK README — the exact client initialization may vary.
+
+### 4c: Create Auth Controller
+
+Create a Spring `@RestController` with these endpoints:
+
+1. **GET /auth/login** — Redirect user to WorkOS AuthKit hosted login
+   - Use `workos.userManagement.getAuthorizationUrl()` — this returns a URL string
+   - Parameters: `clientId`, `redirectUri`, `provider = "authkit"`
+   - The method uses a builder pattern: `.provider("authkit").redirectUri(uri).build()`
+
+2. **GET /auth/callback** — Exchange authorization code for user profile
+   - Extract `code` query parameter
+   - Call `workos.userManagement.authenticateWithCode()` with the code and clientId
+   - Store user session (use Spring's `HttpSession`)
+   - Redirect to home page
+
+3. **GET /auth/logout** — Clear session and redirect
+   - Invalidate `HttpSession`
+   - Redirect to home page or WorkOS logout URL
+
+**Follow the README for exact API method names and parameters.**
+
+## Step 5: Session Management
+
+Use Spring's built-in `HttpSession` for session management:
+
+- Store user profile in session after callback
+- Check session in protected routes
+- Clear session on logout
+
+If Spring Security is already configured, integrate with the existing security filter chain rather than replacing it.
+
+## Step 6: Verification
+
+Run the build to verify everything compiles:
+
+```bash
+./gradlew build
+```
+
+**If build fails:**
+
+- Check dependency resolution: `./gradlew dependencies | grep workos`
+- Check for missing imports in the auth controller
+- Verify application.properties syntax
+- Gradle builds can be slow (30-60s) — be patient
+
+### Checklist
+
+- [ ] WorkOS SDK dependency in build.gradle.kts
+- [ ] Application properties configured
+- [ ] Auth controller with login, callback, logout endpoints
+- [ ] Build succeeds (`./gradlew build`)
+
+## Error Recovery
+
+### Dependency resolution failure
+
+- Check Maven Central is accessible
+- Verify the artifact coordinates match README exactly
+- Ensure `mavenCentral()` is in the `repositories` block of build.gradle.kts
+
+### "Could not resolve com.workos:workos-kotlin"
+
+- The package may use a different group ID — check README
+- Ensure repositories block includes `mavenCentral()`
+
+### Build fails with missing Spring Boot annotations
+
+- Verify `org.springframework.boot` plugin is applied
+- Check Spring Boot starter dependencies are present
+
+### Gradle wrapper permission denied
+
+- Run `chmod +x ./gradlew` before building

--- a/.claude/skills/workos/references/workos-management.md
+++ b/.claude/skills/workos/references/workos-management.md
@@ -1,0 +1,290 @@
+# WorkOS Management Commands
+
+Use these commands to manage WorkOS resources directly from the terminal. The CLI must be authenticated via `workos auth login` or `WORKOS_API_KEY` env var.
+
+All commands support `--json` for structured output. Use `--json` when you need to parse output (e.g., extract an ID).
+
+## Checking what the CLI can do (READ THIS FIRST)
+
+**If a user asks whether the CLI supports operation X, or if you're about to suggest a `workos ...` command, verify it first.** The authoritative, machine-readable command tree is:
+
+```bash
+workos --help --json
+```
+
+This emits a complete JSON tree of every registered command, subcommand, and flag. If a command or subcommand is not in that output, **it does not exist** — do not invent it, do not suggest it, do not assume "it must be there." Common agent failure mode: seeing that `workos <resource>` supports `list/get/delete` and assuming `create` / `update` also exist when they don't.
+
+**Rule**: Before suggesting any `workos` command not listed in the Quick Reference table below, either (a) run `workos --help --json` and confirm the command exists, or (b) tell the user "this doesn't appear to be in the CLI — verify with `workos --help --json`." Never guess.
+
+**The tables below are a snapshot and may lag the published CLI.** The live `--help --json` output is the source of truth.
+
+## Detecting and recommending CLI upgrades
+
+If `workos --help --json` is missing a command you expected, or the user reports `unknown command: <something>` for a command that exists in the latest release, **the user is likely on an outdated CLI** rather than encountering a bug. Before suggesting a workaround:
+
+1. Ask the user to run `workos --version`.
+2. Compare against the latest published version with `npm view workos version` (do NOT guess the latest version from memory — it moves frequently).
+3. If the user is behind, send them to `references/workos-cli-upgrade.md` for the upgrade command for their package manager (npm/pnpm) and the no-install `npx workos@latest` fallback.
+
+## Quick Reference
+
+| Task                   | Command                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| List organizations     | `workos organization list`                                                   |
+| Create organization    | `workos organization create "Acme Corp" acme.com:verified`                   |
+| List users             | `workos user list --email=alice@acme.com`                                    |
+| Create permission      | `workos permission create --slug=read-users --name="Read Users"`             |
+| Create role            | `workos role create --slug=admin --name=Admin`                               |
+| Assign perms to role   | `workos role set-permissions admin --permissions=read-users,write-users`     |
+| Create org-scoped role | `workos role create --slug=admin --name=Admin --org=org_xxx`                 |
+| Add user to org        | `workos membership create --org=org_xxx --user=user_xxx`                     |
+| Send invitation        | `workos invitation send --email=alice@acme.com --org=org_xxx`                |
+| Revoke session         | `workos session revoke <sessionId>`                                          |
+| Add redirect URI       | `workos config redirect add http://localhost:3000/callback`                  |
+| Add CORS origin        | `workos config cors add http://localhost:3000`                               |
+| Set homepage URL       | `workos config homepage-url set http://localhost:3000`                       |
+| Create webhook         | `workos webhook create --url=https://example.com/hook --events=user.created` |
+| List SSO connections   | `workos connection list --org=org_xxx`                                       |
+| List directories       | `workos directory list`                                                      |
+| Toggle feature flag    | `workos feature-flag enable my-flag`                                         |
+| Store a secret         | `workos vault create --name=api-secret --value=sk_xxx --org=org_xxx`         |
+| Generate portal link   | `workos portal generate-link --intent=sso --org=org_xxx`                     |
+| Seed environment       | `workos seed --file=workos-seed.yml`                                         |
+| Debug SSO              | `workos debug-sso conn_xxx`                                                  |
+| Debug directory sync   | `workos debug-sync directory_xxx`                                            |
+| Set up an org          | `workos setup-org "Acme Corp" --domain=acme.com --roles=admin,viewer`        |
+| Onboard a user         | `workos onboard-user alice@acme.com --org=org_xxx --role=admin`              |
+
+## Workflows
+
+### Setting up RBAC
+
+When you see permission checks in the codebase (e.g., `hasPermission('read-users')`), create the matching WorkOS resources:
+
+```bash
+workos permission create --slug=read-users --name="Read Users"
+workos permission create --slug=write-users --name="Write Users"
+workos role create --slug=admin --name=Admin
+workos role set-permissions admin --permissions=read-users,write-users
+workos role create --slug=viewer --name=Viewer
+workos role set-permissions viewer --permissions=read-users
+```
+
+For organization-scoped roles, add `--org=org_xxx` to role commands.
+
+### Organization Onboarding
+
+One-shot setup with the compound command:
+
+```bash
+workos setup-org "Acme Corp" --domain=acme.com --roles=admin,viewer
+```
+
+Or step by step:
+
+```bash
+ORG_ID=$(workos organization create "Acme Corp" --json | jq -r '.data.id')
+workos org-domain create acme.com --org=$ORG_ID
+workos role create --slug=admin --name=Admin --org=$ORG_ID
+workos portal generate-link --intent=sso --org=$ORG_ID
+```
+
+### User Onboarding
+
+```bash
+workos onboard-user alice@acme.com --org=org_xxx --role=admin
+```
+
+Or step by step:
+
+```bash
+workos invitation send --email=alice@acme.com --org=org_xxx --role=admin
+workos membership create --org=org_xxx --user=user_xxx --role=admin
+```
+
+### Local Development Setup
+
+Configure WorkOS for local development:
+
+```bash
+workos config redirect add http://localhost:3000/callback
+workos config cors add http://localhost:3000
+workos config homepage-url set http://localhost:3000
+```
+
+### Environment Seeding
+
+Create a `workos-seed.yml` file in your repo:
+
+```yaml
+permissions:
+  - name: 'Read Users'
+    slug: 'read-users'
+  - name: 'Write Users'
+    slug: 'write-users'
+
+roles:
+  - name: 'Admin'
+    slug: 'admin'
+    permissions: ['read-users', 'write-users']
+  - name: 'Viewer'
+    slug: 'viewer'
+    permissions: ['read-users']
+
+organizations:
+  - name: 'Test Org'
+    domains: ['test.com']
+
+config:
+  redirect_uris: ['http://localhost:3000/callback']
+  cors_origins: ['http://localhost:3000']
+  homepage_url: 'http://localhost:3000'
+```
+
+Then run:
+
+```bash
+workos seed --file=workos-seed.yml   # Create resources
+workos seed --clean                  # Tear down seeded resources
+```
+
+### Debugging SSO
+
+```bash
+workos debug-sso conn_xxx
+```
+
+Shows: connection type/state, organization binding, recent auth events, and common issues (inactive connection, org mismatch).
+
+### Debugging Directory Sync
+
+```bash
+workos debug-sync directory_xxx
+```
+
+Shows: directory type/state, user/group counts, recent sync events, and stall detection.
+
+### Webhook Management
+
+```bash
+workos webhook list
+workos webhook create --url=https://example.com/hook --events=user.created,dsync.user.created
+workos webhook delete we_xxx
+```
+
+### Audit Logs
+
+```bash
+workos audit-log create-event --org=org_xxx --action=user.login --actor-type=user --actor-id=user_xxx
+workos audit-log list-actions
+workos audit-log get-schema user.login
+workos audit-log export --org=org_xxx --range-start=2024-01-01 --range-end=2024-02-01
+workos audit-log get-retention --org=org_xxx
+```
+
+## Using --json for Structured Output
+
+All commands support `--json` for machine-readable output. Use this when you need to extract values:
+
+```bash
+# Get an organization ID
+workos organization list --json | jq '.data[0].id'
+
+# Get a connection's state
+workos connection get conn_xxx --json | jq '.state'
+
+# List all role slugs
+workos role list --json | jq '.data[].slug'
+
+# Chain commands: create org then add domain
+ORG_ID=$(workos organization create "Acme" --json | jq -r '.data.id')
+workos org-domain create acme.com --org=$ORG_ID
+```
+
+JSON output format:
+
+- **List commands**: `{ "data": [...], "listMetadata": { "before": null, "after": "cursor" } }`
+- **Get commands**: Raw object (no wrapper)
+- **Create/Update/Delete**: `{ "status": "ok", "message": "...", "data": {...} }`
+- **Errors**: `{ "error": { "code": "...", "message": "..." } }` on stderr
+
+## Command Reference
+
+### Resource Commands
+
+| Command               | Subcommands                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `workos organization` | `list`, `get`, `create`, `update`, `delete`                                                           |
+| `workos user`         | `list`, `get`, `update`, `delete`                                                                     |
+| `workos role`         | `list`, `get`, `create`, `update`, `delete`, `set-permissions`, `add-permission`, `remove-permission` |
+| `workos permission`   | `list`, `get`, `create`, `update`, `delete`                                                           |
+| `workos membership`   | `list`, `get`, `create`, `update`, `delete`, `deactivate`, `reactivate`                               |
+| `workos invitation`   | `list`, `get`, `send`, `revoke`, `resend`                                                             |
+| `workos session`      | `list`, `revoke`                                                                                      |
+| `workos connection`   | `list`, `get`, `delete`                                                                               |
+| `workos directory`    | `list`, `get`, `delete`, `list-users`, `list-groups`                                                  |
+| `workos event`        | `list` (requires `--events` flag)                                                                     |
+| `workos audit-log`    | `create-event`, `export`, `list-actions`, `get-schema`, `create-schema`, `get-retention`              |
+| `workos feature-flag` | `list`, `get`, `enable`, `disable`, `add-target`, `remove-target`                                     |
+| `workos webhook`      | `list`, `create`, `delete`                                                                            |
+| `workos config`       | `redirect add`, `cors add`, `homepage-url set`                                                        |
+| `workos portal`       | `generate-link`                                                                                       |
+| `workos vault`        | `list`, `get`, `get-by-name`, `create`, `update`, `delete`, `describe`, `list-versions`               |
+| `workos api-key`      | `list`, `create`, `validate`, `delete`                                                                |
+| `workos org-domain`   | `get`, `create`, `verify`, `delete`                                                                   |
+
+### Workflow Commands
+
+| Command                       | Purpose                                     |
+| ----------------------------- | ------------------------------------------- |
+| `workos seed --file=<yaml>`   | Declarative resource provisioning from YAML |
+| `workos seed --clean`         | Tear down seeded resources                  |
+| `workos setup-org <name>`     | One-shot org onboarding                     |
+| `workos onboard-user <email>` | Send invitation + optional wait             |
+| `workos debug-sso <connId>`   | SSO connection diagnostics                  |
+| `workos debug-sync <dirId>`   | Directory sync diagnostics                  |
+
+### Common Flags
+
+| Flag                                        | Purpose                  | Scope                                               |
+| ------------------------------------------- | ------------------------ | --------------------------------------------------- |
+| `--json`                                    | Structured JSON output   | All commands                                        |
+| `--api-key`                                 | Override API key         | Resource commands                                   |
+| `--org`                                     | Organization scope       | role, membership, invitation, api-key, feature-flag |
+| `--force`                                   | Skip confirmation prompt | connection delete, directory delete                 |
+| `--limit`, `--before`, `--after`, `--order` | Pagination               | All list commands                                   |
+
+## Not in the CLI (use Dashboard, Admin Portal, API, or a different workflow)
+
+These operations are commonly asked for but are **not** supported in the WorkOS CLI today. Do not invent commands for them. For each, the right answer is listed.
+
+### Dashboard / Admin Portal only
+
+| Operation                                                       | Where it lives                                                                          | Docs                                                                     |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Create an SSO connection                                        | Admin Portal (generate via `workos portal generate-link --intent=sso --org=<org_id>`)   | https://workos.com/docs/sso/guide                                        |
+| Create a Directory Sync connection                              | Admin Portal (generate via `workos portal generate-link --intent=dsync --org=<org_id>`) | https://workos.com/docs/directory-sync/quick-start                       |
+| Map IdP (Entra/AD/Okta/Google Workspace) groups to WorkOS roles | Admin Portal during directory setup, or directory page in Dashboard                     | https://workos.com/docs/directory-sync/identity-provider-role-assignment |
+| Map SSO groups to WorkOS roles                                  | Admin Portal during SSO setup, or connection page in Dashboard                          | https://workos.com/docs/rbac/idp-role-assignment                         |
+| Enable/disable Admin Portal role-assignment step                | Authorization page in the WorkOS Dashboard                                              | https://workos.com/docs/directory-sync/identity-provider-role-assignment |
+| Enable/disable authentication methods                           | Authentication settings in the WorkOS Dashboard                                         | https://workos.com/docs/authkit                                          |
+| Configure session lifetime                                      | Authentication settings in the WorkOS Dashboard                                         | https://workos.com/docs/user-management/sessions                         |
+| Set up social login providers (Google, GitHub, etc.)            | Authentication settings in the WorkOS Dashboard                                         | https://workos.com/docs/user-management/social-login                     |
+| Create feature flags                                            | Feature Flags page in the WorkOS Dashboard (toggle/target ops work via CLI)             | https://workos.com/docs/feature-flags                                    |
+| Configure branding (logos, colors)                              | Branding settings in the WorkOS Dashboard                                               | https://workos.com/docs/admin-portal/branding                            |
+| Set up email templates                                          | Email settings in the WorkOS Dashboard                                                  | https://workos.com/docs/emails                                           |
+| Manage billing / plan                                           | Settings in the WorkOS Dashboard                                                        | —                                                                        |
+
+### API-only (not in CLI, but can be scripted via SDK / REST)
+
+| Operation                              | Where it lives                              | Notes                                                                                                      |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Assign a role to an individual user    | `updateOrganizationMembership` via SDK/REST | Warning: IdP mapping silently overrides this on next sync/login when mapping exists. See `workos-rbac.md`. |
+| Webhook signature verification         | SDK (`workos.webhooks.verifyEvent`)         | CLI can create/list/delete webhooks but does not verify events                                             |
+| Session introspection / JWT validation | SDK                                         | CLI has `workos session list/revoke` only                                                                  |
+
+**Rule of thumb**: if a user asks "is there a CLI command for X" and X is not in the Quick Reference table above and is not produced by `workos --help --json`, the answer is **no**. Do not speculate. Point the user at the right surface per this table.
+
+### Do not invent click-paths in the Dashboard
+
+The paths in the "Where it lives" column above are intentionally described in conceptual terms ("Authentication settings", "directory page") rather than as literal click-paths like "Dashboard > Organizations > X > Y". The docs don't commit to exact menu paths, and the Dashboard UI is re-organized periodically. Link the user to the docs URL and let them navigate. If you see yourself writing `Dashboard > A > B > C` or `dashboard.workos.com/some/path`, stop and link to docs instead.

--- a/.claude/skills/workos/references/workos-mfa.md
+++ b/.claude/skills/workos/references/workos-mfa.md
@@ -1,0 +1,20 @@
+# WorkOS Multi-Factor Authentication
+
+## Docs
+
+- https://workos.com/docs/mfa/index
+- https://workos.com/docs/mfa/example-apps
+- https://workos.com/docs/mfa/ux/sign-in
+- https://workos.com/docs/mfa/ux/enrollment
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- MFA API is NOT compatible with WorkOS SSO. For SSO users, use the IdP's built-in MFA features instead.
+- You must persist `factor.id` in your user database. Without it, the enrolled factor cannot be used for future challenges.
+- Challenges are single-use. Attempting to verify a challenge twice returns "challenge already verified." Create a new challenge for each sign-in attempt.
+- SMS challenges expire after 10 minutes. TOTP has no such limit but is affected by device clock skew.
+- `qr_code` from TOTP enrollment is a data URI, not a URL. Use it directly as an image `src` — do not attempt to fetch it.
+- SMS phone numbers must be E.164 format (`+1234567890`). Other formats (e.g., `(123) 456-7890`) cause a 400 error.
+- TOTP enrollment requires both `totp_issuer` and `totp_user` parameters. Omitting either causes a 400 error.
+- MFA verifies factor ownership, not user identity. It supplements primary authentication — never use it as the sole auth method.

--- a/.claude/skills/workos/references/workos-migrate-auth0.md
+++ b/.claude/skills/workos/references/workos-migrate-auth0.md
@@ -1,0 +1,14 @@
+# WorkOS Migration: Auth0
+
+## Docs
+
+- https://workos.com/docs/migrate/auth0
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Auth0 does NOT export plaintext passwords. Only bcrypt hashes are available, and only via a support ticket (1-2 week turnaround). Decide upfront whether you need them — requesting after starting the export adds weeks to the timeline.
+- `password_hash_type` MUST be `'bcrypt'` for Auth0 exports. Other algorithm values will silently fail.
+- Auth0 bcrypt hashes must start with `$2a$`, `$2b$`, or `$2y$`. If the prefix is missing, the export may be incomplete — contact Auth0 support.
+- If a user already exists in WorkOS (duplicate email), the Create User API will reject it. Use Update User API instead.
+- WorkOS has an official migration tool at https://github.com/workos/migrate-auth0-users that handles rate limiting, retries, and duplicates automatically.

--- a/.claude/skills/workos/references/workos-migrate-aws-cognito.md
+++ b/.claude/skills/workos/references/workos-migrate-aws-cognito.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: AWS Cognito
+
+## Docs
+
+- https://workos.com/docs/migrate/aws-cognito
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- AWS Cognito does not export password hashes or MFA keys (Cognito platform limitation). WorkOS supports hash import for other providers (bcrypt, scrypt, argon2, pbkdf2, ssha, firebase-scrypt), but since Cognito won't export them, all migrated users must reset their password.
+- There is NO JIT (just-in-time) migration path for Cognito. Cognito does not expose a password verification endpoint. The only path is bulk import of user attributes + forced password reset.
+- OAuth users do NOT need password resets — their provider tokens continue working after migration.
+- WORKOS_COOKIE_PASSWORD applies to ALL server-side AuthKit framework SDKs (Next.js, Remix, React Router, TanStack Start, SvelteKit) — not just Next.js.
+- Bulk password reset emails can be flagged as spam. Slow send rate to 1 req/second max and verify SPF/DKIM records if using a custom email domain.
+- Do NOT set the password field when importing users. Users imported without passwords are automatically flagged for password reset.

--- a/.claude/skills/workos/references/workos-migrate-better-auth.md
+++ b/.claude/skills/workos/references/workos-migrate-better-auth.md
@@ -1,0 +1,14 @@
+# WorkOS Migration: Better Auth
+
+## Docs
+
+- https://workos.com/docs/migrate/better-auth
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Password hashes live in the `account` table (not `user`), filtered by `providerId = 'credential'`. Do NOT skip this table.
+- Better Auth uses scrypt by default. If you customized the hash algorithm, you must know which one it is before importing to WorkOS.
+- The `password` column contains the full hash string including algorithm parameters. Do NOT strip prefixes or decode it.
+- Import order matters when organizations are involved: create orgs first, then import users, then password hashes, then assign memberships. Out-of-order imports will fail with "Organization not found."
+- Better Auth sessions are JWT-based and remain valid until expiry even after migration. This is expected — not an error. To force immediate cutover, rotate the Better Auth secret key.

--- a/.claude/skills/workos/references/workos-migrate-clerk.md
+++ b/.claude/skills/workos/references/workos-migrate-clerk.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: Clerk
+
+## Docs
+
+- https://workos.com/docs/migrate/clerk
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Clerk exports multiple emails pipe-separated (e.g., `john@example.com|john.doe@example.com`) and does NOT indicate which is the primary email. If you can't call the Clerk API per user to resolve `primary_email_address_id`, you must pick the first email and document the choice.
+- Clerk does NOT provide plaintext passwords. Password hashes are only available via the Clerk Backend API export, not the standard dashboard export.
+- WorkOS users have a single primary email. You must pick ONE from Clerk's pipe-separated list.
+- Clerk export may include deleted/suspended users. Filter these before import or you'll get count mismatches.
+- Duplicate emails in the Clerk export will cause WorkOS rejections — deduplicate before importing.
+- WorkOS has an official migration tool at https://github.com/workos/migrate-clerk-users that handles rate limits and retries.

--- a/.claude/skills/workos/references/workos-migrate-descope.md
+++ b/.claude/skills/workos/references/workos-migrate-descope.md
@@ -1,0 +1,13 @@
+# WorkOS Migration: Descope
+
+## Docs
+
+- https://workos.com/docs/migrate/descope
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Descope does NOT expose password hashes via API. A support ticket is required to get a CSV export with hashes — this is not self-service.
+- When requesting the export from Descope support, confirm which hashing algorithm was used (bcrypt, argon2, or pbkdf2). You need this value for the `password_hash_type` parameter during WorkOS import.
+- The algorithm name must match exactly: `"bcrypt"` not `"bcrypt_sha256"` or `"bcrypt-sha256"`. Typos cause silent rejection.
+- If Descope used a hashing algorithm not supported by WorkOS, you must fall back to the password reset flow. Contact WorkOS support before attempting import.

--- a/.claude/skills/workos/references/workos-migrate-firebase.md
+++ b/.claude/skills/workos/references/workos-migrate-firebase.md
@@ -1,0 +1,16 @@
+# WorkOS Migration: Firebase
+
+## Docs
+
+- https://workos.com/docs/migrate/firebase
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Firebase uses a non-standard scrypt variant. Password hashes must be converted to PHC format with Firebase-specific parameters (`sk=` signer key, `ss=` salt separator). Missing either parameter causes import failure.
+- Firebase exports use base64 encoding. WorkOS expects base64 in the PHC string — do NOT decode the bytes before importing.
+- Firebase users can have MULTIPLE auth methods (e.g., password + Google). A user with both needs both migration paths (password import AND OAuth reconnection).
+- Firebase's OAuth redirect URI is `/__/auth/handler`. WorkOS uses your custom callback URL. The redirect URI must match exactly or OAuth will fail silently.
+- WorkOS user IDs differ from Firebase UIDs. You must store the mapping (`firebase_uid` -> `workos_user_id`) in your database.
+- For SAML/OIDC enterprise connections, the identity provider admin must update THEIR config with the new WorkOS callback URL. Coordinate timing — this is a cross-org dependency.
+- Firebase Email Link sends a link that completes auth in the same browser. WorkOS Magic Auth sends a code the user enters in-app. The UX is different — plan for user communication.

--- a/.claude/skills/workos/references/workos-migrate-other-services.md
+++ b/.claude/skills/workos/references/workos-migrate-other-services.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: Other Services
+
+## Docs
+
+- https://workos.com/docs/migrate/other-services
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- WorkOS only supports these hash algorithms for password import: bcrypt, scrypt, pbkdf2, argon2, ssha, firebase-scrypt. If your source uses md5, sha1, or a custom algorithm, you cannot import passwords — use the password reset flow instead.
+- OAuth tokens CANNOT be imported for security reasons. Social auth users must re-authenticate with their provider. WorkOS links accounts automatically by email match — if emails differ between WorkOS and the social profile, the user sees a "create new account" flow instead of linking.
+- WorkOS user IDs (`user_01...`) are new. You MUST persist the mapping from your old system's IDs. Failing to do so breaks all foreign key references.
+- Email matching for social account linking is case-sensitive. If the WorkOS user email doesn't exactly match the social profile email, auto-linking fails silently.
+- Migration scripts MUST be idempotent. Track migration status per user — re-running a non-idempotent script creates duplicates.
+- Bulk password reset emails can be throttled or spam-filtered. Batch at 10 resets/sec max and verify your sending domain in WorkOS Dashboard.

--- a/.claude/skills/workos/references/workos-migrate-stytch.md
+++ b/.claude/skills/workos/references/workos-migrate-stytch.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: Stytch
+
+## Docs
+
+- https://workos.com/docs/migrate/stytch
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Stytch password export requires a support ticket (support@stytch.com). Start this FIRST — it's the bottleneck with variable turnaround time. Do not proceed with password import until hashes are received.
+- Stytch uses scrypt for password hashing. Verify the hash format from the Stytch export matches WorkOS requirements before bulk import — test with ONE user first.
+- Stytch Search API has a 100 requests/minute rate limit. For large datasets, add delays between batches or you'll get throttled during export.
+- Domain conflicts: if a domain is already claimed by another WorkOS organization, the org import fails with "Domain already exists." Import without `domainData` and resolve conflicts manually.
+- Organizations must be imported BEFORE users. If the org mapping is lost or orgs aren't created yet, user import fails with "Missing organization ID."
+- For consumer (non-B2B) users, use the Stytch export utility at https://github.com/stytchauth/stytch-node-export-users instead of the Search API.

--- a/.claude/skills/workos/references/workos-migrate-supabase-auth.md
+++ b/.claude/skills/workos/references/workos-migrate-supabase-auth.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: Supabase Auth
+
+## Docs
+
+- https://workos.com/docs/migrate/supabase
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Supabase uses bcrypt. Verify exported hashes start with `$2a$`, `$2b$`, or `$2y$`. If verification fails, re-export — corrupted hashes cannot be recovered.
+- Do NOT use Supabase UUIDs as WorkOS user IDs. WorkOS generates its own IDs (`user_*`). Store the mapping (`supabase_user_id` -> `workos_user_id`) in your database.
+- You CANNOT migrate active sessions from Supabase to WorkOS. Sessions are provider-specific. Users with valid Supabase sessions must be forced to re-authenticate with WorkOS.
+- Supabase `phone` field cannot be migrated — WorkOS AuthKit uses email-based auth.
+- If password hash export is corrupted, use explicit SQL cast: `CAST(encrypted_password AS TEXT)` during re-export.
+- For >10,000 users, contact WorkOS support for bulk import assistance rather than scripting it yourself.

--- a/.claude/skills/workos/references/workos-migrate-the-standalone-sso-api.md
+++ b/.claude/skills/workos/references/workos-migrate-the-standalone-sso-api.md
@@ -1,0 +1,15 @@
+# WorkOS Migration: Standalone SSO API
+
+## Docs
+
+- https://workos.com/docs/migrate/standalone-sso
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- User IDs change when migrating from standalone SSO API to AuthKit. Old Profile IDs (`user_xxx` from `sso.getProfileAndToken`) are NOT the same as new AuthKit User IDs. If Profile IDs are foreign keys in your database, you need a migration script before cutover.
+- `authenticateWithCode` requires a `clientId` parameter (`client_xxx`) that the standalone SSO API's `getProfileAndToken` did not require. Missing or wrong `clientId` causes "Invalid client_id" errors.
+- AuthKit returns new error types that the standalone SSO API never produced: `email_verification_required`, `mfa_enrollment_required`, and `mfa_challenge_required`. If your callback doesn't handle these, logins will appear to fail silently.
+- Using the hosted UI (`provider: "authkit"`) handles email verification and MFA challenges automatically. With the API directly, you must implement those flows yourself.
+- Use exactly two terms: "standalone SSO API" for the old system, "AuthKit" for the new system. The docs use these terms consistently. Do NOT use bare "SSO" or "SSO API" — it creates ambiguity.
+- WORKOS_COOKIE_PASSWORD applies to ALL server-side AuthKit framework SDKs (Next.js, Remix, React Router, TanStack Start, SvelteKit) — not just Next.js.

--- a/.claude/skills/workos/references/workos-node.md
+++ b/.claude/skills/workos/references/workos-node.md
@@ -1,0 +1,192 @@
+# WorkOS AuthKit for Node.js
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP - Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-node/main/README.md`
+
+Also fetch the AuthKit quickstart for reference:
+WebFetch: `https://workos.com/docs/authkit/vanilla/nodejs`
+
+README is the source of truth for all SDK patterns. **README overrides this skill if conflict.**
+
+## Step 2: Detect Framework & Project Structure
+
+```
+package.json has 'express'?              → Express
+package.json has 'fastify'?              → Fastify
+package.json has 'hono'?                 → Hono
+package.json has 'koa'?                  → Koa
+None of the above?                       → Vanilla Node.js http (use Express quickstart pattern)
+
+tsconfig.json exists?                    → TypeScript (.ts files)
+"type": "module" in package.json?        → ESM (import/export)
+else                                     → CJS (require/module.exports)
+```
+
+Detect entry point: `src/index.ts`, `src/app.ts`, `app.js`, `server.js`, `index.js`
+
+Detect package manager: `pnpm-lock.yaml` → `yarn.lock` → `bun.lockb` → npm
+
+**Adapt all subsequent steps to the detected framework and module system.**
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `@workos-inc/node` is already in `package.json`
+2. Check for incomplete auth files — routes/handlers that import `@workos-inc/node` but are non-functional (TODO comments, 501 responses, empty handlers)
+3. If partial install detected:
+   - Do NOT reinstall the SDK (it's already there)
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - Preserve any working code — only fix what's broken
+   - Check for a missing `/callback` route (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+package.json has 'passport'?                → Passport.js auth
+package.json has 'express-openid-connect'?  → Auth0 / OIDC
+package.json has 'express-session'?         → Session-based auth may exist
+*.js/*.ts files have 'jsonwebtoken'?        → JWT-based auth
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If `express-session` is already configured, reuse it for WorkOS session storage (don't create a second session middleware)
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/login` is taken)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+```
+pnpm-lock.yaml → pnpm add @workos-inc/node dotenv cookie-parser
+yarn.lock      → yarn add @workos-inc/node dotenv cookie-parser
+bun.lockb      → bun add @workos-inc/node dotenv cookie-parser
+else           → npm install @workos-inc/node dotenv cookie-parser
+```
+
+For TypeScript, also install types: `pnpm add -D @types/cookie-parser`
+
+**Verify:** `@workos-inc/node` in package.json dependencies
+
+## Step 4: Initialize WorkOS Client
+
+Adapt to detected module system (ESM vs CJS):
+
+**ESM/TypeScript:**
+
+```typescript
+import { WorkOS } from '@workos-inc/node';
+const workos = new WorkOS(process.env.WORKOS_API_KEY, {
+  clientId: process.env.WORKOS_CLIENT_ID,
+});
+```
+
+**CJS:**
+
+```javascript
+const { WorkOS } = require('@workos-inc/node');
+const workos = new WorkOS(process.env.WORKOS_API_KEY, {
+  clientId: process.env.WORKOS_CLIENT_ID,
+});
+```
+
+## Step 5: Integrate Authentication
+
+### If Express
+
+Follow the quickstart pattern:
+
+1. **`/login` route** — call `workos.userManagement.getAuthorizationUrl({ provider: 'authkit', redirectUri: ..., clientId: ... })`, redirect
+2. **`/callback` route** — call `workos.userManagement.authenticateWithCode({ code, clientId })`, store session via sealed session or express-session
+3. **`/logout` route** — clear session cookie, redirect
+4. **Cookie middleware** — `app.use(cookieParser())`
+5. **Session-aware home route** — read session, display user info
+
+**Session handling options (pick one):**
+
+- **Sealed sessions** (recommended, from quickstart): use `sealSession: true` in authenticateWithCode, store sealed cookie, use `loadSealedSession` for verification
+- **express-session**: install `express-session`, configure middleware before routes, store user in `req.session`
+
+### If Fastify
+
+1. Register `@fastify/cookie` plugin
+2. Create `/login`, `/callback`, `/logout` routes using Fastify route syntax
+3. Use `reply.redirect()` for redirects
+4. Store session in signed cookie
+
+### If Hono
+
+1. Create `/login`, `/callback`, `/logout` routes using Hono router
+2. Use `c.redirect()` for redirects
+3. Use Hono's cookie helpers for session
+
+### If Koa
+
+1. Install `koa-router` if not present
+2. Create auth routes on router
+3. Use `ctx.redirect()` for redirects
+4. Use `koa-session` for session management
+
+### If Vanilla Node.js (no framework detected)
+
+Install Express and follow the Express pattern above. This matches the official quickstart.
+
+## Step 6: Environment Setup
+
+Create `.env` if it doesn't exist. Do NOT overwrite existing values:
+
+```
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+WORKOS_REDIRECT_URI=http://localhost:3000/callback
+WORKOS_COOKIE_PASSWORD=<generate with openssl rand -base64 32>
+```
+
+Ensure `.env` is in `.gitignore`.
+
+## Step 7: Verification
+
+**TypeScript:** `npx tsc --noEmit`
+**JavaScript:** `node --check <entry-file>`
+
+### Checklist
+
+- [ ] SDK installed (`@workos-inc/node` in package.json)
+- [ ] WorkOS client initialized
+- [ ] Login route redirects to AuthKit
+- [ ] Callback route exchanges code for user
+- [ ] Logout route clears session
+- [ ] `.env` has required variables
+- [ ] Build/syntax check passes
+
+## Error Recovery
+
+### Module not found: @workos-inc/node
+
+Re-run install for detected package manager.
+
+### Session not persisting
+
+If using express-session: ensure middleware registered BEFORE routes.
+If using sealed sessions: ensure cookie is being set with correct options (httpOnly, secure in prod, sameSite: 'lax').
+
+### Callback returns 404
+
+Route path must match WORKOS_REDIRECT_URI exactly.
+
+### ESM/CJS mismatch
+
+Check `"type"` field in package.json — `"module"` = ESM (import/export), absent = CJS (require).
+
+### TypeScript errors
+
+Install missing types: `@types/express`, `@types/cookie-parser`, `@types/express-session`.

--- a/.claude/skills/workos/references/workos-php-laravel.md
+++ b/.claude/skills/workos/references/workos-php-laravel.md
@@ -1,0 +1,177 @@
+# WorkOS AuthKit for Laravel
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-php-laravel/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `artisan` file exists at project root
+- Confirm `composer.json` contains `laravel/framework` dependency
+- Confirm `app/` and `routes/` directories exist
+
+### Environment Variables
+
+Check `.env` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `WORKOS_REDIRECT_URI` - valid callback URL (e.g., `http://localhost:8000/auth/callback`)
+
+If `.env` exists but is missing these variables, append them. If `.env` doesn't exist, copy `.env.example` and add them.
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `workos/workos-php-laravel` is already in `composer.json`
+2. Check if `config/workos.php` exists but no auth controller or routes are wired
+3. If partial install detected:
+   - Do NOT reinstall the SDK (it's already there)
+   - Do NOT re-publish config if `config/workos.php` already exists
+   - Read existing files to understand what's done vs missing
+   - Complete the integration by filling gaps (controller, routes, middleware)
+   - Preserve any working code — only fix what's broken
+   - Check for missing auth controller or routes (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+composer.json has 'laravel/breeze'?               → Breeze auth scaffolding
+composer.json has 'laravel/jetstream'?            → Jetstream auth
+composer.json has 'laravel/fortify'?              → Fortify auth backend
+app/Http/Controllers/Auth/ exists?                → Auth controllers present
+routes/auth.php exists?                           → Auth routes file
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If Laravel session is already configured, reuse it for WorkOS
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/login` is taken)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+```bash
+composer require workos/workos-php-laravel
+```
+
+**Verify:** Check `composer.json` contains `workos/workos-php-laravel` in require section before continuing.
+
+## Step 4: Publish Configuration
+
+```bash
+php artisan vendor:publish --provider="WorkOS\Laravel\WorkOSServiceProvider"
+```
+
+This creates `config/workos.php`. Verify the file exists after publishing.
+
+If the artisan command fails, check README for the correct provider class name — it may differ.
+
+## Step 5: Configure Environment
+
+Ensure `.env` contains:
+
+```
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+WORKOS_REDIRECT_URI=http://localhost:8000/auth/callback
+```
+
+Also ensure `config/workos.php` reads these env vars correctly. Check README for exact config structure.
+
+## Step 6: Create Auth Controller
+
+Create `app/Http/Controllers/AuthController.php` with methods for:
+
+- `login()` — Redirect to WorkOS AuthKit authorization URL
+- `callback()` — Handle OAuth callback, exchange code for user profile
+- `logout()` — Clear session and redirect
+
+Use SDK methods from README. Do NOT construct OAuth URLs manually.
+
+## Step 7: Add Routes
+
+Add to `routes/web.php`:
+
+```php
+use App\Http\Controllers\AuthController;
+
+Route::get('/login', [AuthController::class, 'login'])->name('login');
+Route::get('/auth/callback', [AuthController::class, 'callback']);
+Route::get('/logout', [AuthController::class, 'logout'])->name('logout');
+```
+
+Ensure the callback route path matches `WORKOS_REDIRECT_URI`.
+
+## Step 8: Add Middleware (if applicable)
+
+Check README for any authentication middleware the SDK provides. If available:
+
+1. Register middleware in `app/Http/Kernel.php` or `bootstrap/app.php` (Laravel 11+)
+2. Apply to routes that require authentication
+
+For Laravel 11+, middleware is registered in `bootstrap/app.php` instead of `Kernel.php`.
+
+## Step 9: Add UI Integration
+
+Update the home page or dashboard view to show:
+
+- Sign in link when user is not authenticated
+- User info and sign out link when authenticated
+
+Use Blade directives or SDK helpers from README.
+
+## Verification Checklist (ALL MUST PASS)
+
+```bash
+# 1. Config file exists
+ls config/workos.php
+
+# 2. Controller exists
+ls app/Http/Controllers/AuthController.php
+
+# 3. Routes registered
+php artisan route:list | grep -E "login|callback|logout"
+
+# 4. SDK installed
+composer show workos/workos-php-laravel
+
+# 5. Lint check
+php -l app/Http/Controllers/AuthController.php
+```
+
+## Error Recovery
+
+### "Class WorkOS\Laravel\WorkOSServiceProvider not found"
+
+- Verify `composer require` completed successfully
+- Run `composer dump-autoload`
+- Check `vendor/workos/` directory exists
+
+### "Route not defined"
+
+- Verify routes are in `routes/web.php`
+- Run `php artisan route:clear && php artisan route:cache`
+
+### Config not loading
+
+- Verify `config/workos.php` exists
+- Run `php artisan config:clear`
+- Check `.env` variables match config keys
+
+### Middleware issues (Laravel 11+)
+
+- Laravel 11 removed `Kernel.php` — register middleware in `bootstrap/app.php`
+- Check README for Laravel version-specific instructions

--- a/.claude/skills/workos/references/workos-php.md
+++ b/.claude/skills/workos/references/workos-php.md
@@ -1,0 +1,155 @@
+# WorkOS AuthKit for PHP
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-php/main/README.md`
+
+The README is the source of truth. If this skill conflicts with README, follow README.
+
+## Step 2: Pre-Flight Validation
+
+### Project Structure
+
+- Confirm `composer.json` exists at project root
+- If `composer.json` doesn't exist, create a minimal one with `composer init --no-interaction`
+
+### Environment Variables
+
+Check for `.env` file with:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+- `WORKOS_REDIRECT_URI` - valid callback URL (e.g., `http://localhost:8000/callback.php`)
+
+If `.env` doesn't exist, create it with the required variables.
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `workos/workos-php` is already in `composer.json`
+2. Check for incomplete auth files — `login.php` or `callback.php` that import WorkOS but are non-functional (TODO comments, 501 responses, empty handlers)
+3. If partial install detected:
+   - Do NOT reinstall the SDK (it's already there)
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - Preserve any working code — only fix what's broken
+   - Check for a missing `callback.php` (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+*.php files have 'session_start()' + '$_SESSION'?  → Native PHP session auth
+*.php files have 'password_verify'?                 → Password-based auth
+*.php files have form POST to '/login'?             → Form-based auth
+composer.json has auth libraries?                   → Third-party auth
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If `session_start()` is already used, reuse the session for WorkOS (don't create a second session mechanism)
+- Create separate file paths for WorkOS auth (e.g., `workos-login.php` if `login.php` is taken)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install SDK
+
+```bash
+composer require workos/workos-php
+```
+
+**Verify:** Check `composer.json` contains `workos/workos-php` in require section.
+
+Also install a dotenv library if not present:
+
+```bash
+composer require vlucas/phpdotenv
+```
+
+## Step 4: Create Bootstrap File
+
+Create a bootstrap or config file (e.g., `config.php` or `bootstrap.php`) that:
+
+1. Requires Composer autoloader: `require_once __DIR__ . '/vendor/autoload.php';`
+2. Loads `.env` using phpdotenv
+3. Initializes the WorkOS SDK client with API key
+
+Use SDK initialization from README. Do NOT hardcode credentials.
+
+## Step 5: Create Auth Endpoint Files
+
+### `login.php`
+
+- Initialize WorkOS client (include bootstrap)
+- Generate authorization URL using SDK
+- Redirect user to WorkOS AuthKit
+
+### `callback.php`
+
+- Initialize WorkOS client (include bootstrap)
+- Exchange authorization code from `$_GET['code']` for user profile using SDK
+- Start session, store user data
+- Redirect to home/dashboard
+
+### `logout.php`
+
+- Destroy session
+- Redirect to home page
+
+Use SDK methods from README for all WorkOS API calls. Do NOT construct OAuth URLs manually.
+
+## Step 6: Create Home Page
+
+Create or update `index.php` to show:
+
+- Sign in link (`login.php`) when no session
+- User info and sign out link (`logout.php`) when session exists
+
+## Verification Checklist (ALL MUST PASS)
+
+```bash
+# 1. SDK installed
+composer show workos/workos-php
+
+# 2. Auth files exist
+ls login.php callback.php logout.php
+
+# 3. No syntax errors
+php -l login.php
+php -l callback.php
+php -l logout.php
+php -l index.php
+
+# 4. Autoloader exists
+ls vendor/autoload.php
+```
+
+## Error Recovery
+
+### "Class WorkOS\WorkOS not found"
+
+- Verify `composer require` completed successfully
+- Check `vendor/autoload.php` is required in bootstrap
+- Run `composer dump-autoload`
+
+### Session issues
+
+- Ensure `session_start()` is called before any session access
+- Check PHP session configuration (`session.save_path`)
+
+### Redirect URI mismatch
+
+- Compare callback file path to `WORKOS_REDIRECT_URI` in `.env`
+- URLs must match exactly (including trailing slash)
+
+### Environment variables not loading
+
+- Verify `.env` file exists in project root
+- Verify phpdotenv is installed and loaded in bootstrap
+- Check file permissions on `.env`

--- a/.claude/skills/workos/references/workos-pipes.md
+++ b/.claude/skills/workos/references/workos-pipes.md
@@ -1,0 +1,36 @@
+# WorkOS Pipes
+
+## Docs
+
+- https://workos.com/docs/pipes
+- https://workos.com/docs/pipes/providers
+- https://workos.com/docs/reference/pipes
+- https://workos.com/docs/reference/pipes/provider
+- https://workos.com/docs/reference/pipes/connected-account
+- https://workos.com/docs/reference/pipes/access-token
+- https://workos.com/docs/widgets/pipes
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Pipes manages the full OAuth lifecycle (authorization, token refresh, credential storage) — do NOT implement your own token refresh logic.
+- Use `workos.pipes.getAccessToken()` to get tokens — WorkOS auto-refreshes expired tokens. Never cache access tokens client-side.
+- Sandbox environments use "shared credentials" (WorkOS-managed OAuth apps). Production requires custom credentials configured per provider in the Dashboard.
+- Response is a discriminated union. **Node SDK** (camelCase): `{ active: true, accessToken }` on success or `{ active: false, error: "needs_reauthorization" | "not_installed" }` on failure. **Raw REST** uses snake_case (`access_token`). Branch on `active` first — `accessToken`/`error` only exist on their respective branches.
+- Provider slugs are lowercase (e.g., `github`, `slack`, `salesforce`). Claude tends to capitalize or use display names.
+- Connected account deletion removes stored tokens — the user must re-authorize. This is not reversible.
+- The Pipes Widget provides a pre-built UI for account connection — use it instead of building custom OAuth flows. Load via `workos-widgets` skill.
+- `getAccessToken()` requires `provider` and `userId` params. `organizationId` is optional but needed for org-scoped connections.
+- The authorize endpoint (`/data-integrations/{slug}/authorize`) returns a URL — redirect the user to it, do NOT fetch it server-side.
+
+## Endpoints
+
+| Endpoint                    | Description                  |
+| --------------------------- | ---------------------------- |
+| `/pipes`                    | Pipes overview               |
+| `/provider`                 | Provider details             |
+| `/connected-account`        | Connected account management |
+| `/connected-account/get`    | Get a connected account      |
+| `/connected-account/delete` | Delete a connected account   |
+| `/access-token`             | Get OAuth access token       |
+| `/authorize`                | Generate authorization URL   |

--- a/.claude/skills/workos/references/workos-python.md
+++ b/.claude/skills/workos/references/workos-python.md
@@ -1,0 +1,188 @@
+# WorkOS AuthKit for Python
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP. Do not proceed until complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-python/main/README.md`
+
+Also fetch the AuthKit quickstart for reference:
+WebFetch: `https://workos.com/docs/authkit/vanilla/python`
+
+The README is the source of truth for SDK API usage. If this skill conflicts with README, follow README.
+
+## Step 2: Detect Framework
+
+Examine the project to determine which Python web framework is in use:
+
+```
+manage.py exists?                        → Django
+  settings.py has django imports?        → Confirmed Django
+
+Gemfile/requirements has 'fastapi'?      → FastAPI
+  main.py has FastAPI() instance?        → Confirmed FastAPI
+
+requirements has 'flask'?               → Flask
+  server.py/app.py has Flask() instance? → Confirmed Flask
+
+None of the above?                       → Vanilla Python (use Flask quickstart pattern)
+```
+
+**Adapt all subsequent steps to the detected framework.** Do not force one framework onto another.
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `workos` is already in `requirements.txt` or `pyproject.toml`
+2. Check for incomplete auth files — files that import `workos` but have non-functional routes (TODO comments, commented-out code, empty handlers)
+3. If partial install detected:
+   - Do NOT reinstall the SDK (it's already there)
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - Preserve any working code — only fix what's broken
+   - Check for a missing `/callback` route (most common gap)
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+requirements.txt has 'flask-login'?         → Flask-Login auth
+requirements.txt has 'authlib'?             → OAuth/OIDC auth (e.g., Auth0)
+requirements.txt has 'django-allauth'?      → Django allauth
+manage.py exists + 'django.contrib.auth'?   → Django built-in auth
+*.py files have 'flask_login'?              → Flask-Login in use
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If `flask-login` is present, use Flask-Login's session infrastructure (`login_user()`) for WorkOS auth too, rather than raw session management
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/login` is taken)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Pre-Flight Validation
+
+### Package Manager Detection
+
+```
+uv.lock exists?                          → uv add
+pyproject.toml has [tool.poetry]?        → poetry add
+Pipfile exists?                          → pipenv install
+requirements.txt exists?                 → pip install (+ append to requirements.txt)
+else                                     → pip install
+```
+
+### Environment Variables
+
+Check `.env` for:
+
+- `WORKOS_API_KEY` - starts with `sk_`
+- `WORKOS_CLIENT_ID` - starts with `client_`
+
+## Step 4: Install SDK
+
+Install using the detected package manager:
+
+```bash
+# uv
+uv add workos python-dotenv
+
+# poetry
+poetry add workos python-dotenv
+
+# pip
+pip install workos python-dotenv
+```
+
+If using `requirements.txt`, also append `workos` and `python-dotenv` to it.
+
+**Verify:** `python -c "import workos; print('OK')"`
+
+## Step 5: Integrate Authentication
+
+### If Django
+
+1. **Configure settings.py** — add `import os` + `from dotenv import load_dotenv` + `load_dotenv()` at top. Add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` from `os.environ.get()`.
+2. **Create auth views** — create `auth_views.py` (or add to existing views):
+   - `login_view`: call SDK's `get_authorization_url()` with `provider='authkit'`, redirect
+   - `callback_view`: call `authenticate_with_code()` with the code param, store user in `request.session`
+   - `logout_view`: flush session, redirect
+3. **Add URL patterns** — add `auth/login/`, `auth/callback/`, `auth/logout/` to `urls.py`
+4. **Update templates** — add login/logout links using `{% url %}` tags
+
+### If Flask
+
+Follow the quickstart pattern exactly:
+
+1. **Initialize WorkOS client** in `server.py` / `app.py`:
+   ```python
+   from workos import WorkOSClient
+   workos = WorkOSClient(api_key=os.getenv("WORKOS_API_KEY"), client_id=os.getenv("WORKOS_CLIENT_ID"))
+   ```
+2. **Create `/login` route** — call `workos.user_management.get_authorization_url(provider="authkit", redirect_uri="...")`, redirect
+3. **Create `/callback` route** — call `workos.user_management.authenticate_with_code(code=code)`, set session cookie
+4. **Create `/logout` route** — clear session, redirect
+5. **Update home route** — show user info if session exists
+
+### If FastAPI
+
+1. **Initialize WorkOS client** in main app file
+2. **Create `/login` endpoint** — generate auth URL, return `RedirectResponse`
+3. **Create `/callback` endpoint** — exchange code, store in session/cookie
+4. **Create `/logout` endpoint** — clear session
+5. Use `Depends()` for auth middleware on protected routes
+
+### If Vanilla Python (no framework detected)
+
+Install Flask and follow the Flask pattern above. This matches the official quickstart.
+
+## Step 6: Environment Setup
+
+Create/update `.env` with WorkOS credentials. Do NOT overwrite existing values.
+
+```
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+```
+
+## Step 7: Verification Checklist
+
+```bash
+# 1. SDK importable
+python -c "import workos; print('OK')"
+
+# 2. Credentials configured
+python -c "
+from dotenv import load_dotenv; import os; load_dotenv()
+assert os.environ.get('WORKOS_API_KEY','').startswith('sk_'), 'Missing WORKOS_API_KEY'
+assert os.environ.get('WORKOS_CLIENT_ID','').startswith('client_'), 'Missing WORKOS_CLIENT_ID'
+print('Credentials OK')
+"
+
+# 3. Framework-specific check
+# Django: python manage.py check
+# Flask: python -m py_compile server.py
+# FastAPI: python -m py_compile main.py
+```
+
+## Error Recovery
+
+### "ModuleNotFoundError: No module named 'workos'"
+
+Re-run the install command for the detected package manager.
+
+### Django: "CSRF verification failed"
+
+Auth callback receives GET requests from WorkOS. Ensure callback view uses GET, not POST. Or add `@csrf_exempt`.
+
+### Flask: Session not persisting
+
+Ensure `app.secret_key` is set (required for Flask sessions).
+
+### Virtual environment not active
+
+Check for `.venv/`, `venv/`, or poetry-managed environments. Activate before running install.

--- a/.claude/skills/workos/references/workos-radar.md
+++ b/.claude/skills/workos/references/workos-radar.md
@@ -1,0 +1,37 @@
+# WorkOS Radar
+
+## Docs
+
+- https://workos.com/docs/radar
+- https://workos.com/docs/radar/overview
+- https://workos.com/docs/radar/standalone
+- https://workos.com/docs/reference/radar
+- https://workos.com/docs/reference/radar/attempts
+- https://workos.com/docs/reference/radar/lists
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- Radar is built into AuthKit natively — if using AuthKit, fraud detection works automatically. The standalone API is only needed for custom auth flows.
+- **There is no `workos.radar.*` namespace in the Node SDK.** The Radar standalone API has no SDK wrapper methods at all — for attempts, lists, or anything else. Use `workos.post('/radar/attempts', ...)`, `workos.put('/radar/attempts/:id', ...)`, `workos.post('/radar/lists/{type}/{action}', ...)` directly. Claude hallucinates `workos.radar.assessAttempt`, `workos.radar.updateAttempt`, `workos.userManagement.updateAuthenticationAttempt`, etc. — none exist.
+- The standalone API is in preview — access requires contacting WorkOS support.
+- `POST /radar/attempts` returns a `verdict`: `"allow"`, `"block"`, or `"challenge"`. Your app MUST act on the verdict — Radar does not block requests itself.
+- All attempt fields are required: `ip_address`, `user_agent`, `email`, `auth_method`, `action`. Missing fields cause a 422.
+- `auth_method` must be one of: `Password`, `Passkey`, `Authenticator`, `SMS_OTP`, `Email_OTP`, `Social`, `SSO`, `Other`. Claude tends to use lowercase or invented values.
+- `action` accepts: `login`, `signup` (and variants like `sign-in`, `sign_up`). Use the simplest form.
+- After a successful authentication, call `PUT /radar/attempts/:id` with `attempt_status: "success"` to improve Radar's model (enables impossible travel detection).
+- Block/allow lists use path-based routing: `POST /radar/lists/{type}/{action}` where type is `ip_address`, `domain`, `email`, `device`, `user_agent`, `device_fingerprint`, or `country`, and action is `block` or `allow`.
+- `device_fingerprint` and `bot_score` are optional enrichment fields — pass them if your client-side SDK collects them.
+- There are NO SDK wrapper methods for block/allow list management. Use direct HTTP calls (`POST /radar/lists/{type}/{action}`). Claude hallucinates `workos.radar.blockIpAddress()` or `workos.userManagement.createBlocklistEntry()` — neither exists.
+
+## Endpoints
+
+| Endpoint                    | Description                    |
+| --------------------------- | ------------------------------ |
+| `/radar`                    | Radar overview                 |
+| `/attempts`                 | Attempt management             |
+| `/attempts/create`          | Create an attempt (get verdict)|
+| `/attempts/update`          | Update attempt status          |
+| `/lists`                    | List management                |
+| `/lists/{type}/{action}/add`    | Add entry to block/allow list    |
+| `/lists/{type}/{action}/remove` | Remove entry from block/allow list |

--- a/.claude/skills/workos/references/workos-rbac.md
+++ b/.claude/skills/workos/references/workos-rbac.md
@@ -1,0 +1,100 @@
+# WorkOS Role-Based Access Control
+
+## Docs
+
+- https://workos.com/docs/rbac/quick-start
+- https://workos.com/docs/rbac/organization-roles
+- https://workos.com/docs/rbac/integration
+- https://workos.com/docs/rbac/idp-role-assignment
+- https://workos.com/docs/directory-sync/identity-provider-role-assignment
+  If this file conflicts with fetched docs, follow the docs.
+
+## IdP group → role mapping (the common customer ask)
+
+When a user asks how to map Entra / Azure AD / Okta / Google Workspace groups to WorkOS roles, this is the canonical flow. It is **not** a CLI operation. Do not fabricate `workos role-mappings ...` or similar commands.
+
+**Which source to use**:
+
+- If the org has a Directory Sync connection (SCIM or Google Workspace), use **Directory Sync group role assignment**. Roles propagate in real time. Docs: https://workos.com/docs/directory-sync/identity-provider-role-assignment
+- If the org only has SSO (no Directory Sync), use **SSO group role assignment**. Roles only update when the user re-authenticates. Docs: https://workos.com/docs/rbac/idp-role-assignment
+- When both exist, prefer Directory Sync. Per docs: "SCIM is generally the preferred option due to its real-time synchronization capabilities."
+
+**Order of operations**:
+
+1. Configure roles first in the WorkOS Dashboard. Per docs: "Once roles are configured for your application, enable directory group role assignment in Admin Portal to allow IT contacts to assign roles to groups during directory setup."
+2. Enable directory group role assignment on the Authorization page of the WorkOS Dashboard (toggle controlling whether the Admin Portal surfaces the role-assignment step).
+3. The IT contact / org admin maps groups → roles during directory setup via Admin Portal, **or** via the directory page on the WorkOS Dashboard (per docs: "Navigate to the directory page on the WorkOS dashboard").
+4. For Directory Sync: new users added to a mapped group get the mapped role in real time ("Roles are granted to directory users in real-time, when we receive updates to their group memberships").
+5. For SSO: the mapped role is applied when the user authenticates ("Roles are granted to SSO profiles when the user authenticates").
+
+**Precedence (read this before telling a user to call `updateOrganizationMembership`)**:
+
+Per docs: "IdP role assignment will always take precedence over roles assigned via API or the WorkOS Dashboard." If an IdP mapping exists for the user's group, any API-assigned role is silently overwritten on the next sync (Directory Sync) or next login (SSO).
+
+**What NOT to do**:
+
+- Do **not** invent specific dashboard menu paths (e.g. "Dashboard → Organizations → [name] → Roles → Map Groups"). The docs do not commit to a specific click-path. Link the user to the docs URLs above and let them navigate.
+- Do **not** claim this is configurable via the WorkOS CLI. It is not. If the user asks for a CLI command, explicitly say it is not supported in the CLI and link to the docs above.
+
+## API role assignment recipe
+
+Use this when the user asks how to assign an already-configured role to a user in an organization.
+
+1. Confirm from the prompt or user context that the role slug already exists. If they are unsure, tell them to verify the role in the WorkOS Dashboard first; do not create the role as part of assignment.
+2. List organization memberships filtered by `user_id` and `organization_id` to find the organization membership ID.
+3. Update the organization membership with the role slug.
+4. If the role reverts later, check for IdP group role mapping; IdP mapping overrides API/Dashboard role assignments.
+
+Python shape:
+
+```python
+memberships = workos_client.user_management.list_organization_memberships(
+    user_id=user_id,
+    organization_id=organization_id,
+)
+membership_id = memberships.data[0].id
+
+workos_client.user_management.update_organization_membership(
+    organization_membership_id=membership_id,
+    role_slug="billing-admin",
+)
+```
+
+## Gotchas
+
+- Always check permissions (role.permissions.includes('action')), NOT role slugs (role.slug === 'admin') — slug checks break in multi-org with custom roles. Claude defaults to slug checks.
+- Role assignment requires the MEMBERSHIP ID, not the user ID — fetch via listOrganizationMemberships() first, then call updateOrganizationMembership(membershipId, { roleSlug })
+- IdP group mapping OVERRIDES API/Dashboard role assignments on every auth — updateOrganizationMembership() changes silently revert on next login if IdP mapping exists
+- IdP role mapping only works with environment-level roles, NOT org-level roles
+- First org-level role creation isolates that org permanently — it stops inheriting environment-level role changes. This is irreversible.
+- Org-level role slugs are auto-prefixed with "org:" — use the full slug "org:custom_admin", not just "custom_admin"
+- Stale session after role change — role assigned after login won't take effect until user re-authenticates. Force re-auth or refresh the session.
+- Permission slug typos fail silently — "video.create" vs "videos.create" won't error, just denies access
+
+## Endpoints
+
+| Endpoint                               | Description                     |
+| -------------------------------------- | ------------------------------- |
+| `/roles`                               | Roles overview                  |
+| `/organization-role`                   | Organization role management    |
+| `/organization-role/add-permission`    | Add permission to org role      |
+| `/organization-role/create`            | Create org role                 |
+| `/organization-role/delete`            | Delete org role                 |
+| `/organization-role/get`               | Get org role                    |
+| `/organization-role/list`              | List org roles                  |
+| `/organization-role/remove-permission` | Remove permission from org role |
+| `/organization-role/set-permissions`   | Set permissions on org role     |
+| `/organization-role/update`            | Update org role                 |
+| `/permission`                          | Permission management           |
+| `/permission/create`                   | Create permission               |
+| `/permission/delete`                   | Delete permission               |
+| `/permission/get`                      | Get permission                  |
+| `/permission/list`                     | List permissions                |
+| `/permission/update`                   | Update permission               |
+| `/role`                                | Environment role management     |
+| `/role/add-permission`                 | Add permission to role          |
+| `/role/create`                         | Create role                     |
+| `/role/get`                            | Get role                        |
+| `/role/list`                           | List roles                      |
+| `/role/set-permissions`                | Set permissions on role         |
+| `/role/update`                         | Update role                     |

--- a/.claude/skills/workos/references/workos-ruby.md
+++ b/.claude/skills/workos/references/workos-ruby.md
@@ -1,0 +1,193 @@
+# WorkOS AuthKit for Ruby
+
+## Step 1: Fetch SDK Documentation (BLOCKING)
+
+**STOP — Do not proceed until this fetch is complete.**
+
+WebFetch: `https://raw.githubusercontent.com/workos/workos-ruby/main/README.md`
+
+Also fetch the AuthKit quickstart for reference:
+WebFetch: `https://workos.com/docs/authkit/vanilla/ruby`
+
+The README is the **source of truth** for gem API usage. If this skill conflicts with the README, **follow the README**.
+
+## Step 2: Detect Framework
+
+Examine the project to determine which Ruby web framework is in use:
+
+```
+config/routes.rb exists?                 → Rails
+  Gemfile has 'rails' gem?               → Confirmed Rails
+
+Gemfile has 'sinatra' gem?               → Sinatra
+  server.rb/app.rb has Sinatra routes?   → Confirmed Sinatra
+
+None of the above?                       → Vanilla Ruby (use Sinatra quickstart pattern)
+```
+
+**Adapt all subsequent steps to the detected framework.** Do not force Rails on a Sinatra project or vice versa.
+
+## Step 2b: Partial Install Recovery
+
+Before creating new files, check if a previous AuthKit attempt exists:
+
+1. Check if `workos` is already in `Gemfile`
+2. Check for incomplete auth files — files that `require "workos"` but have non-functional routes (TODO comments, 501 responses, empty handlers)
+3. If partial install detected:
+   - Do NOT reinstall the gem (it's already there)
+   - Read existing auth files to understand what's done vs missing
+   - Complete the integration by filling gaps rather than starting fresh
+   - Preserve any working code — only fix what's broken
+   - Run `bundle install` (not `bundle update`) to avoid unexpected gem upgrades
+
+## Step 2c: Existing Auth System Detection
+
+Check for existing authentication before integrating:
+
+```
+Gemfile has 'devise'?                       → Devise auth (uses Warden)
+Gemfile has 'warden'?                       → Warden auth
+Gemfile has 'omniauth'?                     → OmniAuth (OAuth/OIDC)
+*.rb files have 'Warden'?                   → Warden middleware in use
+config/initializers has devise.rb?          → Devise configured
+```
+
+If existing auth detected:
+
+- Do NOT remove or disable it
+- Add WorkOS AuthKit alongside the existing system
+- If Devise is present, Devise uses Warden under the hood — integrate WorkOS at the Warden strategy level if possible
+- Create separate route paths for WorkOS auth (e.g., `/auth/workos/login` if `/login` is taken)
+- Ensure Rack middleware ordering is correct (WorkOS session middleware must not conflict)
+- Ensure existing auth routes continue to work unchanged
+- Document in code comments how to migrate fully to WorkOS later
+
+## Step 3: Install WorkOS Gem
+
+```bash
+bundle add workos
+```
+
+If `dotenv` is not in the Gemfile:
+
+```bash
+# Rails
+bundle add dotenv-rails --group development,test
+
+# Sinatra / other
+bundle add dotenv
+```
+
+**Verify:** `bundle show workos`
+
+## Step 4: Integrate Authentication
+
+### If Rails
+
+1. **Create initializer** — `config/initializers/workos.rb`:
+
+   ```ruby
+   WorkOS.configure do |config|
+     config.api_key = ENV.fetch("WORKOS_API_KEY")
+     config.client_id = ENV.fetch("WORKOS_CLIENT_ID")
+   end
+   ```
+
+2. **Create AuthController** — `app/controllers/auth_controller.rb`:
+   - `login` action: call `WorkOS::UserManagement.get_authorization_url(provider: "authkit", redirect_uri: ...)`, redirect
+   - `callback` action: call `WorkOS::UserManagement.authenticate_with_code(code: params[:code])`, store user in session
+   - `logout` action: clear session, redirect
+
+3. **Add routes** to `config/routes.rb`:
+
+   ```ruby
+   get "/auth/login", to: "auth#login"
+   get "/auth/callback", to: "auth#callback"
+   get "/auth/logout", to: "auth#logout"
+   ```
+
+4. **Add current_user helper** to `ApplicationController` (optional):
+
+   ```ruby
+   helper_method :current_user
+   def current_user
+     @current_user ||= session[:user] && JSON.parse(session[:user])
+   end
+   ```
+
+5. **Verify:** `bundle exec rails routes | grep auth`
+
+### If Sinatra
+
+Follow the quickstart pattern exactly:
+
+1. **Configure WorkOS** in `server.rb`:
+
+   ```ruby
+   require "dotenv/load"
+   require "workos"
+   require "sinatra"
+
+   WorkOS.configure do |config|
+     config.key = ENV["WORKOS_API_KEY"]
+   end
+   ```
+
+2. **Create `/login` route** — call `WorkOS::UserManagement.authorization_url(provider: "authkit", client_id: ..., redirect_uri: ...)`, redirect
+
+3. **Create `/callback` route** — call `WorkOS::UserManagement.authenticate_with_code(client_id: ..., code: ...)`, store in session cookie
+
+4. **Create `/logout` route** — clear session cookie, redirect
+
+5. **Update home route** — read session, show user info if present
+
+6. **Verify:** `ruby -c server.rb`
+
+### If Vanilla Ruby (no framework detected)
+
+Install Sinatra and follow the Sinatra pattern above. This matches the official quickstart.
+
+## Step 5: Environment Setup
+
+Create/update `.env` with WorkOS credentials. Do NOT overwrite existing values.
+
+```
+WORKOS_API_KEY=sk_...
+WORKOS_CLIENT_ID=client_...
+```
+
+## Step 6: Verification
+
+### Rails
+
+```bash
+bundle show workos
+bundle exec rails routes | grep auth
+grep WORKOS .env
+```
+
+### Sinatra
+
+```bash
+bundle show workos
+ruby -c server.rb
+grep WORKOS .env
+```
+
+## Error Recovery
+
+### "uninitialized constant WorkOS"
+
+Gem not loaded. Verify `bundle show workos` succeeds. For Rails, ensure initializer exists. For Sinatra, ensure `require "workos"` is at top of server file.
+
+### "NoMethodError" on WorkOS methods
+
+SDK API may differ from this skill. Re-read the README (Step 1) and use exact method names.
+
+### Routes not working (Rails)
+
+Run `bundle exec rails routes | grep auth`. Verify routes are inside `Rails.application.routes.draw` block.
+
+### Session not persisting (Sinatra)
+
+Enable sessions: `enable :sessions` in server.rb, or use `rack-session` gem.

--- a/.claude/skills/workos/references/workos-sso.md
+++ b/.claude/skills/workos/references/workos-sso.md
@@ -1,0 +1,87 @@
+# WorkOS Single Sign-On
+
+## Docs
+
+- https://workos.com/docs/sso/guide
+- https://workos.com/docs/sso/login-flows
+- https://workos.com/docs/reference/sso/get-authorization-url
+- https://workos.com/docs/sso/redirect-uris
+- https://workos.com/docs/sso/test-sso
+- https://workos.com/docs/sso/launch-checklist
+- https://workos.com/docs/rbac/idp-role-assignment
+  If this file conflicts with fetched docs, follow the docs.
+
+## Mapping SSO groups to WorkOS roles
+
+Full recipe lives in `workos-rbac.md` under "IdP group → role mapping". SSO-specific caveats:
+
+- **Re-auth required**: SSO group role assignment does **not** propagate in real time. Per docs: "Roles are granted to SSO profiles when the user authenticates." A role change in the IdP only takes effect the next time the user re-authenticates.
+- When Directory Sync is also available, prefer Directory Sync. Per docs: "SCIM is generally the preferred option due to its real-time synchronization capabilities."
+- Same precedence rule applies: IdP mapping overrides API/Dashboard role assignment ("IdP role assignment will always take precedence over roles assigned via API or the WorkOS Dashboard").
+- Not configurable via the WorkOS CLI. If asked, say so explicitly and link to https://workos.com/docs/rbac/idp-role-assignment.
+
+## Canonical SSO flows
+
+Use only the relevant flow when the user asks for implementation help. Do not include email-domain routing or IdP-initiated callback handling unless the user asks for those topics. Keep the exact operation order clear; most bugs come from doing state validation or connection selection in the wrong place.
+
+Standalone SSO SDK methods:
+
+- Node: use `workos.sso.getAuthorizationUrl(...)` and `workos.sso.getProfileAndToken(...)`.
+- Ruby: use `WorkOS::SSO.authorization_url(...)` and `WorkOS::SSO.profile_and_token(...)`.
+- Do not use AuthKit/User Management methods such as `workos.userManagement.getAuthorizationUrl(...)` or `authenticateWithCode(...)` for standalone SSO prompts.
+
+### SP-initiated SSO
+
+1. Generate a cryptographically random `state` value and store it server-side in the user's session.
+2. Generate the authorization URL with exactly one connection selector: `organization`, `connection`, or `provider`.
+3. Redirect the user to the IdP using that authorization URL.
+4. In the callback, check the `error` query parameter before exchanging the code.
+5. Verify the returned `state` against the session value.
+6. Exchange `code` for the profile and token with `getProfileAndToken` (Node) or `profile_and_token` (Ruby).
+7. Create the app session from the returned profile, then clear the one-time state value.
+
+### IdP-initiated SSO callback
+
+1. Check if the `state` parameter is present on the callback.
+2. If `state` has a non-empty value, verify it against the session value.
+3. If `state` is `""` (empty string), treat it as IdP-initiated and skip CSRF state verification for that request.
+4. Do not skip state verification for every callback; only the empty-string IdP-initiated case gets this exception.
+5. Exchange `code` for the profile and token, then create the app session.
+
+### Email-domain routing
+
+1. Collect the user's email address before starting SSO.
+2. Extract the domain from the email address.
+3. Look up the matching WorkOS organization ID from your app database, tenant config, or the Organizations API.
+4. Pass `organization` / `organization_id` to the authorization URL call.
+5. Use exactly one connection selector per request. Do not combine `organization` with `connection` or `provider`.
+
+## Gotchas
+
+- Use exactly ONE connection selector (connection, organization, or provider) in getAuthorizationUrl — never combine them, causes error
+- domain_hint and login_hint are UX params, NOT connection selectors — they pre-fill fields but don't route the request
+- IdP-initiated flow sends state="" (empty string, not missing) — skip CSRF verification for empty string, reject for null/missing
+- Auth codes expire in 10 min and are single-use — exchange immediately in callback, never store or retry
+- signin_consent_denied means user clicked Cancel at IdP — check req.query.error BEFORE attempting code exchange
+- Email domain does NOT auto-resolve to organization — YOUR app must map email domain → org_id via your DB or the Organizations API
+- Redirect URI must match EXACTLY including trailing slash — mismatch causes invalid_grant
+- Use getProfileAndToken (not getProfile) to exchange code — returns both profile and access token
+
+## Endpoints
+
+| Endpoint                              | Description                       |
+| ------------------------------------- | --------------------------------- |
+| `/sso`                                | SSO overview                      |
+| `/connection`                         | SSO connection management         |
+| `/connection/delete`                  | Delete a connection               |
+| `/connection/get`                     | Get a connection                  |
+| `/connection/list`                    | List connections                  |
+| `/get-authorization-url`              | Generate authorization URL        |
+| `/get-authorization-url/error-codes`  | Authorization error codes         |
+| `/get-authorization-url/redirect-uri` | Redirect URI configuration        |
+| `/logout`                             | SSO logout                        |
+| `/logout/authorize`                   | Authorize logout                  |
+| `/logout/redirect`                    | Logout redirect                   |
+| `/profile`                            | User profile                      |
+| `/profile/get-profile-and-token`      | Exchange code for profile + token |
+| `/profile/get-user-profile`           | Get user profile by ID            |

--- a/.claude/skills/workos/references/workos-terms.md
+++ b/.claude/skills/workos/references/workos-terms.md
@@ -1,0 +1,37 @@
+# WorkOS Terminology → Canonical Docs URLs
+
+If this file conflicts with fetched docs, follow the docs. URLs here are canonical at time of writing; if a user reports a broken link, WebFetch to confirm and update the row.
+
+## How to Use
+
+User asked about a WorkOS term, dashboard field, environment variable, or configuration concept? Look it up here first. The table gives you:
+
+- **Term** — exact name as it appears in the WorkOS Dashboard, SDK, or docs
+- **What it is** — one-line definition (enough to answer simple "what is X" questions without a fetch)
+- **Canonical URL** — WebFetch this if the user wants the full reference
+- **See also** — deeper reference file to Read when the task goes beyond terminology
+
+## Terms
+
+| Term                     | What it is                                                                                                                                                                                                                                 | Canonical URL                                                                               | See also                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------------------------ |
+| Redirect URI             | URL WorkOS redirects to after successful authentication; configured in Dashboard → Redirects. The `redirect_uri` request parameter must match one of the configured values EXACTLY (including trailing slash).                             | https://workos.com/docs/reference/authkit/authentication/get-authorization-url/redirect-uri | `workos-authkit-base.md` |
+| Sign-in endpoint         | URL on YOUR app that AuthKit redirects to when a sign-in request did not originate from your app (e.g., bookmark of hosted sign-in, password-reset email). Configured in Dashboard → Redirects.                                            | https://workos.com/docs/authkit/vanilla/nodejs#configure-sign-in-endpoint                   | `workos-authkit-base.md` |
+| `initiate_login_uri`     | OIDC client metadata parameter an IdP reads to begin IdP-initiated login at the RP. For WorkOS configuration purposes this maps to the **Sign-in endpoint** in Dashboard → Redirects; no distinct WorkOS docs page exists under this name. | https://workos.com/docs/authkit/vanilla/nodejs#configure-sign-in-endpoint                   | `workos-authkit-base.md` |
+| Sign-out redirect        | URL users are redirected to after logging out of AuthKit. Configured in Dashboard → Redirects and/or passed as the `return_to` query parameter on the logout URL.                                                                          | https://workos.com/docs/reference/authkit/logout/get-logout-url                             | `workos-authkit-base.md` |
+| Organization ID          | Identifier for a group of users (typically a tenant/customer org). Preferred parameter when initiating SAML/OIDC flows — pass this instead of Connection ID so the org can pick its active connection.                                     | https://workos.com/docs/sso/overview                                                        | `workos-sso.md`          |
+| Connection ID            | Identifier for a specific SSO connection (auth method) belonging to an Organization. Use when you need to authenticate via a particular connection rather than letting the Org decide.                                                     | https://workos.com/docs/sso/overview                                                        | `workos-sso.md`          |
+| Admin Portal `intent`    | Query parameter on `generateLink` that selects which Admin Portal flow to open. Valid values: `sso`, `dsync`, `audit_logs`, `log_streams`, `domain_verification`, `certificate_renewal`, `bring_your_own_key`.                             | https://workos.com/docs/reference/admin-portal/portal-link/generate                         | `workos-admin-portal.md` |
+| JWKS endpoint            | Public key set endpoint used to verify signatures on AuthKit-issued session access tokens.                                                                                                                                                 | https://workos.com/docs/reference/authkit/session-tokens/jwks                               | `workos-api-authkit.md`  |
+| Sealed session           | AuthKit session data encrypted and stored in a cookie. "Sealing" = encrypting with the cookie password at sign-in; "unsealing" = decrypting via `loadSealedSession()` / `authenticateWithSessionCookie()` on each request.                 | https://workos.com/docs/reference/authkit/session-helpers/load-sealed-session               | `workos-node.md`         |
+| `WORKOS_COOKIE_PASSWORD` | 32+ character password used to seal/unseal the AuthKit session cookie. Must be identical across all instances of your app. Generate with `openssl rand -base64 32`.                                                                        | https://workos.com/docs/authkit/vanilla/nodejs                                              | `workos-authkit-base.md` |
+
+## Still not here?
+
+1. Check the "See also" column for the closest feature reference and Read it — the term may be covered in context there.
+2. If still unclear, WebFetch https://workos.com/docs/llms.txt and search for the term.
+3. If you find a canonical URL for a term that wasn't in this table, answer the user, then **suggest they open a PR** adding a row to this file. (This file is human-maintained; you can't reliably persist edits from a user session.)
+
+## Verification
+
+URLs drift when WorkOS reorganizes docs. Verify a URL by WebFetch only when (a) the user reports a broken link, or (b) you're about to write the URL into a file the user will commit. Routine chat answers don't require verification — that wastes tokens.

--- a/.claude/skills/workos/references/workos-vault.md
+++ b/.claude/skills/workos/references/workos-vault.md
@@ -1,0 +1,44 @@
+# WorkOS Vault
+
+## Docs
+
+- https://workos.com/docs/vault/quick-start
+- https://workos.com/docs/vault/key-context
+- https://workos.com/docs/vault/index
+- https://workos.com/docs/vault/byok
+- https://workos.com/docs/reference/vault
+- https://workos.com/docs/reference/vault/key
+- https://workos.com/docs/reference/vault/key/create-data-key
+- https://workos.com/docs/reference/vault/key/decrypt-data
+- https://workos.com/docs/reference/vault/key/decrypt-data-key
+  If this file conflicts with fetched docs, follow the docs.
+
+## Gotchas
+
+- BYOK requires customer-side IAM permissions granting WorkOS access to their KMS. Your app cannot do this programmatically — provide customers with IAM policy templates from the BYOK docs.
+- Vault encrypts data per WorkOS organization. Every operation requires an `organization_id` — there is no global/unscoped access.
+- Do NOT use internal customer IDs as `organization_id`. WorkOS organization IDs have format `org_*`. Always map through WorkOS APIs.
+- Key context metadata is NOT encrypted separately. Do not store sensitive data or PII in metadata fields.
+- Vault keys are case-sensitive. Mismatched casing between store and retrieve silently returns "key not found."
+- BYOK KMS IAM changes can take 5-10 minutes to propagate. Customer must grant `kms:Decrypt` and `kms:Encrypt` on their key.
+
+## Endpoints
+
+| Endpoint                | Description                    |
+| ----------------------- | ------------------------------ |
+| `/vault`                | vault                          |
+| `/key`                  | vault - key                    |
+| `/key/create-data-key`  | vault - key - create-data-key  |
+| `/key/decrypt-data`     | vault - key - decrypt-data     |
+| `/key/decrypt-data-key` | vault - key - decrypt-data-key |
+| `/key/encrypt-data`     | vault - key - encrypt-data     |
+| `/object`               | vault - object                 |
+| `/object/create`        | vault - object - create        |
+| `/object/delete`        | vault - object - delete        |
+| `/object/get`           | vault - object - get           |
+| `/object/get-by-name`   | vault - object - get-by-name   |
+| `/object/list`          | vault - object - list          |
+| `/object/metadata`      | vault - object - metadata      |
+| `/object/update`        | vault - object - update        |
+| `/object/version`       | vault - object - version       |
+| `/object/versions`      | vault - object - versions      |

--- a/.claude/skills/x/SKILL.md
+++ b/.claude/skills/x/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: x
+description: Read tweets from X (Twitter) from any project — search by query or operator (from:, min_faves:, since:), pull a user's timeline, or fetch a tweet by id/URL. Two backends: TwitterAPI.io (clean JSON, tiny per-read cost) and a logged-in browser session via agent-browser (no key, no cost). Use when asked to "read tweets", "search X/Twitter", "what is <handle> tweeting", "get this tweet", "check X for <topic>", or when an x.com/twitter.com status URL appears. Read-only.
+---
+
+# x
+
+Standalone tweet reader for any project. Two backends behind one CLI:
+
+- **API** (default) — [TwitterAPI.io](https://twitterapi.io), third-party read API.
+  Clean structured JSON, a fraction of a cent per read, needs a key. Same
+  provider `social-arb` uses (`lib/social_arb/sources/x.ex`).
+- **Browser** (`--browser`) — drives a real logged-in X session via
+  `agent-browser` using saved cookies. No key, no per-read cost. Use it when the
+  API key is out of credits (it currently is), or for reads the API doesn't cover.
+
+## Commands
+
+```bash
+python3 ~/.claude/skills/x/x.py search "<query>" [--top] [--limit N] [--json|--raw] [--browser]
+python3 ~/.claude/skills/x/x.py user   <handle>  [--replies] [--limit N] [--json|--raw] [--browser]
+python3 ~/.claude/skills/x/x.py tweet  <id|url> [<id|url> ...] [--json|--raw]   # API only
+```
+
+- `search` — advanced search. `--top` ranks by engagement instead of recency.
+- `user` — a handle's recent posts. `--replies` includes replies.
+- `tweet` — one or more tweets by id or status URL (API backend).
+- Output: human-readable by default (author · date · engagement · text · url).
+  `--json` = normalized objects; `--raw` = untouched backend objects.
+- `--browser` routes `search`/`user` through the saved X session instead of the
+  API. `--scrolls N` bounds how far it scrolls (default 8).
+
+## Search operators (passed straight through)
+
+`from:elonmusk` `to:naval` `min_faves:50` `min_retweets:10`
+`since:2026-06-01 until:2026-06-30` `-filter:replies` `filter:media`
+`"exact phrase"` `OR` — e.g. `'"halal finance" OR sukuk min_faves:20'`
+
+## Backends
+
+### API key (for the default backend)
+
+Resolved in order (first hit wins):
+
+1. `$TWITTERAPI_KEY`
+2. `~/.config/x-skill/key` (chmod 600)
+3. `TWITTERAPI_KEY=` in `~/git/social-arb/.env`
+
+Pay-per-use; API pagination capped at 10 requests/command. Returns HTTP 402 when
+out of credits — the error hint tells you to switch to `--browser`.
+
+### Browser session (for `--browser`)
+
+Cookies live in `~/.agent-browser/x-state.json` (Playwright storage state with
+`auth_token` + `ct0`). Reads run headless in an `agent-browser` session named
+`xread`. Login itself must happen in a **real Chrome** — X bot-blocks login
+inside the automation browser ("We've temporarily limited your login"), but
+authenticated reads work fine headless once the cookies exist.
+
+**Re-auth when the session expires** (redirects to /login, or reads come back empty):
+
+```bash
+# 1. Launch a real Chrome with a debug port + dedicated profile
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.agent-browser/chrome-x-profile" \
+  --no-first-run --no-default-browser-check "https://x.com/login" &
+
+# 2. Log in BY HAND in that window (password + 2FA). Reach the home timeline.
+# 3. Attach and save the session:
+agent-browser --cdp 9222 state save "$HOME/.agent-browser/x-state.json"
+```
+
+The dedicated Chrome profile at `~/.agent-browser/chrome-x-profile` stays logged
+in on disk, so re-saving later usually just needs the two commands above.

--- a/.claude/skills/x/x.py
+++ b/.claude/skills/x/x.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+x: read tweets from X (Twitter) from any project.
+
+Two backends:
+  - API (default): TwitterAPI.io, third-party read API. Clean JSON, costs a
+    fraction of a cent per read, needs a key. Same provider social-arb uses.
+  - Browser (--browser): drives a real logged-in X session via agent-browser
+    using saved cookies. No API key, no per-read cost. Use this when the API
+    key is out of credits, or for reads the API doesn't cover.
+
+API key resolution order (first hit wins):
+  1. $TWITTERAPI_KEY
+  2. ~/.config/x-skill/key            (chmod 600; dedicated to this skill)
+  3. ~/git/social-arb/.env            (TWITTERAPI_KEY=...; current source of truth)
+
+Browser session:
+  Cookies live in ~/.agent-browser/x-state.json (Playwright storage state with
+  auth_token + ct0). Re-auth when it expires: relaunch a real Chrome with a
+  debug port, log in by hand, then `agent-browser --cdp 9222 state save
+  ~/.agent-browser/x-state.json`. (X bot-blocks login inside the automation
+  browser, so login must happen in a real Chrome; reads work fine headless.)
+
+Usage:
+  x.py search "<query>" [--top] [--limit N] [--json|--raw] [--browser]
+  x.py user   <handle>  [--replies] [--limit N] [--json|--raw] [--browser]
+  x.py tweet  <id|url>  [<id|url> ...] [--json|--raw]
+
+Search query supports X operators, e.g.:
+  x.py search 'from:elonmusk starship'
+  x.py search '"halal finance" min_faves:50 -filter:replies'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+BASE_URL = "https://api.twitterapi.io"
+PAGE_CAP = 10  # hard ceiling on paginated API requests per command (cost guard)
+
+STATE_FILE = Path.home() / ".agent-browser" / "x-state.json"
+BROWSE_SESSION = "xread"
+
+# Pull each rendered tweet (article) out of the DOM. Returns a JSON string, which
+# agent-browser then JSON-encodes again — so callers decode twice.
+EXTRACT_JS = r"""JSON.stringify([...document.querySelectorAll('article[data-testid="tweet"]')].map(a => {
+  const t = a.querySelector('[data-testid="tweetText"]');
+  const tm = a.querySelector('time');
+  const link = tm ? tm.closest('a') : null;
+  const grp = a.querySelector('[role="group"]');
+  const nm = a.querySelector('[data-testid="User-Name"]');
+  let h = ''; if (nm) { const m = nm.innerText.match(/@\w+/); h = m ? m[0] : ''; }
+  return {handle: h, time: tm ? tm.getAttribute('datetime') : '', url: link ? link.href : '',
+          text: t ? t.innerText : '', stats: grp ? grp.getAttribute('aria-label') : ''};
+}))"""
+
+
+# --- key resolution (API backend only) --------------------------------------
+
+def resolve_key() -> str:
+    env = os.environ.get("TWITTERAPI_KEY")
+    if env:
+        return env.strip()
+
+    dedicated = Path.home() / ".config" / "x-skill" / "key"
+    if dedicated.is_file():
+        val = dedicated.read_text().strip()
+        if val:
+            return val
+
+    env_file = Path.home() / "git" / "social-arb" / ".env"
+    if env_file.is_file():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("TWITTERAPI_KEY="):
+                val = line.split("=", 1)[1].strip().strip("'\"")
+                if val:
+                    return val
+
+    sys.exit(
+        "No TwitterAPI.io key found. Set one of:\n"
+        "  export TWITTERAPI_KEY=...\n"
+        "  ~/.config/x-skill/key   (chmod 600)\n"
+        "  TWITTERAPI_KEY= line in ~/git/social-arb/.env\n"
+        "Or read via the logged-in browser session with --browser."
+    )
+
+
+# --- API backend ------------------------------------------------------------
+
+def api_get(path: str, params: dict[str, str], key: str) -> dict:
+    url = f"{BASE_URL}{path}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"X-API-Key": key})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        hint = "  (out of credits — retry with --browser)" if e.code == 402 else ""
+        sys.exit(f"HTTP {e.code} from {path}: {detail}{hint}")
+    except urllib.error.URLError as e:
+        sys.exit(f"Network error calling {path}: {e.reason}")
+
+    if body.get("status") == "error":
+        sys.exit(f"API error from {path}: {body.get('message', 'unknown')}")
+    return body
+
+
+def paginate(path: str, base_params: dict[str, str], limit: int, key: str) -> list[dict]:
+    tweets: list[dict] = []
+    cursor = ""
+    pages = 0
+    while len(tweets) < limit and pages < PAGE_CAP:
+        params = dict(base_params)
+        if cursor:
+            params["cursor"] = cursor
+        body = api_get(path, params, key)
+        batch = body.get("tweets") or []
+        tweets.extend(batch)
+        pages += 1
+        if not batch or not body.get("has_next_page") or not body.get("next_cursor"):
+            break
+        cursor = body["next_cursor"]
+    return tweets[:limit]
+
+
+def normalize_api(t: dict) -> dict:
+    author = t.get("author") or {}
+    return {
+        "url": t.get("url"),
+        "author": author.get("userName"),
+        "created_at": t.get("createdAt"),
+        "text": t.get("text"),
+        "likes": t.get("likeCount") or 0,
+        "retweets": t.get("retweetCount") or 0,
+        "replies": t.get("replyCount") or 0,
+        "quotes": t.get("quoteCount") or 0,
+        "views": t.get("viewCount") or 0,
+        "is_reply": t.get("isReply") or False,
+        "conversation_id": t.get("conversationId"),
+    }
+
+
+# --- browser backend --------------------------------------------------------
+
+def _ab(*args: str, stdin: str | None = None) -> str:
+    try:
+        proc = subprocess.run(
+            ["agent-browser", "--session-name", BROWSE_SESSION, *args],
+            input=stdin, capture_output=True, text=True, timeout=90,
+        )
+    except FileNotFoundError:
+        sys.exit("agent-browser not found on PATH — install it or use the API backend.")
+    return proc.stdout.strip()
+
+
+def _parse_eval(out: str) -> list:
+    """agent-browser prints progress lines plus a (double-encoded) JSON payload.
+    Scan from the bottom for the first line that decodes to a list."""
+    for line in reversed(out.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            v = json.loads(line)
+            if isinstance(v, str):
+                v = json.loads(v)
+            if isinstance(v, list):
+                return v
+        except (json.JSONDecodeError, ValueError):
+            continue
+    return []
+
+
+def browse(url: str, scrolls: int, limit: int) -> list[dict]:
+    if not STATE_FILE.is_file():
+        sys.exit(
+            f"No saved X session at {STATE_FILE}. Log in via a real Chrome and save state "
+            "(see this file's docstring)."
+        )
+    _ab("state", "load", str(STATE_FILE))
+    _ab("open", url)
+    _ab("wait", "3500")
+    seen: dict[str, dict] = {}
+    for _ in range(scrolls):
+        arr = _parse_eval(_ab("eval", "--stdin", stdin=EXTRACT_JS))
+        for t in arr:
+            u = t.get("url", "")
+            if u and u not in seen and t.get("text"):
+                seen[u] = t
+        if len(seen) >= limit:
+            break
+        _ab("scroll", "down", "1600")
+        _ab("wait", "1800")
+    return list(seen.values())[:limit]
+
+
+def _parse_stats(s: str) -> dict:
+    # aria-label like "12 replies, 34 reposts, 567 likes, 8 bookmarks, 9012 views"
+    out = {}
+    for key, label in [("replies", "repl"), ("retweets", "repost"),
+                       ("likes", "like"), ("views", "view")]:
+        m = re.search(r"([\d,]+)\s+" + label, s or "", re.I)
+        out[key] = int(m.group(1).replace(",", "")) if m else 0
+    return out
+
+
+def normalize_browse(t: dict) -> dict:
+    st = _parse_stats(t.get("stats", ""))
+    return {
+        "url": t.get("url"),
+        "author": (t.get("handle", "") or "").lstrip("@") or None,
+        "created_at": t.get("time"),
+        "text": t.get("text"),
+        "quotes": 0,
+        "is_reply": None,
+        "conversation_id": None,
+        **st,
+    }
+
+
+# --- formatting -------------------------------------------------------------
+
+def fmt_count(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}m".replace(".0m", "m")
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k".replace(".0k", "k")
+    return str(n)
+
+
+def fmt_date(raw: str) -> str:
+    if not raw:
+        return "?"
+    if "T" in raw and raw.endswith("Z"):  # ISO from browser
+        return raw[:16].replace("T", " ")
+    for parse in (parsedate_to_datetime,
+                  lambda s: datetime.strptime(s, "%a %b %d %H:%M:%S %z %Y")):
+        try:
+            return parse(raw).astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        except (ValueError, TypeError):
+            continue
+    return raw
+
+
+def render(norm: list[dict]) -> str:
+    if not norm:
+        return "(no tweets)"
+    blocks = []
+    for n in norm:
+        head = (
+            f"@{n['author']} · {fmt_date(n['created_at'])} · "
+            f"♥{fmt_count(n['likes'])} ↺{fmt_count(n['retweets'])} "
+            f"💬{fmt_count(n['replies'])} · {fmt_count(n['views'])} views"
+        )
+        blocks.append(f"{head}\n{n['text']}\n{n['url']}")
+    return "\n\n".join(blocks)
+
+
+def emit(raw: list[dict], norm: list[dict], args: argparse.Namespace) -> None:
+    if args.raw:
+        print(json.dumps(raw, indent=2, ensure_ascii=False))
+    elif args.json:
+        print(json.dumps(norm, indent=2, ensure_ascii=False))
+    else:
+        print(render(norm))
+
+
+# --- commands ---------------------------------------------------------------
+
+TWEET_ID_RE = re.compile(r"(?:status(?:es)?/)(\d+)")
+
+
+def extract_id(token: str) -> str:
+    m = TWEET_ID_RE.search(token)
+    if m:
+        return m.group(1)
+    digits = re.sub(r"\D", "", token)
+    if digits:
+        return digits
+    sys.exit(f"Could not extract a tweet id from: {token}")
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    if args.browser:
+        f = "top" if args.top else "live"
+        url = f"https://x.com/search?q={urllib.parse.quote(args.query)}&f={f}"
+        raw = browse(url, args.scrolls, args.limit)
+        emit(raw, [normalize_browse(t) for t in raw], args)
+        return
+    params = {"query": args.query, "queryType": "Top" if args.top else "Latest"}
+    raw = paginate("/twitter/tweet/advanced_search", params, args.limit, resolve_key())
+    emit(raw, [normalize_api(t) for t in raw], args)
+
+
+def cmd_user(args: argparse.Namespace) -> None:
+    handle = args.handle.lstrip("@")
+    if args.browser:
+        raw = browse(f"https://x.com/{handle}", args.scrolls, args.limit)
+        if not args.replies:
+            raw = [t for t in raw if (t.get("handle", "") or "").lower() == f"@{handle}".lower()]
+        raw = raw[:args.limit]
+        emit(raw, [normalize_browse(t) for t in raw], args)
+        return
+    params = {"userName": handle, "includeReplies": "true" if args.replies else "false"}
+    raw = paginate("/twitter/user/last_tweets", params, args.limit, resolve_key())
+    emit(raw, [normalize_api(t) for t in raw], args)
+
+
+def cmd_tweet(args: argparse.Namespace) -> None:
+    ids = ",".join(extract_id(tok) for tok in args.refs)
+    body = api_get("/twitter/tweets", {"tweet_ids": ids}, resolve_key())
+    raw = body.get("tweets") or []
+    emit(raw, [normalize_api(t) for t in raw], args)
+
+
+# --- cli --------------------------------------------------------------------
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="x", description="Read tweets from X")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_output_flags(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--json", action="store_true", help="normalized JSON output")
+        sp.add_argument("--raw", action="store_true", help="raw backend objects")
+
+    def add_browser_flags(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--browser", action="store_true",
+                        help="read via the logged-in browser session (no API key/cost)")
+        sp.add_argument("--scrolls", type=int, default=8,
+                        help="max scroll passes in --browser mode (default 8)")
+
+    s = sub.add_parser("search", help="advanced search (supports X operators)")
+    s.add_argument("query")
+    s.add_argument("--top", action="store_true", help="rank by Top instead of Latest")
+    s.add_argument("--limit", type=int, default=20, help="max tweets (default 20)")
+    add_output_flags(s)
+    add_browser_flags(s)
+    s.set_defaults(func=cmd_search)
+
+    u = sub.add_parser("user", help="a user's recent tweets")
+    u.add_argument("handle", help="@handle or handle")
+    u.add_argument("--replies", action="store_true", help="include replies")
+    u.add_argument("--limit", type=int, default=20, help="max tweets (default 20)")
+    add_output_flags(u)
+    add_browser_flags(u)
+    u.set_defaults(func=cmd_user)
+
+    t = sub.add_parser("tweet", help="fetch tweet(s) by id or URL (API only)")
+    t.add_argument("refs", nargs="+", help="tweet ids or status URLs")
+    add_output_flags(t)
+    t.set_defaults(func=cmd_tweet)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ lazy-lock.json
 .zsh/work.zsh
 .config/nvim/nvim-macos-arm64/
 tmp/
+
+# The global ~/.gitignore ignores .claude/ (Claude Code per-project state).
+# Re-include only the global config we version here; keep machine-local and
+# transient bits (settings.local.json, worktrees/, sessions, etc.) ignored.
+!.claude/
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,43 @@ just unlink    # remove symlinks
 just check     # validate symlinks
 ```
 
+## Claude Code config
+
+The global Claude Code config lives under `.claude/` and is symlinked into `~/.claude/` by `just link`:
+
+- `.claude/CLAUDE.md` -> `~/.claude/CLAUDE.md` (global instructions)
+- `.claude/skills/*` -> `~/.claude/skills/*` (personal, hand-authored skills)
+
+### Work / personal skill gate
+
+Skills are split into three lists in the `justfile`, gated on `~/.is_work_machine` (the same
+flag `just set-work` / `just set-personal` toggle for the zsh split):
+
+- `claude_skills` - linked on every machine
+- `claude_skills_personal` - linked only on personal machines (skipped on work)
+- `claude_skills_work` - linked only on work machines
+
+So e.g. `android-cli` and `x` live in `claude_skills_personal` and never land on a work machine.
+`CLAUDE.md` is linked on every machine. Move a skill between the lists to change where it lands;
+after switching a machine's type, run `just unlink && just link` to resync (a stale symlink from
+the previous type is not auto-pruned by `link` alone).
+
+`just link` is non-destructive: it only creates a symlink where nothing real exists yet (a
+fresh machine), and **skips** any existing real `~/.claude/CLAUDE.md` or skill dir rather than
+overwriting it. To adopt the dotfiles copy on a machine that already has a real one (e.g. to
+replace a machine-specific `CLAUDE.md`), remove the real target first, then re-run `just link`:
+
+```bash
+rm ~/.claude/CLAUDE.md
+rm -rf ~/.claude/skills/gameplan   # per skill you want to adopt
+just link
+```
+
+Anything not listed in `claude_files` / `claude_skills` is left untouched. Marketplace skills
+(installed via the skills CLI into `~/.agents/skills` and symlinked into `~/.claude/skills`) are
+intentionally *not* managed here, so they keep updating themselves. The rest of `~/.claude/`
+(sessions, history, credentials, plugins) is machine-local and never symlinked.
+
 ## zmx workflow
 
 zmx provides session persistence without a multiplexer. Ghostty handles splits and tabs natively.

--- a/justfile
+++ b/justfile
@@ -12,6 +12,19 @@ config_dirs := "aerospace ghostty nvim starship tmux zellij zsh-plugins"
 # .config files to symlink (file-level, not directory-level)
 config_files := "jj/config.toml"
 
+# ~/.claude files to symlink (global Claude Code config)
+claude_files := "CLAUDE.md"
+
+# ~/.claude/skills subdirectories to symlink (personal, hand-authored skills;
+# marketplace skills stay symlinked into ~/.agents/skills and are not managed here).
+# Gated on ~/.is_work_machine (set by `just set-work`), same signal as the zsh split:
+#   claude_skills          - linked on every machine
+#   claude_skills_personal - linked only on personal machines (skipped on work)
+#   claude_skills_work     - linked only on work machines
+claude_skills := ""
+claude_skills_personal := "android-cli design gameplan jj-vcs loom-extract make-responsive portless raycast-settings use-railway workos workos-widgets x"
+claude_skills_work := ""
+
 # show available recipes
 default:
     @just --list
@@ -57,6 +70,36 @@ link:
         ln -sfn "{{dotfiles}}/.config/$f" "$target"
         echo "  .config/$f -> {{dotfiles}}/.config/$f"
     done
+    mkdir -p "$HOME/.claude/skills"
+    for f in {{claude_files}}; do
+        src="{{dotfiles}}/.claude/$f"
+        target="$HOME/.claude/$f"
+        [ -e "$src" ] || { echo "  SKIP .claude/$f (not vendored in dotfiles)"; continue; }
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            echo "  SKIP .claude/$f (real file exists, remove it to adopt the dotfiles copy)"
+            continue
+        fi
+        mkdir -p "$(dirname "$target")"
+        ln -sfn "$src" "$target"
+        echo "  .claude/$f -> $src"
+    done
+    skills="{{claude_skills}}"
+    if [ -f "$HOME/.is_work_machine" ]; then
+        skills="$skills {{claude_skills_work}}"
+    else
+        skills="$skills {{claude_skills_personal}}"
+    fi
+    for d in $skills; do
+        src="{{dotfiles}}/.claude/skills/$d"
+        target="$HOME/.claude/skills/$d"
+        [ -e "$src" ] || { echo "  SKIP .claude/skills/$d (not vendored in dotfiles)"; continue; }
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            echo "  SKIP .claude/skills/$d (real dir exists, remove it to adopt the dotfiles copy)"
+            continue
+        fi
+        ln -sfn "$src" "$target"
+        echo "  .claude/skills/$d -> $src"
+    done
     echo "done."
 
 # remove all managed symlinks
@@ -74,6 +117,12 @@ unlink:
     done
     for f in {{config_files}}; do
         [ -L "$HOME/.config/$f" ] && rm "$HOME/.config/$f" && echo "  removed ~/.config/$f"
+    done
+    for f in {{claude_files}}; do
+        [ -L "$HOME/.claude/$f" ] && rm "$HOME/.claude/$f" && echo "  removed ~/.claude/$f"
+    done
+    for d in {{claude_skills}} {{claude_skills_personal}} {{claude_skills_work}}; do
+        [ -L "$HOME/.claude/skills/$d" ] && rm "$HOME/.claude/skills/$d" && echo "  removed ~/.claude/skills/$d"
     done
     echo "done."
 
@@ -114,6 +163,30 @@ check:
             ((ok++))
         else
             echo "  MISSING  ~/.config/$f"
+            ((bad++))
+        fi
+    done
+    for f in {{claude_files}}; do
+        if [ -L "$HOME/.claude/$f" ]; then
+            echo "  ok  ~/.claude/$f"
+            ((ok++))
+        else
+            echo "  MISSING  ~/.claude/$f"
+            ((bad++))
+        fi
+    done
+    skills="{{claude_skills}}"
+    if [ -f "$HOME/.is_work_machine" ]; then
+        skills="$skills {{claude_skills_work}}"
+    else
+        skills="$skills {{claude_skills_personal}}"
+    fi
+    for d in $skills; do
+        if [ -L "$HOME/.claude/skills/$d" ]; then
+            echo "  ok  ~/.claude/skills/$d"
+            ((ok++))
+        else
+            echo "  MISSING  ~/.claude/skills/$d"
             ((bad++))
         fi
     done


### PR DESCRIPTION
## What

Version-controls the global Claude Code config that was previously only living in `~/.claude/`:

- **`.claude/CLAUDE.md`** — global instructions (linked on every machine).
- **`.claude/skills/`** — 12 personal, hand-authored skills.

`just link` symlinks these into `~/.claude/` (new `claude_files` / `claude_skills*` lists), and `unlink` / `check` cover them too.

## Work / personal gate

Skills split into three lists, gated on `~/.is_work_machine` (the flag `just set-work` / `just set-personal` already toggle):

- `claude_skills` — every machine: *(empty)*
- `claude_skills_personal` — personal only (skipped on work): `android-cli design gameplan jj-vcs loom-extract make-responsive portless raycast-settings use-railway workos workos-widgets x` (all 12)
- `claude_skills_work` — work only: *(empty)*

All 12 skills are personal-only as a starting point, so a fresh work machine links only `CLAUDE.md` (no skills). Add entries to `claude_skills` / `claude_skills_work` when tweaking the work machine. (`prd`, `ralph`, `zoom-hub` were dropped from the dotfiles entirely.) Move a skill between lists to change where it goes. After switching a machine's type, `just unlink && just link` resyncs (a stale symlink from the previous type isn't auto-pruned by `link` alone). `unlink` and the deploy `check` account for all three lists.

## Non-destructive by design

`just link` **never overwrites** an existing real `~/.claude/CLAUDE.md` or skill dir — it skips it (same behavior as the existing `home_dirs` / `config_dirs`). It only creates a symlink where nothing real exists yet. So running `just link` on a machine with its own work-specific config touches nothing it already has.

To *adopt* the dotfiles copy on a machine that already has a real one, remove the target first, then re-link:

```bash
rm ~/.claude/CLAUDE.md
rm -rf ~/.claude/skills/gameplan   # per skill you want to adopt
just link
```

## Deliberately excluded

- **Marketplace skills** (`agent-browser`, `find-skills`, `frontend-design`, `humanize-writing`, `obsidian-cli`, `web-design-guidelines`) — symlinks into `~/.agents/skills` managed by the skills CLI (`~/.agents/.skill-lock.json`). Vendoring them would break the relative symlinks and stop them self-updating.
- **Machine-local / transient state** — `~/.claude/settings.local.json`, `sessions/`, `history`, `credentials`, `plugins`, and the jj `worktrees/` all stay ignored.

## `.gitignore` override

Your global `~/.gitignore` ignores `.claude/` (so Claude Code's per-project state never gets committed anywhere). This adds a repo-local override that re-includes only `.claude/CLAUDE.md` and `.claude/skills/`, verified with `git check-ignore` in a simulated merged layout: the 15 skills + `CLAUDE.md` track, while `settings.local.json` and `worktrees/` stay ignored.

## Deploying (after merge)

```bash
cd ~/.dotfiles && jj git fetch    # pull the merged change into main
just link                          # symlinks CLAUDE.md + machine-appropriate skills (skips anything real)
just check
```

On the machine you authored these on, `just link` will *skip* the existing real `~/.claude/CLAUDE.md` + skill dirs (they already exist as real files). Use the adopt-step above to convert them to symlinks when you want live editing to sync through the repo.

## Notes

- `workos`, `workos-widgets`, `use-railway`, `android-cli` also exist in the `~/.agents/skills` store; included here since they're real dirs in `~/.claude/skills` (not symlinks) and not tracked by the marketplace lockfile. Once symlinked, any self-update writes through into this repo as a normal diff.
- Default skill categorization is a starting point — `android-cli` + `x` in personal, the rest common. Adjust the lists to taste.
- Pre-existing, unrelated: the justfile still lists `aerospace` in `config_dirs` even though the AeroSpace config was removed. Left as-is (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


