### PR TITLE
Track cly.zsh and load it on every machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 lazy-lock.json
-.zsh/cly.zsh
 .zsh/work.zsh
 .config/nvim/nvim-macos-arm64/
 tmp/

--- a/.zsh/cly.zsh
+++ b/.zsh/cly.zsh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+
+_set_title() {
+    local title="$1"
+    echo -ne "\033]0;${title}\007"
+}
+
+cly() {
+    local dir_name="${PWD##*/}"
+    local title="${dir_name}: $*"
+
+    _set_title "$title"
+
+    (
+        while true; do
+            sleep 1
+            _set_title "$title"
+        done
+    ) &
+    local bg_pid=$!
+
+    claude --dangerously-skip-permissions "$@"
+    local claude_exit_code=$?
+
+    kill $bg_pid 2>/dev/null
+
+    _set_title "$dir_name"
+
+    return $claude_exit_code
+}
+
+_claude_precmd() {
+    local dir_name="${PWD##*/}"
+    _set_title "$dir_name"
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _claude_precmd

--- a/.zsh/common_after.zsh
+++ b/.zsh/common_after.zsh
@@ -9,3 +9,6 @@ sdk() {
 
 eval "$(zoxide init zsh)"
 eval "$(starship init zsh)"
+
+# claude wrapper + terminal-title helper (loaded on every machine)
+[ -f ~/.zsh/cly.zsh ] && source ~/.zsh/cly.zsh

--- a/.zsh/personal.zsh
+++ b/.zsh/personal.zsh
@@ -15,5 +15,3 @@ export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agen
 alias kamal='docker run -it --rm -v "${PWD}:/workdir" -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal:latest'
 # bun completions
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-[ -f ~/.zsh/cly.zsh ] && source ~/.zsh/cly.zsh


### PR DESCRIPTION
## What

Tracks `.zsh/cly.zsh` (previously gitignored) and makes it load on **both** work and personal machines.

`cly.zsh` is a small, non-sensitive shell helper: a `cly` function that runs `claude --dangerously-skip-permissions "$@"` while keeping the terminal tab titled `dir: args`, plus a `precmd` hook that resets the tab title to the cwd. No secrets, nothing machine-specific.

## Why the move

`.zshrc` loads `common.zsh` and `common_after.zsh` on every machine, but picks `work.zsh` **xor** `personal.zsh` based on `~/.is_work_machine`. `cly.zsh` was sourced only from `personal.zsh`, so it never loaded on a work machine.

Changes:
- Remove `.zsh/cly.zsh` from `.gitignore` and commit the file.
- Move `[ -f ~/.zsh/cly.zsh ] && source ~/.zsh/cly.zsh` from `.zsh/personal.zsh` → `.zsh/common_after.zsh` (loaded on both machine types).

`zsh -n` clean on all three edited files. Not encrypted — it carries no secrets, unlike the `.claude/skills-work/` work skills.

## Deploy

After merge, on each machine: pull, then `just link` (`.zsh` is already a managed symlink, so the new `cly.zsh` shows up automatically), and restart the shell. On the work machine, confirm `~/.is_work_machine` is set — `cly` now loads there via `common_after.zsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)